### PR TITLE
fix: message serialization and reliable popup close

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -213,7 +213,21 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  let messageQueue: Promise<void> = Promise.resolve();
+
+  browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    messageQueue = messageQueue
+      .then(() => handleMessage(message as MessageAction))
+      .then((response) => {
+        sendResponse(response);
+      })
+      .catch((err) => {
+        console.error('[tomate] message handler error:', err);
+        sendResponse(undefined);
+      });
+    // Return true to keep the message channel open for the async sendResponse
+    return true;
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -77,21 +77,25 @@ export default function App() {
   const startTimer = async () => {
     const newState = await browser.runtime.sendMessage({ action: 'START_TIMER' });
     setState(newState as TimerState);
+    window.close();
   };
 
   const abandonTimer = async () => {
     const newState = await browser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
     setState(newState as TimerState);
+    window.close();
   };
 
   const acceptLongBreak = async () => {
     const newState = await browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
     setState(newState as TimerState);
+    window.close();
   };
 
   const skipLongBreak = async () => {
     const newState = await browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
     setState(newState as TimerState);
+    window.close();
   };
 
   let labelTimeout: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
## Summary
- Background onMessage handler now processes messages serially via a Promise queue, preventing race conditions
- Popup awaits sendMessage() completion before calling window.close(), ensuring actions are delivered

## Verification
- [ ] Type check passes
- [ ] Messages processed in order under concurrent load
- [ ] Timer actions reliably received before popup closes

Closes #1
Closes #2