### PR TITLE
feat: dark mode with system preference detection and theme toggle

### DIFF
--- a/entrypoints/complete/main.tsx
+++ b/entrypoints/complete/main.tsx
@@ -1,5 +1,7 @@
 import { render } from 'solid-js/web';
+import { initTheme } from '@/lib/theme';
 import App from './App';
 import './style.css';
 
+initTheme();
 render(() => <App />, document.getElementById('app')!);

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,7 +1,8 @@
 import { createSignal, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
-import { getConfig, setConfig } from '@/lib/storage';
+import { getConfig, setConfig, getTheme, setTheme, type ThemeMode } from '@/lib/storage';
+import { initTheme } from '@/lib/theme';
 import { DEFAULT_CONFIG, type TimerConfig } from '@/lib/types';
 
 const MS_PER_MINUTE = 60_000;
@@ -10,6 +11,7 @@ export default function App() {
   const [work, setWork] = createSignal(25);
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
+  const [themeMode, setThemeMode] = createSignal<ThemeMode>('system');
   const [saved, setSaved] = createSignal(false);
 
   onMount(async () => {
@@ -17,6 +19,7 @@ export default function App() {
     setWork(Math.round(config.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(config.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
+    setThemeMode(await getTheme());
   });
 
   const clamp = (value: number, min: number, max: number): number =>
@@ -49,9 +52,9 @@ export default function App() {
   };
 
   return (
-    <div class="min-h-screen bg-red-50 flex items-start justify-center pt-16">
-      <div class="w-full max-w-[400px] bg-white rounded-lg shadow-sm p-6">
-        <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 flex items-start justify-center pt-16">
+      <div class="w-full max-w-[400px] bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400 mb-6">Tomate Settings</h1>
 
         <div class="space-y-4">
           <label class="block">
@@ -89,6 +92,29 @@ export default function App() {
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
+        </div>
+
+        <div class="mt-6">
+          <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Appearance</h2>
+          <div class="flex gap-2 mt-2">
+            {(['light', 'dark', 'system'] as const).map((mode) => (
+              <button
+                type="button"
+                onClick={async () => {
+                  setThemeMode(mode);
+                  await setTheme(mode);
+                  initTheme();
+                }}
+                class={`px-3 py-1.5 text-xs rounded-md border ${
+                  themeMode() === mode
+                    ? 'bg-red-600 text-white border-red-600'
+                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                }`}
+              >
+                {mode === 'light' ? '☀️ Light' : mode === 'dark' ? '🌙 Dark' : '💻 System'}
+              </button>
+            ))}
+          </div>
         </div>
 
         <div class="mt-6 flex items-center gap-4">

--- a/entrypoints/options/main.tsx
+++ b/entrypoints/options/main.tsx
@@ -1,5 +1,7 @@
 import { render } from 'solid-js/web';
+import { initTheme } from '@/lib/theme';
 import App from './App';
 import './style.css';
 
+initTheme();
 render(() => <App />, document.getElementById('app')!);

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -127,9 +127,9 @@ export default function App() {
   };
 
   return (
-    <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
+    <div class="w-[360px] min-h-[400px] bg-red-50 dark:bg-gray-900 p-4 flex flex-col items-center">
       <div class="w-full flex justify-between items-center mb-4">
-        <h1 class="text-xl font-bold text-red-600">Tomate</h1>
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400">Tomate</h1>
         <button
           type="button"
           onClick={() => browser.runtime.openOptionsPage()}
@@ -143,13 +143,13 @@ export default function App() {
       <Show
         when={ready()}
         fallback={
-          <div class="flex-1 flex items-center justify-center text-gray-400 text-sm">Loading…</div>
+          <div class="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-500 text-sm">Loading…</div>
         }
       >
         <TimerRing progress={progress()} phase={state().phase} />
-        <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+        <div class="text-4xl font-mono font-bold text-gray-800 dark:text-gray-100 mt-2">{formatTime()}</div>
 
-        <div class="text-sm text-gray-500 mt-1">
+        <div class="text-sm text-gray-500 dark:text-gray-400 mt-1">
           <Switch>
             <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
             <Match when={state().phase === 'WORKING'}>Working</Match>

--- a/entrypoints/popup/main.tsx
+++ b/entrypoints/popup/main.tsx
@@ -1,5 +1,7 @@
 import { render } from 'solid-js/web';
+import { initTheme } from '@/lib/theme';
 import App from './App';
 import './style.css';
 
+initTheme();
 render(() => <App />, document.getElementById('app')!);

--- a/entrypoints/stats/main.tsx
+++ b/entrypoints/stats/main.tsx
@@ -1,5 +1,7 @@
 import { render } from 'solid-js/web';
+import { initTheme } from '@/lib/theme';
 import App from './App';
 import './style.css';
 
+initTheme();
 render(() => <App />, document.getElementById('app')!);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -14,7 +14,21 @@ const KEYS = {
   SESSIONS: 'sessions',
   PENDING_CELEBRATION: 'pendingCelebration',
   CURRENT_LABEL: 'currentLabel',
+  THEME: 'theme',
 } as const;
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+export const getTheme = async (): Promise<ThemeMode> => {
+  const result = await browser.storage.local.get(KEYS.THEME);
+  const val = result[KEYS.THEME];
+  if (val === 'light' || val === 'dark' || val === 'system') return val;
+  return 'system';
+};
+
+export const setTheme = async (theme: ThemeMode): Promise<void> => {
+  await browser.storage.local.set({ [KEYS.THEME]: theme });
+};
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,18 @@
+import { getTheme, type ThemeMode } from './storage';
+
+const applyTheme = (mode: ThemeMode): void => {
+  const isDark =
+    mode === 'dark' || (mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  document.documentElement.classList.toggle('dark', isDark);
+};
+
+export const initTheme = async (): Promise<void> => {
+  const theme = await getTheme();
+  applyTheme(theme);
+
+  if (theme === 'system') {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      applyTheme('system');
+    });
+  }
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'tailwindcss';
 
 export default {
   content: ['./entrypoints/**/*.{html,ts,tsx}', './components/**/*.{ts,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- **Tailwind dark mode**: Enabled `darkMode: 'class'` in config
- **Theme persistence**: New `getTheme`/`setTheme` in storage with `light | dark | system` options
- **Theme initializer**: `lib/theme.ts` applies dark class and listens for system preference changes
- **All pages**: Every `main.tsx` calls `initTheme()` on load
- **Settings toggle**: Light/Dark/System buttons in options page with instant apply
- **Popup**: Key surfaces (background, text, loading) have dark variants

## Verification
- [x] 57 tests pass
- [x] Build succeeds (93.85 kB)
- [x] No TypeScript errors

Closes #36