### PR TITLE
fix(backend): alarm safety guard and celebration audio error logging

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -226,6 +226,12 @@ export default defineBackground(() => {
     }
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+    if (!isActivePhase(state.phase)) {
+      await clearActiveAlarms();
+      await refreshBadge();
+      return;
+    }
+
     const completed = completeTimer(state, config);
     await setTimerState(completed);
 

--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -27,5 +27,7 @@ export const playCelebration = (type: 'work' | 'milestone' | 'break'): void => {
 
   try {
     new Audio(browser.runtime.getURL('/sounds/completion.mp3' as '/popup.html')).play();
-  } catch {}
+  } catch (e) {
+    console.warn('Audio playback failed:', e);
+  }
 };


### PR DESCRIPTION
## Summary
- Add guard to skip alarm handler when timer is not in an active phase, preventing stale alarms from corrupting state (#45)
- Log celebration audio playback errors instead of silently swallowing them (#46)
- Verified #44 (LONG_BREAK notification) is already handled correctly — false positive

## Verification
- [x] LSP diagnostics clean on changed files
- [x] Changes are minimal and non-overlapping with other PRs

Closes #45
Closes #46