### PR TITLE
fix: stats empty state and minimum heatmap column count

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -74,6 +74,8 @@ export default function Heatmap(props: HeatmapProps) {
 
   const toMonRow = (jsDay: number) => (jsDay === 0 ? 6 : jsDay - 1);
 
+  const MIN_WEEKS = 12;
+
   const columns = createMemo(() => {
     const cells = grid();
     const cols: (HeatmapCell | null)[][] = [];
@@ -95,6 +97,11 @@ export default function Heatmap(props: HeatmapProps) {
 
     if (currentCol.some((c) => c !== null)) {
       cols.push(currentCol);
+    }
+
+    // Pad with empty columns at the start to ensure at least MIN_WEEKS columns
+    while (cols.length < MIN_WEEKS) {
+      cols.unshift(Array(7).fill(null));
     }
 
     return cols;

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For } from 'solid-js';
+import { createResource, For, Show } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -39,44 +39,59 @@ export default function App() {
   const bestDay = () => computeBestDay(sessions() ?? []);
   const streak = () => computeStreak(sessions() ?? []);
 
+  const totalSessions = () => total();
+
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <h1 class="text-2xl font-bold text-red-600 mb-6">Tomate Stats</h1>
 
-        <div class="grid grid-cols-5 gap-3 mb-6">
-          <StatCard label="Total tomates" value={total()} />
-          <StatCard label="Today" value={todayCount() ?? 0} />
-          <StatCard label="This week" value={week()} />
-          <StatCard
-            label="Best day"
-            value={bestDay()?.count ?? '—'}
-            sublabel={bestDay()?.date}
-          />
-          <StatCard
-            label="Current streak"
-            value={`${streak()}d`}
-          />
-        </div>
-
-        <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-          <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
-          <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
-
-          <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
-            <span>Less</span>
-            <For each={INTENSITY_LEGEND}>
-              {(item) => (
-                <div
-                  class="w-3 h-3 rounded-sm"
-                  style={{ "background-color": item.color }}
-                  title={item.label}
+        <Show
+          when={totalSessions() === 0 && !sessions.loading}
+          fallback={
+            <>
+              <div class="grid grid-cols-5 gap-3 mb-6">
+                <StatCard label="Total tomates" value={total()} />
+                <StatCard label="Today" value={todayCount() ?? 0} />
+                <StatCard label="This week" value={week()} />
+                <StatCard
+                  label="Best day"
+                  value={bestDay()?.count ?? '—'}
+                  sublabel={bestDay()?.date}
                 />
-              )}
-            </For>
-            <span>More</span>
+                <StatCard
+                  label="Current streak"
+                  value={`${streak()}d`}
+                />
+              </div>
+
+              <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
+                <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
+                <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+
+                <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
+                  <span>Less</span>
+                  <For each={INTENSITY_LEGEND}>
+                    {(item) => (
+                      <div
+                        class="w-3 h-3 rounded-sm"
+                        style={{ "background-color": item.color }}
+                        title={item.label}
+                      />
+                    )}
+                  </For>
+                  <span>More</span>
+                </div>
+              </div>
+            </>
+          }
+        >
+          <div class="flex flex-col items-center justify-center py-12 text-center text-gray-500">
+            <div class="text-4xl mb-4">🍅</div>
+            <p class="text-lg font-medium">No sessions yet</p>
+            <p class="text-sm mt-2">Start a timer in the popup to track your first tomate!</p>
           </div>
-        </div>
+        </Show>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Stats page shows friendly onboarding message when user has 0 sessions
- Heatmap always renders at least 12 weeks of columns for consistent layout

## Verification
- [ ] Type check passes
- [ ] Empty state shown for new users
- [ ] Heatmap looks correct with 1-3 days of data

Closes #104
Closes #105