### PR TITLE
feat: website blocking during focus sessions

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,5 @@
 import { browser } from 'wxt/browser';
+import type { Browser } from 'wxt/browser';
 
 import {
   abandonTimer,
@@ -22,7 +23,7 @@ import {
   setTimerState,
   toDateKey,
 } from '@/lib/storage';
-import type { CompletedSession, TimerConfig } from '@/lib/types';
+import type { CompletedSession, TimerConfig, TimerPhase } from '@/lib/types';
 
 export type MessageAction =
   | { action: 'START_TIMER' }
@@ -31,6 +32,44 @@ export type MessageAction =
   | { action: 'ACCEPT_LONG_BREAK' }
   | { action: 'SKIP_LONG_BREAK' }
   | { action: 'UPDATE_CONFIG'; config: TimerConfig };
+
+const BLOCK_RULE_ID_BASE = 1000;
+
+const buildBlockingRules = (sites: string[]): Browser.declarativeNetRequest.Rule[] =>
+  sites.map((site, index) => {
+    const hostname = site.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+    return {
+      id: BLOCK_RULE_ID_BASE + index,
+      priority: 1,
+      action: { type: 'block' as Browser.declarativeNetRequest.RuleActionType },
+      condition: {
+        urlFilter: `||${hostname}`,
+        resourceTypes: ['main_frame' as Browser.declarativeNetRequest.ResourceType],
+      },
+    };
+  });
+
+const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  if (sites.length === 0) return;
+  const addRules = buildBlockingRules(sites);
+  const removeRuleIds = addRules.map((r) => r.id);
+  await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules });
+};
+
+const removeBlockingRules = async (): Promise<void> => {
+  const existing = await browser.declarativeNetRequest.getDynamicRules();
+  const removeRuleIds = existing.filter((r) => r.id >= BLOCK_RULE_ID_BASE).map((r) => r.id);
+  if (removeRuleIds.length === 0) return;
+  await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules: [] });
+};
+
+const syncBlockingForPhase = async (phase: TimerPhase, config: TimerConfig): Promise<void> => {
+  if (phase === 'WORKING') {
+    await applyBlockingRules(config.blockedSites ?? []);
+  } else {
+    await removeBlockingRules();
+  }
+};
 
 export default defineBackground(() => {
   const ALARM_TIMER = 'tomate-timer';
@@ -136,6 +175,7 @@ export default defineBackground(() => {
       await clearActiveAlarms();
     }
 
+    await syncBlockingForPhase(recovered.phase, config);
     await refreshBadge();
   };
 
@@ -152,6 +192,7 @@ export default defineBackground(() => {
           await startBadgeRefresh();
         }
 
+        await syncBlockingForPhase(nextState.phase, config);
         await refreshBadge();
         return nextState;
       }
@@ -159,6 +200,7 @@ export default defineBackground(() => {
         const nextState = abandonTimer(state);
         await setTimerState(nextState);
         await clearActiveAlarms();
+        await removeBlockingRules();
         await refreshBadge();
         return nextState;
       }
@@ -174,6 +216,7 @@ export default defineBackground(() => {
           await startBadgeRefresh();
         }
 
+        await syncBlockingForPhase(nextState.phase, config);
         await refreshBadge();
         return nextState;
       }
@@ -181,6 +224,7 @@ export default defineBackground(() => {
         const nextState = skipLongBreak(state);
         await setTimerState(nextState);
         await clearActiveAlarms();
+        await removeBlockingRules();
         await refreshBadge();
         return nextState;
       }
@@ -196,6 +240,7 @@ export default defineBackground(() => {
           await clearActiveAlarms();
         }
 
+        await syncBlockingForPhase(nextState.phase, message.config);
         await refreshBadge();
         return nextState;
       }
@@ -255,6 +300,7 @@ export default defineBackground(() => {
       await clearActiveAlarms();
     }
 
+    await syncBlockingForPhase(completed.phase, config);
     await refreshBadge();
   });
 });

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, For, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
@@ -10,6 +10,8 @@ export default function App() {
   const [work, setWork] = createSignal(25);
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
+  const [blockedSites, setBlockedSites] = createSignal<string[]>([]);
+  const [newSite, setNewSite] = createSignal('');
   const [saved, setSaved] = createSignal(false);
 
   onMount(async () => {
@@ -17,13 +19,39 @@ export default function App() {
     setWork(Math.round(config.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(config.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
+    setBlockedSites(config.blockedSites ?? []);
   });
+
+  const handleAddSite = () => {
+    const raw = newSite().trim();
+    if (!raw) return;
+    const hostname = raw.replace(/^https?:\/\//, '').replace(/\/.*$/, '').toLowerCase();
+    if (!hostname) return;
+    if (blockedSites().includes(hostname)) {
+      setNewSite('');
+      return;
+    }
+    setBlockedSites([...blockedSites(), hostname]);
+    setNewSite('');
+  };
+
+  const handleRemoveSite = (site: string) => {
+    setBlockedSites(blockedSites().filter((s) => s !== site));
+  };
+
+  const handleNewSiteKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddSite();
+    }
+  };
 
   const handleSave = async () => {
     const config: TimerConfig = {
       workDuration: work() * MS_PER_MINUTE,
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,
       longBreakDuration: longBreak() * MS_PER_MINUTE,
+      blockedSites: blockedSites(),
     };
     await setConfig(config);
     await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
@@ -35,6 +63,7 @@ export default function App() {
     setWork(Math.round(DEFAULT_CONFIG.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(DEFAULT_CONFIG.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
+    setBlockedSites([]);
   };
 
   return (
@@ -78,6 +107,55 @@ export default function App() {
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
+        </div>
+
+        <div class="mt-6">
+          <h2 class="text-sm font-medium text-gray-700 mb-2">Blocked Sites During Focus</h2>
+          <p class="text-xs text-gray-500 mb-3">
+            These sites will be blocked while a work session is active.
+          </p>
+
+          <div class="flex gap-2 mb-3">
+            <input
+              type="text"
+              placeholder="e.g. twitter.com"
+              value={newSite()}
+              onInput={(e) => setNewSite(e.currentTarget.value)}
+              onKeyDown={handleNewSiteKeyDown}
+              class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+            />
+            <button
+              type="button"
+              onClick={handleAddSite}
+              class="bg-red-600 text-white px-3 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            >
+              Add
+            </button>
+          </div>
+
+          <Show when={blockedSites().length > 0}>
+            <ul class="space-y-1 mb-2">
+              <For each={blockedSites()}>
+                {(site) => (
+                  <li class="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 text-sm">
+                    <span class="text-gray-800">{site}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveSite(site)}
+                      class="text-gray-400 hover:text-red-600 ml-2 text-xs font-medium"
+                      aria-label={`Remove ${site}`}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </Show>
+
+          <Show when={blockedSites().length === 0}>
+            <p class="text-xs text-gray-400 italic">No sites blocked yet.</p>
+          </Show>
         </div>
 
         <div class="mt-6 flex items-center gap-4">

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export type TimerConfig = {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  blockedSites: string[];
 };
 
 export type TimerState = {
@@ -29,6 +30,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  blockedSites: [],
 };
 
 export const INITIAL_STATE: TimerState = {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Tomate',
     description: 'A Pomodoro timer that helps you focus — one tomate at a time.',
-    permissions: ['alarms', 'notifications', 'storage'],
+    permissions: ['alarms', 'notifications', 'storage', 'declarativeNetRequest', 'declarativeNetRequestWithHostAccess'],
     action: {
       default_icon: {
         '16': '/icons/icon-16.png',


### PR DESCRIPTION
## Summary
- Adds `blockedSites: string[]` field to `TimerConfig` (stored in chrome.storage, default: `[]`)
- Blocks configured sites via `browser.declarativeNetRequest` dynamic rules (IDs 1000+) during work sessions
- Unblocks sites when session ends (break), is abandoned, skipped, or recovered from missed alarm
- Options page UI to add/remove sites from the blocked list (enter hostname or URL, press Enter or Add)
- Adds `declarativeNetRequest` and `declarativeNetRequestWithHostAccess` permissions to manifest

## Verification
- [ ] Type check passes (`npx tsc --noEmit` — no new errors)
- [ ] Options page shows site blocking UI with add/remove controls
- [ ] `declarativeNetRequest` permission added to manifest
- [ ] Sites blocked when `START_TIMER` transitions to WORKING phase
- [ ] Sites unblocked when timer completes to break, or ABANDON/SKIP actions are taken

Closes #34