### PR TITLE
fix: stats page refreshes in real time via storage change listener

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,5 @@
-import { createResource, For } from 'solid-js';
+import { createResource, onMount, onCleanup, For } from 'solid-js';
+import { browser } from 'wxt/browser';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -30,9 +31,21 @@ function StatCard(props: StatCardProps) {
 }
 
 export default function App() {
-  const [yearData] = createResource(() => getHeatmapData(365));
-  const [sessions] = createResource(() => getSessionHistory());
-  const [todayCount] = createResource(() => getTodayCount());
+  const [yearData, { refetch: refetchYearData }] = createResource(() => getHeatmapData(365));
+  const [sessions, { refetch: refetchSessions }] = createResource(() => getSessionHistory());
+  const [todayCount, { refetch: refetchTodayCount }] = createResource(() => getTodayCount());
+
+  onMount(() => {
+    const handler = (changes: Record<string, browser.storage.StorageChange>) => {
+      if ('sessions' in changes || 'todayCount' in changes) {
+        refetchSessions();
+        refetchTodayCount();
+        refetchYearData();
+      }
+    };
+    browser.storage.onChanged.addListener(handler);
+    onCleanup(() => browser.storage.onChanged.removeListener(handler));
+  });
 
   const total = () => computeTotalCount(sessions() ?? []);
   const week = () => computeWeekCount(sessions() ?? []);


### PR DESCRIPTION
## Summary

- Adds a `browser.storage.onChanged` listener inside `onMount` in `entrypoints/stats/App.tsx`
- When the `sessions` or `todayCount` storage keys change, all three resources (`sessions`, `todayCount`, `yearData`) are refetched immediately
- Registers cleanup via `onCleanup` so the listener is removed when the component unmounts
- Follows the exact same pattern already used in `entrypoints/popup/App.tsx`

## Test plan

- [ ] Complete a Pomodoro session while the stats page is open — stat cards and heatmap should update without a manual page reload
- [ ] Verify no console errors on stats page mount/unmount

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)