### PR TITLE
feat: system notifications and session data export

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -262,6 +262,13 @@ export default defineBackground(() => {
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
 
+      await browser.notifications.create('tomate-work-complete', {
+        type: 'basic',
+        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+        title: 'Tomate complete!',
+        message: `Great work! You've completed ${completed.completedToday} tomate${completed.completedToday === 1 ? '' : 's'} today.`,
+      });
+
       const isLong = completed.cyclePosition === 3 ? '1' : '0';
       await browser.tabs.create({
         url: browser.runtime.getURL(
@@ -271,6 +278,13 @@ export default defineBackground(() => {
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
+      await browser.notifications.create('tomate-break-complete', {
+        type: 'basic',
+        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+        title: 'Break over!',
+        message: 'Time to get back to work.',
+      });
+
       await browser.tabs.create({
         url: browser.runtime.getURL('/complete.html?type=break' as '/popup.html'),
       });

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,6 +1,7 @@
 import { createResource, For } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
+import type { CompletedSession } from '@/lib/types';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
 
 import Heatmap from '@/components/Heatmap';
@@ -77,7 +78,54 @@ export default function App() {
             <span>More</span>
           </div>
         </div>
+        <div class="mt-6 flex gap-3">
+          <button
+            type="button"
+            onClick={() => exportData('csv')}
+            class="text-xs text-gray-500 hover:text-red-600 underline"
+          >
+            Export CSV
+          </button>
+          <button
+            type="button"
+            onClick={() => exportData('json')}
+            class="text-xs text-gray-500 hover:text-red-600 underline"
+          >
+            Export JSON
+          </button>
+        </div>
       </div>
     </div>
   );
+
+  function exportData(format: 'csv' | 'json') {
+    const data = sessions();
+    if (!data || data.length === 0) return;
+
+    let content: string;
+    let mimeType: string;
+    let ext: string;
+
+    if (format === 'csv') {
+      const header = 'date,label,startTime,endTime,duration_minutes';
+      const rows = data.map((s: CompletedSession) =>
+        `${s.date},"${s.label.replace(/"/g, '""')}",${new Date(s.startTime).toISOString()},${new Date(s.endTime).toISOString()},${Math.round(s.duration / 60000)}`
+      );
+      content = [header, ...rows].join('\n');
+      mimeType = 'text/csv';
+      ext = 'csv';
+    } else {
+      content = JSON.stringify(data, null, 2);
+      mimeType = 'application/json';
+      ext = 'json';
+    }
+
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `tomate-sessions.${ext}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
 }


### PR DESCRIPTION
## Summary
- **System notifications** (#33): Desktop notifications fire when work sessions complete ("Great work! You've completed N tomates today") and when breaks end ("Time to get back to work"). Uses chrome.notifications API with extension icon.
- **Data export** (#38): Stats page now has "Export CSV" and "Export JSON" buttons. CSV includes date, label, start/end timestamps, and duration in minutes. JSON exports the raw session array.

## Verification
- [x] 57 tests pass
- [x] Build succeeds (91.01 kB)
- [x] No TypeScript errors
- [x] No file overlap with other open PRs

Closes #33
Closes #38