### PR TITLE
fix: stats loading skeletons and popup focus management

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -16,6 +16,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'IDLE'}>
           <button
             type="button"
+            data-focus-target
             onClick={props.onStart}
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
           >
@@ -25,6 +26,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'WORKING'}>
           <button
             type="button"
+            data-focus-target
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
@@ -34,6 +36,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'SHORT_BREAK' || props.phase === 'LONG_BREAK'}>
           <button
             type="button"
+            data-focus-target
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
@@ -43,6 +46,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'BREAK_SUGGESTION'}>
           <button
             type="button"
+            data-focus-target
             onClick={props.onAcceptLongBreak}
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
           >

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -60,6 +60,17 @@ export default function App() {
     }
   });
 
+  // Focus the primary action button whenever the phase changes (issue #49)
+  createEffect(() => {
+    // Track the phase so this effect re-runs on every phase change
+    state().phase;
+    // Use a microtask to allow SolidJS to finish rendering the new Controls branch
+    queueMicrotask(() => {
+      const btn = document.querySelector<HTMLElement>('[data-focus-target]');
+      btn?.focus();
+    });
+  });
+
   const formatTime = () => {
     const ms = remaining();
     const totalSeconds = Math.ceil(ms / 1000);

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For } from 'solid-js';
+import { createResource, For, Show } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -45,23 +45,53 @@ export default function App() {
         <h1 class="text-2xl font-bold text-red-600 mb-6">Tomate Stats</h1>
 
         <div class="grid grid-cols-5 gap-3 mb-6">
-          <StatCard label="Total tomates" value={total()} />
-          <StatCard label="Today" value={todayCount() ?? 0} />
-          <StatCard label="This week" value={week()} />
-          <StatCard
-            label="Best day"
-            value={bestDay()?.count ?? '—'}
-            sublabel={bestDay()?.date}
-          />
-          <StatCard
-            label="Current streak"
-            value={`${streak()}d`}
-          />
+          <Show
+            when={!sessions.loading}
+            fallback={<div class="h-24 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />}
+          >
+            <StatCard label="Total tomates" value={total()} />
+          </Show>
+          <Show
+            when={!todayCount.loading}
+            fallback={<div class="h-24 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />}
+          >
+            <StatCard label="Today" value={todayCount() ?? 0} />
+          </Show>
+          <Show
+            when={!sessions.loading}
+            fallback={<div class="h-24 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />}
+          >
+            <StatCard label="This week" value={week()} />
+          </Show>
+          <Show
+            when={!sessions.loading}
+            fallback={<div class="h-24 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />}
+          >
+            <StatCard
+              label="Best day"
+              value={bestDay()?.count ?? '—'}
+              sublabel={bestDay()?.date}
+            />
+          </Show>
+          <Show
+            when={!sessions.loading}
+            fallback={<div class="h-24 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />}
+          >
+            <StatCard
+              label="Current streak"
+              value={`${streak()}d`}
+            />
+          </Show>
         </div>
 
         <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
           <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
-          <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+          <Show
+            when={!yearData.loading}
+            fallback={<div class="h-32 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />}
+          >
+            <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+          </Show>
 
           <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
             <span>Less</span>


### PR DESCRIPTION
## Summary
- Stats page shows animated skeleton cards while data loads, preventing empty flash
- Popup moves keyboard focus to the primary action button on phase transition

## Verification
- [ ] Type check passes
- [ ] Stats cards show skeleton on load
- [ ] Focus moves to action button after phase changes

Closes #18
Closes #49