### PR TITLE
fix: open new tab when work session completes

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -237,6 +237,9 @@ export default defineBackground(() => {
         title: '🍅 Tomate Complete!',
         message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
       });
+      if (config.openBreakTab !== false) {
+        await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
+      }
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -10,6 +10,7 @@ export default function App() {
   const [work, setWork] = createSignal(25);
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
+  const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [saved, setSaved] = createSignal(false);
 
   onMount(async () => {
@@ -17,6 +18,7 @@ export default function App() {
     setWork(Math.round(config.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(config.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
+    setOpenBreakTab(config.openBreakTab !== false);
   });
 
   const handleSave = async () => {
@@ -24,6 +26,7 @@ export default function App() {
       workDuration: work() * MS_PER_MINUTE,
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,
       longBreakDuration: longBreak() * MS_PER_MINUTE,
+      openBreakTab: openBreakTab(),
     };
     await setConfig(config);
     await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
@@ -77,6 +80,16 @@ export default function App() {
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+          </label>
+
+          <label class="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={openBreakTab()}
+              onChange={(e) => setOpenBreakTab(e.currentTarget.checked)}
+              class="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+            />
+            <span class="text-sm font-medium text-gray-700">Open stats tab when work session ends</span>
           </label>
         </div>
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export type TimerConfig = {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  openBreakTab: boolean;
 };
 
 export type TimerState = {
@@ -29,6 +30,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  openBreakTab: true,
 };
 
 export const INITIAL_STATE: TimerState = {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Tomate',
     description: 'A Pomodoro timer that helps you focus — one tomate at a time.',
-    permissions: ['alarms', 'notifications', 'storage'],
+    permissions: ['alarms', 'notifications', 'storage', 'tabs'],
     action: {
       default_icon: {
         '16': '/icons/icon-16.png',


### PR DESCRIPTION
## Summary

- When a Pomodoro work session alarm fires, the extension now opens the stats page in a new tab so the user is immediately notified the session is done and it's break time
- Added `tabs` to the manifest `permissions` array (required to call `browser.tabs.create`)
- Added `openBreakTab: boolean` to `TimerConfig` (default `true`) so the behaviour is on by default but user-configurable
- Added a checkbox toggle in the Settings/Options page ("Open stats tab when work session ends")

## Test plan

- [ ] Start a work session (shorten `workDuration` in settings to ~1 min for quick testing)
- [ ] Let the timer run to completion
- [ ] Verify: a new tab opens on the Stats page
- [ ] Go to Settings, uncheck "Open stats tab when work session ends", save
- [ ] Run another session to completion — confirm no tab opens this time
- [ ] Verify the existing notification still fires in both cases

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)