### PR TITLE
fix: cap blocked sites and handle rule update errors

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/timer';
 import {
   addCompletedSession,
+  getBlockedSites,
   getConfig,
   getCurrentLabel,
   getTimerState,
@@ -31,6 +32,48 @@ export type MessageAction =
   | { action: 'ACCEPT_LONG_BREAK' }
   | { action: 'SKIP_LONG_BREAK' }
   | { action: 'UPDATE_CONFIG'; config: TimerConfig };
+
+const MAX_BLOCKED_SITES = 100;
+
+type DnrRule = {
+  id: number;
+  priority: number;
+  action: { type: string };
+  condition: { urlFilter: string; resourceTypes: string[] };
+};
+
+declare const chrome: {
+  declarativeNetRequest: {
+    getDynamicRules(): Promise<DnrRule[]>;
+    updateDynamicRules(options: { removeRuleIds: number[]; addRules: DnrRule[] }): Promise<void>;
+  };
+};
+
+const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const sitesToBlock = sites.slice(0, MAX_BLOCKED_SITES);
+
+  const newRules: DnrRule[] = sitesToBlock.map((site, index) => ({
+    id: index + 1,
+    priority: 1,
+    action: { type: 'block' },
+    condition: {
+      urlFilter: site,
+      resourceTypes: ['main_frame'],
+    },
+  }));
+
+  const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+  const existingIds = existingRules.map((r) => r.id);
+
+  try {
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: existingIds,
+      addRules: newRules,
+    });
+  } catch (e) {
+    console.error('Failed to update blocking rules:', e);
+  }
+};
 
 export default defineBackground(() => {
   const ALARM_TIMER = 'tomate-timer';
@@ -207,10 +250,21 @@ export default defineBackground(() => {
 
   browser.runtime.onInstalled.addListener(async () => {
     await recoverFromMissedAlarm();
+    const sites = await getBlockedSites();
+    applyBlockingRules(sites).catch((e) => console.error('Failed to apply blocking rules on install:', e));
   });
 
   browser.runtime.onStartup.addListener(async () => {
     await recoverFromMissedAlarm();
+    const sites = await getBlockedSites();
+    applyBlockingRules(sites).catch((e) => console.error('Failed to apply blocking rules on startup:', e));
+  });
+
+  browser.storage.onChanged.addListener((changes: Record<string, { newValue?: unknown }>, area: string) => {
+    if (area === 'local' && 'blockedSites' in changes) {
+      const sites = (changes['blockedSites'].newValue as string[]) ?? [];
+      applyBlockingRules(sites).catch((e) => console.error('Failed to apply blocking rules on change:', e));
+    }
   });
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,22 +1,28 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, For, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
-import { getConfig, setConfig } from '@/lib/storage';
+import { getBlockedSites, getConfig, setBlockedSites, setConfig } from '@/lib/storage';
 import { DEFAULT_CONFIG, type TimerConfig } from '@/lib/types';
 
 const MS_PER_MINUTE = 60_000;
+const MAX_BLOCKED_SITES = 100;
 
 export default function App() {
   const [work, setWork] = createSignal(25);
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
   const [saved, setSaved] = createSignal(false);
+  const [blockedSites, setBlockedSitesSignal] = createSignal<string[]>([]);
+  const [newSite, setNewSite] = createSignal('');
+  const [siteError, setSiteError] = createSignal('');
 
   onMount(async () => {
     const config = await getConfig();
     setWork(Math.round(config.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(config.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
+    const sites = await getBlockedSites();
+    setBlockedSitesSignal(sites);
   });
 
   const handleSave = async () => {
@@ -35,6 +41,33 @@ export default function App() {
     setWork(Math.round(DEFAULT_CONFIG.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(DEFAULT_CONFIG.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
+  };
+
+  const handleAddSite = async () => {
+    setSiteError('');
+    const site = newSite().trim();
+    if (!site) return;
+
+    if (blockedSites().length >= MAX_BLOCKED_SITES) {
+      setSiteError('Maximum 100 sites can be blocked');
+      return;
+    }
+
+    if (blockedSites().includes(site)) {
+      setSiteError('Site is already blocked');
+      return;
+    }
+
+    const updated = [...blockedSites(), site];
+    setBlockedSitesSignal(updated);
+    setNewSite('');
+    await setBlockedSites(updated);
+  };
+
+  const handleRemoveSite = async (site: string) => {
+    const updated = blockedSites().filter((s) => s !== site);
+    setBlockedSitesSignal(updated);
+    await setBlockedSites(updated);
   };
 
   return (
@@ -78,6 +111,48 @@ export default function App() {
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
+        </div>
+
+        <div class="mt-6">
+          <h2 class="text-sm font-medium text-gray-700 mb-2">Blocked Sites During Work</h2>
+          <div class="flex gap-2 mb-2">
+            <input
+              type="text"
+              placeholder="e.g. twitter.com"
+              value={newSite()}
+              onInput={(e) => setNewSite(e.currentTarget.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') void handleAddSite(); }}
+              class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+            />
+            <button
+              type="button"
+              onClick={() => void handleAddSite()}
+              class="bg-red-600 text-white px-3 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            >
+              Add
+            </button>
+          </div>
+          <Show when={siteError()}>
+            <p class="text-sm text-red-600 mb-2">{siteError()}</p>
+          </Show>
+          <ul class="space-y-1">
+            <For each={blockedSites()}>
+              {(site) => (
+                <li class="flex items-center justify-between rounded-md bg-gray-50 px-3 py-1.5 text-sm">
+                  <span class="text-gray-700">{site}</span>
+                  <button
+                    type="button"
+                    onClick={() => void handleRemoveSite(site)}
+                    class="text-gray-400 hover:text-red-600 focus:outline-none"
+                    aria-label={`Remove ${site}`}
+                  >
+                    ×
+                  </button>
+                </li>
+              )}
+            </For>
+          </ul>
+          <p class="mt-1 text-xs text-gray-400">{blockedSites().length} / {MAX_BLOCKED_SITES} sites</p>
         </div>
 
         <div class="mt-6 flex items-center gap-4">

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -103,3 +103,10 @@ export const getCurrentLabel = async (): Promise<string> =>
 export const setCurrentLabel = async (label: string): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CURRENT_LABEL]: label.slice(0, MAX_LABEL_LENGTH) });
 };
+
+export const getBlockedSites = async (): Promise<string[]> =>
+  (await getStoredValue<string[]>('blockedSites')) ?? [];
+
+export const setBlockedSites = async (sites: string[]): Promise<void> => {
+  await browser.storage.local.set({ blockedSites: sites });
+};


### PR DESCRIPTION
## Summary
- Blocked sites capped at 100 with user-visible error message in options
- applyBlockingRules() now catches and logs declarativeNetRequest failures
- Safety slice ensures rule array never exceeds cap even if storage is inconsistent

## Verification
- [ ] Type check passes
- [ ] Options shows error when adding site #101
- [ ] Rule update errors are logged

Closes #102