### PR TITLE
test: add missing edge case and integration test coverage

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -226,6 +226,104 @@ describe('background service worker', () => {
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
   });
 
+  it('accepts a suggested long break, schedules the alarm, and shows a break badge', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(20_000);
+    const config = createConfig({ longBreakDuration: 1_800_000 });
+    await fakeBrowser.storage.local.set({ config });
+    await setTimerState(
+      createState({
+        phase: 'BREAK_SUGGESTION',
+        cyclePosition: 3,
+        completedToday: 4,
+        sessionCount: 4,
+      }),
+    );
+    await initBackground();
+
+    const response = await fakeBrowser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
+
+    expect(response).toEqual(
+      createState({
+        phase: 'LONG_BREAK',
+        startTime: 20_000,
+        endTime: 20_000 + config.longBreakDuration,
+        duration: config.longBreakDuration,
+        cyclePosition: 3,
+        completedToday: 4,
+        sessionCount: 4,
+      }),
+    );
+    await expect(getTimerState()).resolves.toEqual(response);
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
+      expect.objectContaining({ scheduledTime: 20_000 + config.longBreakDuration }),
+    );
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: 'BRK' });
+    expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#16A34A' });
+  });
+
+  it('skips a suggested long break, resets cycle position, and clears alarms', async () => {
+    await setTimerState(
+      createState({
+        phase: 'BREAK_SUGGESTION',
+        cyclePosition: 3,
+        completedToday: 4,
+        sessionCount: 4,
+      }),
+    );
+    await initBackground();
+    await fakeBrowser.alarms.create('tomate-timer', { when: 50_000 });
+    await fakeBrowser.alarms.create('badge-refresh', { periodInMinutes: 1 });
+
+    const response = await fakeBrowser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
+
+    expect(response).toEqual(
+      createState({
+        cyclePosition: 0,
+        completedToday: 4,
+        sessionCount: 4,
+      }),
+    );
+    await expect(getTimerState()).resolves.toEqual(response);
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toBeUndefined();
+    await expect(fakeBrowser.alarms.get('badge-refresh')).resolves.toBeUndefined();
+  });
+
+  it('shows the break badge while a short break is active', async () => {
+    await setTimerState(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: 1_000,
+        endTime: 6_000,
+        duration: 5_000,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 2_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: 'BRK' });
+    expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#16A34A' });
+  });
+
+  it('shows a pause indicator badge while paused', async () => {
+    await setTimerState(
+      createState({
+        phase: 'PAUSED',
+        duration: 1_500_000,
+        pausedFromPhase: 'WORKING',
+        pausedRemaining: 300_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 2_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: expect.stringContaining('❚❚') });
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: '❚❚5' });
+  });
+
   it('updates config during an active timer and recreates the timer alarm', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000);
     const updatedConfig = createConfig({ workDuration: 20_000, shortBreakDuration: 1_000 });

--- a/lib/__tests__/celebration.test.ts
+++ b/lib/__tests__/celebration.test.ts
@@ -32,6 +32,18 @@ describe('celebration', () => {
     vi.unstubAllGlobals();
   });
 
