### PR TITLE
feat(ux): add input validation feedback and stats loading skeleton

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -6,6 +6,17 @@ import { DEFAULT_CONFIG, type TimerConfig } from '@/lib/types';
 
 const MS_PER_MINUTE = 60_000;
 
+type RangeConfig = { min: number; max: number };
+
+const RANGES: Record<string, RangeConfig> = {
+  work: { min: 1, max: 120 },
+  shortBreak: { min: 1, max: 30 },
+  longBreak: { min: 5, max: 60 },
+};
+
+const isOutOfRange = (value: number, range: RangeConfig): boolean =>
+  Number.isNaN(value) || value < range.min || value > range.max;
+
 export default function App() {
   const [work, setWork] = createSignal(25);
   const [shortBreak, setShortBreak] = createSignal(5);
@@ -55,39 +66,66 @@ export default function App() {
 
         <div class="space-y-4">
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Work Duration (minutes)</span>
+            <span class="text-sm font-medium text-gray-700">
+              Work Duration <span class="font-normal text-gray-400">({RANGES.work.min}–{RANGES.work.max} min)</span>
+            </span>
             <input
               type="number"
-              min={1}
-              max={120}
+              min={RANGES.work.min}
+              max={RANGES.work.max}
               value={work()}
               onInput={(e) => setWork(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class={`mt-1 block w-full rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 ${
+                isOutOfRange(work(), RANGES.work)
+                  ? 'border-2 border-red-400 focus:border-red-500 focus:ring-red-500'
+                  : 'border border-gray-300 focus:border-red-500 focus:ring-red-500'
+              }`}
             />
+            <Show when={isOutOfRange(work(), RANGES.work)}>
+              <span class="text-xs text-red-500 mt-1">Must be {RANGES.work.min}–{RANGES.work.max} minutes</span>
+            </Show>
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Short Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700">
+              Short Break <span class="font-normal text-gray-400">({RANGES.shortBreak.min}–{RANGES.shortBreak.max} min)</span>
+            </span>
             <input
               type="number"
-              min={1}
-              max={30}
+              min={RANGES.shortBreak.min}
+              max={RANGES.shortBreak.max}
               value={shortBreak()}
               onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class={`mt-1 block w-full rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 ${
+                isOutOfRange(shortBreak(), RANGES.shortBreak)
+                  ? 'border-2 border-red-400 focus:border-red-500 focus:ring-red-500'
+                  : 'border border-gray-300 focus:border-red-500 focus:ring-red-500'
+              }`}
             />
+            <Show when={isOutOfRange(shortBreak(), RANGES.shortBreak)}>
+              <span class="text-xs text-red-500 mt-1">Must be {RANGES.shortBreak.min}–{RANGES.shortBreak.max} minutes</span>
+            </Show>
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Long Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700">
+              Long Break <span class="font-normal text-gray-400">({RANGES.longBreak.min}–{RANGES.longBreak.max} min)</span>
+            </span>
             <input
               type="number"
-              min={5}
-              max={60}
+              min={RANGES.longBreak.min}
+              max={RANGES.longBreak.max}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class={`mt-1 block w-full rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 ${
+                isOutOfRange(longBreak(), RANGES.longBreak)
+                  ? 'border-2 border-red-400 focus:border-red-500 focus:ring-red-500'
+                  : 'border border-gray-300 focus:border-red-500 focus:ring-red-500'
+              }`}
             />
+            <Show when={isOutOfRange(longBreak(), RANGES.longBreak)}>
+              <span class="text-xs text-red-500 mt-1">Must be {RANGES.longBreak.min}–{RANGES.longBreak.max} minutes</span>
+            </Show>
           </label>
         </div>
 

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For } from 'solid-js';
+import { createResource, For, Show, Suspense } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -18,6 +18,15 @@ type StatCardProps = {
   value: string | number;
   sublabel?: string;
 };
+
+function StatCardSkeleton() {
+  return (
+    <div class="bg-white rounded-xl p-4 shadow-sm border border-red-100 flex flex-col items-center gap-1 animate-pulse">
+      <div class="h-7 w-10 bg-gray-200 rounded" />
+      <div class="h-3 w-16 bg-gray-200 rounded mt-1" />
+    </div>
+  );
+}
 
 function StatCard(props: StatCardProps) {
   return (
@@ -44,20 +53,32 @@ export default function App() {
       <div class="max-w-[800px] mx-auto">
         <h1 class="text-2xl font-bold text-red-600 mb-6">Tomate Stats</h1>
 
-        <div class="grid grid-cols-5 gap-3 mb-6">
-          <StatCard label="Total tomates" value={total()} />
-          <StatCard label="Today" value={todayCount() ?? 0} />
-          <StatCard label="This week" value={week()} />
-          <StatCard
-            label="Best day"
-            value={bestDay()?.count ?? '—'}
-            sublabel={bestDay()?.date}
-          />
-          <StatCard
-            label="Current streak"
-            value={`${streak()}d`}
-          />
-        </div>
+        <Suspense
+          fallback={
+            <div class="grid grid-cols-5 gap-3 mb-6">
+              <StatCardSkeleton />
+              <StatCardSkeleton />
+              <StatCardSkeleton />
+              <StatCardSkeleton />
+              <StatCardSkeleton />
+            </div>
+          }
+        >
+          <div class="grid grid-cols-5 gap-3 mb-6">
+            <StatCard label="Total tomates" value={total()} />
+            <StatCard label="Today" value={todayCount() ?? 0} />
+            <StatCard label="This week" value={week()} />
+            <StatCard
+              label="Best day"
+              value={bestDay()?.count ?? '—'}
+              sublabel={bestDay()?.date}
+            />
+            <StatCard
+              label="Current streak"
+              value={`${streak()}d`}
+            />
+          </div>
+        </Suspense>
 
         <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
           <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>


### PR DESCRIPTION
## Summary
- **Options page**: Shows valid ranges in labels (e.g., "1–120 min"), highlights out-of-range values with red border and inline error text
- **Stats page**: Adds Suspense boundary with animated skeleton cards matching card dimensions, preventing flash of empty content

## Verification
- [x] 69 tests pass
- [x] Build succeeds
- [x] No TypeScript errors
- [x] No file overlap with other open PRs

Closes #12
Closes #18