### PR TITLE
fix(complete): await sendMessage before window.close()

### DIFF
--- a/entrypoints/complete/App.tsx
+++ b/entrypoints/complete/App.tsx
@@ -16,18 +16,18 @@ export default function App() {
     }
   });
 
-  const startBreak = () => {
-    browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
+  const startBreak = async () => {
+    await browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
     window.close();
   };
 
-  const skipBreak = () => {
-    browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
+  const skipBreak = async () => {
+    await browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
     window.close();
   };
 
-  const startTimer = () => {
-    browser.runtime.sendMessage({ action: 'START_TIMER' });
+  const startTimer = async () => {
+    await browser.runtime.sendMessage({ action: 'START_TIMER' });
     window.close();
   };
 


### PR DESCRIPTION
## Summary
- All three action handlers in the completion page (`startBreak`, `skipBreak`, `startTimer`) now properly `await` `browser.runtime.sendMessage()` before calling `window.close()`
- Prevents race condition where the tab closes before the background script processes the action

## Verification
- [x] TypeScript compiles without errors
- [x] No file overlap with other open PRs

Closes #2