### PR TITLE
fix: attribute sessions to completion date not start date

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -106,7 +106,7 @@ export default defineBackground(() => {
       label,
       startTime: state.startTime,
       endTime,
-      date: toDateKey(state.startTime),
+      date: toDateKey(endTime),
       duration: state.duration,
     };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,6 +21,7 @@ export type CompletedSession = {
   label: string;
   startTime: number;
   endTime: number;
+  /** Local calendar date (YYYY-MM-DD) of session completion, derived from endTime. */
   date: string;
   duration: number;
 };


### PR DESCRIPTION
## Summary

- **Bug**: Sessions started before midnight but completed after were attributed to the wrong day because `CompletedSession.date` was derived from `state.startTime` instead of the actual completion time.
- **Fix**: Changed `persistCompletedSession` in `entrypoints/background.ts` to use `toDateKey(endTime)` (the moment the timer alarm fires / the session completes) instead of `toDateKey(state.startTime)`.
- **Clarity**: Added a JSDoc comment to `CompletedSession.date` in `lib/types.ts` documenting that the field represents the local calendar date of session *completion*.

## Test plan

- [ ] Start a Pomodoro session just before midnight (e.g. 11:45 PM) and let it complete after midnight — verify the session appears under the new day's date, not the previous day.
- [ ] Start and complete a session within the same day — verify the date is unchanged.
- [ ] Check heatmap and stats views reflect the corrected date attribution.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)