### PR TITLE
feat(a11y): ARIA attributes for timer ring, controls, task label, and heatmap contrast

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -17,6 +17,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
+            aria-label="Start work session"
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
           >
             Start
@@ -26,6 +27,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
+            aria-label="Abandon current session"
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Abandon
@@ -35,6 +37,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
+            aria-label="Skip current break"
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Skip Break
@@ -44,6 +47,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAcceptLongBreak}
+            aria-label="Start long break"
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
           >
             Long Break
@@ -51,6 +55,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onSkipLongBreak}
+            aria-label="Skip long break"
             class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Skip

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -13,7 +13,7 @@ type HeatmapCell = {
 };
 
 const INTENSITY_COLORS = [
-  '#F3F4F6',
+  '#E5E7EB',
   '#FCA5A5',
   '#EF4444',
   '#DC2626',

--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -11,6 +11,7 @@ export default function TaskLabel(props: TaskLabelProps) {
       onInput={(e) => props.onChange(e.currentTarget.value)}
       placeholder="What are you working on?"
       maxLength={50}
+      aria-label="Current task"
       class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
     />
   );

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -23,8 +23,17 @@ export default function TimerRing(props: TimerRingProps) {
   const color = () => PHASE_COLORS[props.phase];
 
   return (
-    <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      <title>Timer progress</title>
+    <svg
+      width={SIZE}
+      height={SIZE}
+      class="timer-ring"
+      viewBox={`0 0 ${SIZE} ${SIZE}`}
+      role="progressbar"
+      aria-valuenow={Math.round(props.progress * 100)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label="Timer progress"
+    >
       <circle
         cx={SIZE / 2}
         cy={SIZE / 2}


### PR DESCRIPTION
## Summary
- Add `role="progressbar"` with `aria-valuenow/min/max` and `aria-label` to TimerRing SVG (#52)
- Add descriptive `aria-label` to all 5 control buttons (Start, Abandon, Skip Break, Long Break, Skip) (#53)
- Add `aria-label="Current task"` to TaskLabel input (#54)
- Improve heatmap zero-intensity color from #F3F4F6 to #E5E7EB for better WCAG contrast (#55)

## Verification
- [x] 25/25 relevant tests pass
- [x] Only component files modified (no entrypoint changes)
- [x] ARIA attributes follow WAI-ARIA 1.2 spec

Closes #52
Closes #53
Closes #54
Closes #55