### PR TITLE
fix: manifest CSP and web_accessible_resources for audio assets

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -14,5 +14,14 @@ export default defineConfig({
         '128': '/icons/icon-128.png',
       },
     },
+    web_accessible_resources: [
+      {
+        resources: ['sounds/*', '*.html'],
+        matches: ['<all_urls>'],
+      },
+    ],
+    content_security_policy: {
+      extension_pages: "script-src 'self'; object-src 'self'; media-src 'self' blob:;",
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Adds web_accessible_resources covering sounds/* so runtime.getURL() works in MV3
- Adds explicit CSP permitting self-hosted scripts and blob: media sources
- Policy is kept minimal — no unsafe-eval or unsafe-inline

## Verification
- [ ] Type check passes
- [ ] Extension builds without manifest errors
- [ ] Audio plays in loaded extension

Closes #109
Closes #110