### PR TITLE
fix(frontend): error handling, loading states, and focus management

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -2,7 +2,7 @@ import { createSignal, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
-import { DEFAULT_CONFIG, type TimerConfig } from '@/lib/types';
+import { DEFAULT_CONFIG } from '@/lib/types';
 
 const MS_PER_MINUTE = 60_000;
 
@@ -11,6 +11,7 @@ export default function App() {
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
   const [saved, setSaved] = createSignal(false);
+  const [error, setError] = createSignal(false);
 
   onMount(async () => {
     const config = await getConfig();
@@ -20,15 +21,23 @@ export default function App() {
   });
 
   const handleSave = async () => {
-    const config: TimerConfig = {
-      workDuration: work() * MS_PER_MINUTE,
-      shortBreakDuration: shortBreak() * MS_PER_MINUTE,
-      longBreakDuration: longBreak() * MS_PER_MINUTE,
-    };
-    await setConfig(config);
-    await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    try {
+      const currentConfig = await getConfig();
+      const config = {
+        ...currentConfig,
+        workDuration: work() * MS_PER_MINUTE,
+        shortBreakDuration: shortBreak() * MS_PER_MINUTE,
+        longBreakDuration: longBreak() * MS_PER_MINUTE,
+      };
+      await setConfig(config);
+      await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch {
+      setSaved(false);
+      setError(true);
+      setTimeout(() => setError(false), 3000);
+    }
   };
 
   const handleReset = () => {
@@ -99,6 +108,10 @@ export default function App() {
 
           <Show when={saved()}>
             <span class="text-sm text-green-600">Settings saved ✓</span>
+          </Show>
+
+          <Show when={error()}>
+            <span class="text-sm text-red-600">Failed to save settings</span>
           </Show>
         </div>
       </div>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, Switch, Match, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
@@ -25,6 +25,8 @@ export default function App() {
   const [label, setLabel] = createSignal('');
   const [todayCount, setTodayCount] = createSignal(0);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [loading, setLoading] = createSignal(true);
+  let controlsRef: HTMLDivElement | undefined;
 
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
@@ -44,8 +46,13 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const handleStorageChange = (changes: Record<string, unknown>) => {
+      if ('sessions' in changes) refreshStats();
+    };
+
+    browser.storage.onChanged.addListener(handleStorageChange);
+    onCleanup(() => browser.storage.onChanged.removeListener(handleStorageChange));
+    setLoading(false);
   });
 
   createEffect(() => {
@@ -57,6 +64,13 @@ export default function App() {
       onCleanup(() => clearInterval(id));
     } else {
       setRemaining(0);
+    }
+  });
+
+  createEffect(() => {
+    if (state().phase === 'BREAK_SUGGESTION' && controlsRef) {
+      const firstBtn = controlsRef.querySelector('button');
+      firstBtn?.focus();
     }
   });
 
@@ -102,55 +116,63 @@ export default function App() {
   };
 
   return (
-    <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
-      <div class="w-full flex justify-between items-center mb-4">
-        <h1 class="text-xl font-bold text-red-600">Tomate</h1>
+    <Show when={!loading()} fallback={
+      <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex items-center justify-center">
+        <span class="text-gray-400">Loading...</span>
+      </div>
+    }>
+      <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
+        <div class="w-full flex justify-between items-center mb-4">
+          <h1 class="text-xl font-bold text-red-600">Tomate</h1>
+          <button
+            type="button"
+            onClick={() => browser.runtime.openOptionsPage()}
+            class="text-gray-400 hover:text-gray-600 text-lg"
+            aria-label="Settings"
+          >
+            ⚙️
+          </button>
+        </div>
+
+        <TimerRing progress={progress()} phase={state().phase} />
+        <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+
+        <div class="text-sm text-gray-500 mt-1">
+          <Switch>
+            <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
+            <Match when={state().phase === 'WORKING'}>Working</Match>
+            <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
+            <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
+            <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
+          </Switch>
+        </div>
+
+        <TaskLabel value={label()} onChange={handleLabelChange} />
+
+        <div ref={controlsRef}>
+          <Controls
+            phase={state().phase}
+            onStart={startTimer}
+            onAbandon={abandonTimer}
+            onAcceptLongBreak={acceptLongBreak}
+            onSkipLongBreak={skipLongBreak}
+          />
+        </div>
+
+        <TodayCount count={todayCount()} />
+
+        <div class="mt-2 w-full">
+          <Heatmap days={120} data={heatmapData()} />
+        </div>
+
         <button
           type="button"
-          onClick={() => browser.runtime.openOptionsPage()}
-          class="text-gray-400 hover:text-gray-600 text-lg"
-          aria-label="Settings"
+          onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+          class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
         >
-          ⚙️
+          View all stats →
         </button>
       </div>
-
-      <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
-
-      <div class="text-sm text-gray-500 mt-1">
-        <Switch>
-          <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
-          <Match when={state().phase === 'WORKING'}>Working</Match>
-          <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
-          <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
-          <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
-        </Switch>
-      </div>
-
-      <TaskLabel value={label()} onChange={handleLabelChange} />
-
-      <Controls
-        phase={state().phase}
-        onStart={startTimer}
-        onAbandon={abandonTimer}
-        onAcceptLongBreak={acceptLongBreak}
-        onSkipLongBreak={skipLongBreak}
-      />
-
-      <TodayCount count={todayCount()} />
-
-      <div class="mt-2 w-full">
-        <Heatmap days={120} data={heatmapData()} />
-      </div>
-
-      <button
-        type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
-        class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
-      >
-        View all stats →
-      </button>
-    </div>
+    </Show>
   );
 }

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For } from 'solid-js';
+import { createResource, For, Show } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -43,6 +43,10 @@ export default function App() {
     <div class="min-h-screen bg-red-50 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <h1 class="text-2xl font-bold text-red-600 mb-6">Tomate Stats</h1>
+
+        <Show when={sessions.error || yearData.error || todayCount.error}>
+          <div class="text-red-500 text-sm mb-4">Failed to load stats. Please try reopening this page.</div>
+        </Show>
 
         <div class="grid grid-cols-5 gap-3 mb-6">
           <StatCard label="Total tomates" value={total()} />


### PR DESCRIPTION
## Summary
- Show error message when stats page resources fail to load (#47)
- Filter storage change listener to only fire on session key changes (#48)
- Focus first action button when entering BREAK_SUGGESTION phase (#49)
- Show loading indicator during popup initialization instead of stale state (#50)
- Show error feedback when options save fails, with try-catch around save operations (#51)

## Verification
- [x] LSP diagnostics clean on all 3 changed files
- [x] SolidJS patterns used correctly (createSignal, Show, createEffect)

Closes #47
Closes #48
Closes #49
Closes #50
Closes #51