+  it('fires confetti for a break celebration', () => {
+    vi.stubGlobal('Audio', vi.fn(() => ({ play: vi.fn() })));
+
+    playCelebration('break');
+
+    expect(confetti).toHaveBeenCalledWith(
+      expect.objectContaining({ particleCount: 50, spread: 60 }),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
   it('logs a warning when audio playback fails', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubGlobal(

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -104,6 +104,20 @@ describe('storage helpers', () => {
     await expect(getSessionHistory(2)).resolves.toEqual([withinRange, today]);
   });
 
+  it('returns an empty history when zero days are requested', async () => {
+    await addCompletedSession(createSession(new Date(2026, 2, 19, 9, 0, 0).getTime()));
+    await addCompletedSession(createSession(new Date(2026, 2, 20, 9, 0, 0).getTime()));
+
+    await expect(getSessionHistory(0)).resolves.toEqual([]);
+  });
+
+  it('returns an empty history when negative days are requested', async () => {
+    await addCompletedSession(createSession(new Date(2026, 2, 19, 9, 0, 0).getTime()));
+    await addCompletedSession(createSession(new Date(2026, 2, 20, 9, 0, 0).getTime()));
+
+    await expect(getSessionHistory(-1)).resolves.toEqual([]);
+  });
+
   it('aggregates heatmap counts by local date key', async () => {
     const dateA = new Date(2026, 2, 15, 9, 0, 0).getTime();
     const dateB = new Date(2026, 2, 16, 14, 0, 0).getTime();
@@ -117,6 +131,13 @@ describe('storage helpers', () => {
       [toDateKey(dateA)]: 3,
       [toDateKey(dateB)]: 1,
     });
+  });
+
+  it('returns an empty heatmap when zero days are requested', async () => {
+    await addCompletedSession(createSession(new Date(2026, 2, 19, 9, 0, 0).getTime()));
+    await addCompletedSession(createSession(new Date(2026, 2, 20, 9, 0, 0).getTime()));
+
+    await expect(getHeatmapData(0)).resolves.toEqual({});
   });
 
   it('counts only todays sessions', async () => {

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -89,6 +89,46 @@ describe('timer state machine', () => {
     expect(state.duration).toBe(DEFAULT_CONFIG.workDuration);
   });
 
+  it('does not start a timer from non-idle states', () => {
+    const config = createConfig();
+    const states = [
+      createState({ phase: 'WORKING', startTime: 1_000, endTime: 2_000, duration: 1_000 }),
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: 2_000,
+        endTime: 2_500,
+        duration: 500,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+      createState({
+        phase: 'LONG_BREAK',
+        startTime: 3_000,
+        endTime: 3_500,
+        duration: 500,
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+      createState({
+        phase: 'PAUSED',
+        duration: 1_000,
+        pausedFromPhase: 'WORKING',
+        pausedRemaining: 500,
+      }),
+      createState({
+        phase: 'BREAK_SUGGESTION',
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+    ];
+
+    for (const state of states) {
+      expect(startTimer(state, config, 10_000)).toEqual(state);
+    }
+  });
+
   it('abandons a work session without changing counters', () => {
     const state = createState({
       phase: 'WORKING',
@@ -241,6 +281,34 @@ describe('timer state machine', () => {
 
   it('returns null when recovering a missed alarm from idle', () => {
     expect(recoverMissedAlarm(createState(), DEFAULT_CONFIG, 5_000)).toBeNull();
+  });
+
+  it('does not complete a timer from idle', () => {
+    const state = createState();
+
+    expect(completeTimer(state, DEFAULT_CONFIG, 5_000)).toEqual(state);
+  });
+
+  it('does not complete a timer from paused', () => {
+    const state = createState({
+      phase: 'PAUSED',
+      duration: 10_000,
+      pausedFromPhase: 'WORKING',
+      pausedRemaining: 5_000,
+    });
+
+    expect(completeTimer(state, DEFAULT_CONFIG, 5_000)).toEqual(state);
+  });
+
+  it('returns null when recovering a missed alarm before the end time', () => {
+    const state = createState({
+      phase: 'WORKING',
+      startTime: 1_000,
+      endTime: 10_000,
+      duration: 9_000,
+    });
+
+    expect(recoverMissedAlarm(state, createConfig(), 5_000)).toBeNull();
   });
 
   it('returns correct remaining milliseconds', () => {


### PR DESCRIPTION
## Summary
- add timer and storage edge-case coverage for ignored transitions and zero-day queries
- verify break celebration confetti settings and background ACCEPT/SKIP_LONG_BREAK flows
- cover short-break and paused badge refresh behavior in the background service worker

Closes #19
Closes #20