### PR TITLE
fix(a11y): ARIA labels for timer ring, controls, and task input

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -17,6 +17,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
+            aria-label="Start focus session"
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
           >
             Start
@@ -26,6 +27,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
+            aria-label="Abandon current session"
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Abandon
@@ -35,6 +37,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
+            aria-label="Skip break and return to idle"
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Skip Break
@@ -44,6 +47,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAcceptLongBreak}
+            aria-label="Start long break"
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
           >
             Long Break
@@ -51,6 +55,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onSkipLongBreak}
+            aria-label="Skip long break"
             class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Skip

--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -5,13 +5,22 @@ type TaskLabelProps = {
 
 export default function TaskLabel(props: TaskLabelProps) {
   return (
-    <input
-      type="text"
-      value={props.value}
-      onInput={(e) => props.onChange(e.currentTarget.value)}
-      placeholder="What are you working on?"
-      maxLength={50}
-      class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
-    />
+    <div class="w-full mt-4">
+      <label
+        for="task-label-input"
+        style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0"
+      >
+        What are you working on?
+      </label>
+      <input
+        id="task-label-input"
+        type="text"
+        value={props.value}
+        onInput={(e) => props.onChange(e.currentTarget.value)}
+        placeholder="What are you working on?"
+        maxLength={50}
+        class="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
+      />
+    </div>
   );
 }

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -1,8 +1,10 @@
+import { createMemo } from 'solid-js';
 import type { TimerPhase } from '@/lib/types';
 
 type TimerRingProps = {
   progress: number;
   phase: TimerPhase;
+  remainingMs: number;
 };
 
 const PHASE_COLORS: Record<TimerPhase, string> = {
@@ -11,6 +13,14 @@ const PHASE_COLORS: Record<TimerPhase, string> = {
   SHORT_BREAK: '#16A34A',
   LONG_BREAK: '#16A34A',
   BREAK_SUGGESTION: '#CA8A04',
+};
+
+const PHASE_LABELS: Record<TimerPhase, string> = {
+  IDLE: 'Idle',
+  WORKING: 'Focus',
+  SHORT_BREAK: 'Short break',
+  LONG_BREAK: 'Long break',
+  BREAK_SUGGESTION: 'Break suggestion',
 };
 
 const SIZE = 160;
@@ -22,30 +32,64 @@ export default function TimerRing(props: TimerRingProps) {
   const offset = () => CIRCUMFERENCE * (1 - props.progress);
   const color = () => PHASE_COLORS[props.phase];
 
+  const minutesRemaining = createMemo(() => Math.ceil(props.remainingMs / 60000));
+
+  const ariaLabel = createMemo(() => {
+    const phase = PHASE_LABELS[props.phase];
+    const mins = minutesRemaining();
+    if (props.phase === 'IDLE') return 'Timer idle';
+    return `${phase} timer: ${mins} ${mins === 1 ? 'minute' : 'minutes'} remaining`;
+  });
+
+  // Live region text updates every full minute to avoid too-frequent announcements.
+  const liveText = createMemo(() => {
+    const phase = PHASE_LABELS[props.phase];
+    const mins = minutesRemaining();
+    if (props.phase === 'IDLE') return '';
+    return `${phase}: ${mins} ${mins === 1 ? 'minute' : 'minutes'} remaining`;
+  });
+
   return (
-    <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      <title>Timer progress</title>
-      <circle
-        cx={SIZE / 2}
-        cy={SIZE / 2}
-        r={RADIUS}
-        fill="none"
-        stroke="#E5E7EB"
-        stroke-width={STROKE}
-      />
-      <circle
-        cx={SIZE / 2}
-        cy={SIZE / 2}
-        r={RADIUS}
-        fill="none"
-        stroke={color()}
-        stroke-width={STROKE}
-        stroke-linecap="round"
-        stroke-dasharray={String(CIRCUMFERENCE)}
-        stroke-dashoffset={offset()}
-        transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
-        class="transition-[stroke-dashoffset] duration-500 ease-linear"
-      />
-    </svg>
+    <>
+      {/* Visually-hidden live region — announced on phase change or each minute */}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0"
+      >
+        {liveText()}
+      </div>
+      <svg
+        width={SIZE}
+        height={SIZE}
+        class="timer-ring"
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        role="img"
+        aria-label={ariaLabel()}
+      >
+        <title>{ariaLabel()}</title>
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          stroke="#E5E7EB"
+          stroke-width={STROKE}
+        />
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          stroke={color()}
+          stroke-width={STROKE}
+          stroke-linecap="round"
+          stroke-dasharray={String(CIRCUMFERENCE)}
+          stroke-dashoffset={offset()}
+          transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+          class="transition-[stroke-dashoffset] duration-500 ease-linear"
+        />
+      </svg>
+    </>
   );
 }

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -115,7 +115,7 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
+      <TimerRing progress={progress()} phase={state().phase} remainingMs={remaining()} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
       <div class="text-sm text-gray-500 mt-1">


### PR DESCRIPTION
## Summary
- TimerRing SVG gets role="img" and aria-label with phase + remaining time, plus a live region for announcements
- All Controls buttons get contextual aria-labels matching their action
- TaskLabel input gets an associated visible or sr-only label

## Verification
- [ ] Type check passes
- [ ] Screen reader announces timer phase and time
- [ ] All buttons have descriptive labels

Closes #4
Closes #53
Closes #54