### PR TITLE
feat(accessibility): add ARIA attributes to TimerRing and Heatmap

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -169,6 +169,8 @@ export default function Heatmap(props: HeatmapProps) {
 
         {/* Heatmap cells - CSS Grid: 7 rows, auto columns */}
         <div
+          role="img"
+          aria-label="Pomodoro activity heatmap"
           class="grid"
           style={{
             "grid-template-rows": `repeat(7, ${cellSize()}px)`,
@@ -183,6 +185,7 @@ export default function Heatmap(props: HeatmapProps) {
                 {(cell) =>
                   cell ? (
                     <div
+                      role="presentation"
                       class="rounded-sm"
                       style={{
                         width: `${cellSize()}px`,
@@ -190,6 +193,7 @@ export default function Heatmap(props: HeatmapProps) {
                         "background-color": getIntensityColor(cell.count),
                       }}
                       title={tooltipText(cell)}
+                      aria-label={tooltipText(cell)}
                     />
                   ) : (
                     <div

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -24,7 +24,17 @@ export default function TimerRing(props: TimerRingProps) {
   const color = () => PHASE_COLORS[props.phase];
 
   return (
-    <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
+    <svg
+      width={SIZE}
+      height={SIZE}
+      class="timer-ring"
+      viewBox={`0 0 ${SIZE} ${SIZE}`}
+      role="progressbar"
+      aria-valuenow={Math.round(props.progress * 100)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={`Timer: ${props.phase.toLowerCase().replace('_', ' ')}`}
+    >
       <title>Timer progress</title>
       <circle
         cx={SIZE / 2}


### PR DESCRIPTION
## Summary
- **TimerRing**: Added `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-label` so screen readers can announce timer progress and current phase
- **Heatmap**: Added `role="img"` with `aria-label` on the grid container and `aria-label` on each cell for screen reader access to date/count data

## Verification
- [x] TypeScript compiles without errors
- [x] No linting/a11y diagnostics
- [x] No file overlap with other open PRs

Closes #4
Closes #13