### PR TITLE
fix(backend): serialize messages, validate storage, prune sessions

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -44,6 +44,8 @@ export default defineBackground(() => {
   const BADGE_GOLD = '#CA8A04';
   const BADGE_GRAY = '#6B7280';
   const badgeApi = browser.action;
+  let messageQueue = Promise.resolve<unknown>(undefined);
+  let recoveryDone = false;
 
   const refreshBadge = async (): Promise<void> => {
     const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
@@ -70,7 +72,7 @@ export default defineBackground(() => {
         break;
       }
       case 'BREAK_SUGGESTION': {
-        text = `${state.completedToday}✓`;
+        text = `${todayCount}✓`;
         color = BADGE_GOLD;
         break;
       }
@@ -148,6 +150,15 @@ export default defineBackground(() => {
     }
 
     await refreshBadge();
+  };
+
+  const recoverOnce = async (): Promise<void> => {
+    if (recoveryDone) {
+      return;
+    }
+
+    recoveryDone = true;
+    await recoverFromMissedAlarm();
   };
 
   const handleMessage = async (message: MessageAction) => {
@@ -236,14 +247,23 @@ export default defineBackground(() => {
   };
 
   browser.runtime.onInstalled.addListener(async () => {
-    await recoverFromMissedAlarm();
+    await recoverOnce();
   });
 
   browser.runtime.onStartup.addListener(async () => {
-    await recoverFromMissedAlarm();
+    await recoverOnce();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  browser.runtime.onMessage.addListener((message) => {
+    messageQueue = messageQueue
+      .then(() => handleMessage(message as MessageAction))
+      .catch((error) => {
+        console.error('Tomate: message handler error', error);
+        return getTimerState();
+      });
+
+    return messageQueue;
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -17,7 +17,9 @@ const KEYS = {
 } as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_SESSION_AGE_DAYS = 365;
 const MAX_LABEL_LENGTH = 50;
+const VALID_PHASES: readonly string[] = ['IDLE', 'WORKING', 'SHORT_BREAK', 'LONG_BREAK', 'PAUSED', 'BREAK_SUGGESTION'];
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -29,6 +31,31 @@ const getStoredValue = async <T>(key: string): Promise<T | undefined> => {
   return result[key] as T | undefined;
 };
 
+const isValidTimerState = (data: unknown): data is TimerState => {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.phase === 'string' &&
+    VALID_PHASES.includes(d.phase) &&
+    typeof d.sessionCount === 'number' &&
+    typeof d.cyclePosition === 'number' &&
+    typeof d.completedToday === 'number'
+  );
+};
+
+const isValidTimerConfig = (data: unknown): data is TimerConfig => {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.workDuration === 'number' &&
+    d.workDuration > 0 &&
+    typeof d.shortBreakDuration === 'number' &&
+    d.shortBreakDuration > 0 &&
+    typeof d.longBreakDuration === 'number' &&
+    d.longBreakDuration > 0
+  );
+};
+
 export const toDateKey = (timestamp: number): string => {
   const date = new Date(timestamp);
   const year = date.getFullYear();
@@ -38,15 +65,19 @@ export const toDateKey = (timestamp: number): string => {
   return `${year}-${month}-${day}`;
 };
 
-export const getTimerState = async (): Promise<TimerState> =>
-  (await getStoredValue<TimerState>(KEYS.TIMER_STATE)) ?? INITIAL_STATE;
+export const getTimerState = async (): Promise<TimerState> => {
+  const stored = await getStoredValue<TimerState>(KEYS.TIMER_STATE);
+  return isValidTimerState(stored) ? stored : INITIAL_STATE;
+};
 
 export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<TimerConfig>(KEYS.CONFIG);
+  return isValidTimerConfig(stored) ? stored : DEFAULT_CONFIG;
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
@@ -54,7 +85,9 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
 
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  const cutoffDate = toDateKey(Date.now() - MAX_SESSION_AGE_DAYS * DAY_MS);
+  const pruned = sessions.filter((s) => s.date >= cutoffDate);
+  await browser.storage.local.set({ [KEYS.SESSIONS]: [...pruned, session] });
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
## Summary
- **background.ts**: Serialized message handling via promise chain to prevent race conditions; deduped `onInstalled`/`onStartup` recovery; badge now uses session count instead of stale `completedToday`; unhandled rejections caught and logged
- **storage.ts**: Added runtime schema validation for `TimerState` and `TimerConfig` with fallback to defaults on corruption; sessions auto-prune entries older than 365 days on write

## Verification
- [x] TypeScript compiles without errors
- [x] Build passes
- [x] No file overlap with other open PRs

Closes #1
Closes #5
Closes #6
Closes #7
Closes #8
Closes #15