### PR TITLE
fix: clear badge-refresh alarm before recreating

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -85,6 +85,7 @@ export default defineBackground(() => {
   };
 
   const startBadgeRefresh = async (): Promise<void> => {
+    await browser.alarms.clear(ALARM_BADGE_REFRESH);
     await browser.alarms.create(ALARM_BADGE_REFRESH, { periodInMinutes: 1 });
   };
 


### PR DESCRIPTION
## Summary
- startBadgeRefresh() now clears the existing alarm before creating a new one
- Prevents duplicate periodic alarms accumulating from multiple START_TIMER calls

## Verification
- [ ] Type check passes
- [ ] Only one badge-refresh alarm exists at any time

Closes #99