### PR TITLE
fix: TimerState validation and storage listener cleanup in popup

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -11,7 +11,7 @@ import {
   getTodayCount,
   getHeatmapData,
 } from '@/lib/storage';
-import { INITIAL_STATE, type TimerState } from '@/lib/types';
+import { INITIAL_STATE, isTimerState, type TimerState } from '@/lib/types';
 
 import TimerRing from '@/components/TimerRing';
 import Controls from '@/components/Controls';
@@ -31,9 +31,13 @@ export default function App() {
     setHeatmapData(await getHeatmapData(120));
   };
 
+  const handleStorageChange = () => { void refreshStats(); };
+
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    const resp = await browser.runtime.sendMessage({ action: 'GET_STATE' });
+    if (isTimerState(resp)) {
+      setState(resp);
+    }
 
     const pending = await getPendingCelebration();
     if (pending) {
@@ -44,9 +48,10 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    browser.storage.onChanged.addListener(handleStorageChange);
   });
+
+  onCleanup(() => browser.storage.onChanged.removeListener(handleStorageChange));
 
   createEffect(() => {
     const s = state();
@@ -75,23 +80,31 @@ export default function App() {
   };
 
   const startTimer = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'START_TIMER' });
-    setState(newState as TimerState);
+    const resp = await browser.runtime.sendMessage({ action: 'START_TIMER' });
+    if (isTimerState(resp)) {
+      setState(resp);
+    }
   };
 
   const abandonTimer = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
-    setState(newState as TimerState);
+    const resp = await browser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
+    if (isTimerState(resp)) {
+      setState(resp);
+    }
   };
 
   const acceptLongBreak = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
-    setState(newState as TimerState);
+    const resp = await browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
+    if (isTimerState(resp)) {
+      setState(resp);
+    }
   };
 
   const skipLongBreak = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
-    setState(newState as TimerState);
+    const resp = await browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
+    if (isTimerState(resp)) {
+      setState(resp);
+    }
   };
 
   let labelTimeout: ReturnType<typeof setTimeout>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -40,3 +40,13 @@ export const INITIAL_STATE: TimerState = {
   cyclePosition: 0,
   completedToday: 0,
 };
+
+export function isTimerState(x: unknown): x is TimerState {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    'phase' in x &&
+    'endTime' in x &&
+    'workDuration' in x
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `isTimerState()` type guard — all background message responses validated before use
- Storage change listener now properly removed on component unmount
- Prevents stale closure issues with the change handler

## Verification
- [ ] Type check passes
- [ ] Popup handles undefined/malformed background response gracefully
- [ ] No duplicate listeners accumulate on remount

Closes #71
Closes #72