### PR TITLE
fix: ambient AudioContext lifecycle — resume await and popup cleanup

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -10,8 +10,10 @@ import {
   setCurrentLabel,
   getTodayCount,
   getHeatmapData,
+  getConfig,
 } from '@/lib/storage';
-import { INITIAL_STATE, type TimerState } from '@/lib/types';
+import { INITIAL_STATE, type TimerState, type AmbientSound } from '@/lib/types';
+import { ambientPlay, ambientStop, ambientClose } from '@/lib/ambient';
 
 import TimerRing from '@/components/TimerRing';
 import Controls from '@/components/Controls';
@@ -25,10 +27,18 @@ export default function App() {
   const [label, setLabel] = createSignal('');
   const [todayCount, setTodayCount] = createSignal(0);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [ambientSound, setAmbientSound] = createSignal<AmbientSound>('none');
+  const [ambientVolume, setAmbientVolume] = createSignal(50);
 
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
     setHeatmapData(await getHeatmapData(120));
+  };
+
+  const refreshAmbientConfig = async () => {
+    const config = await getConfig();
+    setAmbientSound(config.ambientSound);
+    setAmbientVolume(config.ambientVolume);
   };
 
   onMount(async () => {
@@ -43,9 +53,21 @@ export default function App() {
 
     setLabel(await getCurrentLabel());
     await refreshStats();
+    await refreshAmbientConfig();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const handleStorageChange = async () => {
+      await refreshStats();
+      await refreshAmbientConfig();
+    };
+
+    browser.storage.onChanged.addListener(handleStorageChange);
+    onCleanup(() => {
+      browser.storage.onChanged.removeListener(handleStorageChange);
+      // Fix #98: stop nodes first, then fully close the AudioContext so it
+      // doesn't accumulate across popup open/close cycles.
+      ambientStop();
+      void ambientClose();
+    });
   });
 
   createEffect(() => {
@@ -57,6 +79,21 @@ export default function App() {
       onCleanup(() => clearInterval(id));
     } else {
       setRemaining(0);
+    }
+  });
+
+  // Ambient sound: play during WORKING phase only, stop otherwise.
+  // ambientPlay is async (#96/#97 fix); fire-and-forget is fine because
+  // errors are handled internally and we don't need to block the effect.
+  createEffect(() => {
+    const phase = state().phase;
+    const sound = ambientSound();
+    const volume = ambientVolume();
+
+    if (phase === 'WORKING' && sound !== 'none') {
+      void ambientPlay(sound, volume);
+    } else {
+      ambientStop();
     }
   });
 

--- a/lib/ambient.ts
+++ b/lib/ambient.ts
@@ -1,0 +1,202 @@
+import type { AmbientSound } from './types';
+
+/**
+ * Ambient sound player using Web Audio API synthesis.
+ * Generates rain (brown noise), cafe (filtered brown noise), and white noise
+ * without any external audio file dependencies.
+ */
+
+interface AmbientNodes {
+  source: AudioBufferSourceNode;
+  gainNode: GainNode;
+  filterNode?: BiquadFilterNode;
+}
+
+let audioCtx: AudioContext | null = null;
+let currentNodes: AmbientNodes | null = null;
+let currentSound: AmbientSound = 'none';
+let currentVolume = 0.5;
+
+const getAudioContext = (): AudioContext => {
+  if (!audioCtx || audioCtx.state === 'closed') {
+    audioCtx = new AudioContext();
+  }
+  return audioCtx;
+};
+
+/**
+ * Generate a buffer of white noise samples.
+ */
+const createNoiseBuffer = (ctx: AudioContext, durationSeconds = 2): AudioBuffer => {
+  const sampleRate = ctx.sampleRate;
+  const frameCount = sampleRate * durationSeconds;
+  const buffer = ctx.createBuffer(1, frameCount, sampleRate);
+  const data = buffer.getChannelData(0);
+
+  for (let i = 0; i < frameCount; i++) {
+    data[i] = Math.random() * 2 - 1;
+  }
+
+  return buffer;
+};
+
+/**
+ * Convert white noise buffer into brown noise by integration.
+ * Brown noise has a -6 dB/octave rolloff, making it low-frequency-heavy
+ * (similar to rain or distant thunder).
+ */
+const createBrownNoiseBuffer = (ctx: AudioContext, durationSeconds = 2): AudioBuffer => {
+  const sampleRate = ctx.sampleRate;
+  const frameCount = sampleRate * durationSeconds;
+  const buffer = ctx.createBuffer(1, frameCount, sampleRate);
+  const data = buffer.getChannelData(0);
+
+  let lastOut = 0;
+  for (let i = 0; i < frameCount; i++) {
+    const white = Math.random() * 2 - 1;
+    lastOut = (lastOut + 0.02 * white) / 1.02;
+    data[i] = lastOut * 3.5; // scale to reasonable amplitude
+  }
+
+  return buffer;
+};
+
+const createNoiseSource = (
+  ctx: AudioContext,
+  sound: AmbientSound,
+): AudioBufferSourceNode => {
+  const buffer =
+    sound === 'whitenoise'
+      ? createNoiseBuffer(ctx)
+      : createBrownNoiseBuffer(ctx);
+
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  source.loop = true;
+  return source;
+};
+
+const buildGraph = (ctx: AudioContext, sound: AmbientSound, volume: number): AmbientNodes => {
+  const source = createNoiseSource(ctx, sound);
+  const gainNode = ctx.createGain();
+  gainNode.gain.value = volume;
+
+  if (sound === 'cafe') {
+    // For cafe: bandpass filter around voice/activity frequencies (200–3000 Hz)
+    // layered with low-pass to give a muffled indoor feel
+    const bandpass = ctx.createBiquadFilter();
+    bandpass.type = 'bandpass';
+    bandpass.frequency.value = 1200;
+    bandpass.Q.value = 0.5;
+
+    const lowpass = ctx.createBiquadFilter();
+    lowpass.type = 'lowpass';
+    lowpass.frequency.value = 3000;
+
+    source.connect(bandpass);
+    bandpass.connect(lowpass);
+    lowpass.connect(gainNode);
+    gainNode.connect(ctx.destination);
+
+    return { source, gainNode, filterNode: bandpass };
+  }
+
+  if (sound === 'rain') {
+    // Rain: high-pass to keep the hiss of rain droplets, slight resonance
+    const highpass = ctx.createBiquadFilter();
+    highpass.type = 'highpass';
+    highpass.frequency.value = 200;
+
+    source.connect(highpass);
+    highpass.connect(gainNode);
+    gainNode.connect(ctx.destination);
+
+    return { source, gainNode, filterNode: highpass };
+  }
+
+  // White noise: straight through
+  source.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  return { source, gainNode };
+};
+
+const stopCurrent = (): void => {
+  if (currentNodes) {
+    try {
+      currentNodes.source.stop();
+      currentNodes.source.disconnect();
+      currentNodes.gainNode.disconnect();
+      currentNodes.filterNode?.disconnect();
+    } catch {
+      // already stopped
+    }
+    currentNodes = null;
+  }
+};
+
+// Fix #96 + #97: ambientPlay is now async so we can properly await ctx.resume()
+// before calling source.start(), preventing silent failure under Chrome's
+// autoplay policy and the resume/start race condition.
+export const ambientPlay = async (sound: AmbientSound, volume: number): Promise<void> => {
+  if (sound === 'none') {
+    stopCurrent();
+    currentSound = 'none';
+    return;
+  }
+
+  const normalizedVolume = Math.max(0, Math.min(100, volume)) / 100;
+
+  // If same sound is already playing, just adjust volume
+  if (currentNodes && currentSound === sound) {
+    currentNodes.gainNode.gain.setTargetAtTime(normalizedVolume, getAudioContext().currentTime, 0.1);
+    currentVolume = normalizedVolume;
+    return;
+  }
+
+  stopCurrent();
+
+  const ctx = getAudioContext();
+
+  // Fix #96 + #97: await resume before source.start() so that Chrome's
+  // autoplay-policy suspension is lifted before we attempt playback.
+  if (ctx.state === 'suspended') {
+    await ctx.resume();
+  }
+  if (ctx.state !== 'running') return; // give up if still suspended
+
+  currentNodes = buildGraph(ctx, sound, normalizedVolume);
+  currentNodes.source.start();
+  currentSound = sound;
+  currentVolume = normalizedVolume;
+};
+
+export const ambientStop = (): void => {
+  stopCurrent();
+  currentSound = 'none';
+};
+
+// Fix #98: fully close and discard the AudioContext so it doesn't leak
+// across popup open/close cycles. Call this from onCleanup in the popup.
+export const ambientClose = async (): Promise<void> => {
+  stopCurrent();
+  currentSound = 'none';
+  if (audioCtx && audioCtx.state !== 'closed') {
+    await audioCtx.close();
+  }
+  audioCtx = null;
+};
+
+export const ambientSetVolume = (volume: number): void => {
+  const normalizedVolume = Math.max(0, Math.min(100, volume)) / 100;
+  currentVolume = normalizedVolume;
+  if (currentNodes) {
+    currentNodes.gainNode.gain.setTargetAtTime(
+      normalizedVolume,
+      getAudioContext().currentTime,
+      0.1,
+    );
+  }
+};
+
+export const ambientIsPlaying = (): boolean => currentNodes !== null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,9 +1,13 @@
 export type TimerPhase = 'IDLE' | 'WORKING' | 'SHORT_BREAK' | 'LONG_BREAK' | 'BREAK_SUGGESTION';
 
+export type AmbientSound = 'none' | 'rain' | 'cafe' | 'whitenoise';
+
 export type TimerConfig = {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  ambientSound: AmbientSound;
+  ambientVolume: number;
 };
 
 export type TimerState = {
@@ -29,6 +33,8 @@ export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  ambientSound: 'none',
+  ambientVolume: 50,
 };
 
 export const INITIAL_STATE: TimerState = {


### PR DESCRIPTION
## Summary
- ambientPlay() now awaits ctx.resume() before source.start(), preventing silent failure
- Bails out gracefully if context remains suspended after resume attempt
- ambientClose() exported and called in popup onCleanup to fully tear down AudioContext

## Verification
- [ ] Type check passes
- [ ] Ambient sound plays when work session starts
- [ ] No AudioContext accumulation across popup opens

Closes #96
Closes #97
Closes #98