### PR TITLE
fix(storage): add schema validation and session pruning

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -17,7 +17,9 @@ const KEYS = {
 } as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_SESSION_AGE_DAYS = 365;
 const MAX_LABEL_LENGTH = 50;
+const VALID_PHASES: readonly string[] = ['IDLE', 'WORKING', 'SHORT_BREAK', 'LONG_BREAK', 'PAUSED', 'BREAK_SUGGESTION'];
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -29,6 +31,31 @@ const getStoredValue = async <T>(key: string): Promise<T | undefined> => {
   return result[key] as T | undefined;
 };
 
+const isValidTimerState = (data: unknown): data is TimerState => {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.phase === 'string' &&
+    VALID_PHASES.includes(d.phase) &&
+    typeof d.sessionCount === 'number' &&
+    typeof d.cyclePosition === 'number' &&
+    typeof d.completedToday === 'number'
+  );
+};
+
+const isValidTimerConfig = (data: unknown): data is TimerConfig => {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.workDuration === 'number' &&
+    d.workDuration > 0 &&
+    typeof d.shortBreakDuration === 'number' &&
+    d.shortBreakDuration > 0 &&
+    typeof d.longBreakDuration === 'number' &&
+    d.longBreakDuration > 0
+  );
+};
+
 export const toDateKey = (timestamp: number): string => {
   const date = new Date(timestamp);
   const year = date.getFullYear();
@@ -38,15 +65,19 @@ export const toDateKey = (timestamp: number): string => {
   return `${year}-${month}-${day}`;
 };
 
-export const getTimerState = async (): Promise<TimerState> =>
-  (await getStoredValue<TimerState>(KEYS.TIMER_STATE)) ?? INITIAL_STATE;
+export const getTimerState = async (): Promise<TimerState> => {
+  const stored = await getStoredValue<TimerState>(KEYS.TIMER_STATE);
+  return isValidTimerState(stored) ? stored : INITIAL_STATE;
+};
 
 export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<TimerConfig>(KEYS.CONFIG);
+  return isValidTimerConfig(stored) ? stored : DEFAULT_CONFIG;
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
@@ -54,7 +85,9 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
 
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  const cutoffDate = toDateKey(Date.now() - MAX_SESSION_AGE_DAYS * DAY_MS);
+  const pruned = sessions.filter((s) => s.date >= cutoffDate);
+  await browser.storage.local.set({ [KEYS.SESSIONS]: [...pruned, session] });
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
## Summary
- validate persisted timer state data before returning it from storage and fall back to defaults when storage is corrupted
- validate persisted timer config values before use so invalid durations cannot leak into runtime behavior
- prune completed sessions older than 365 days on every write to keep session storage bounded

Closes #5
Closes #15