### PR TITLE
feat: add GitHub Actions CI pipeline for tests and type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install
+      - name: Type check
+        run: bun run typecheck || npx tsc --noEmit
+      - name: Run tests
+        run: bun run test


### PR DESCRIPTION
## Summary

- Creates `.github/workflows/ci.yml` to run tests automatically on every push to `main` and on all pull requests targeting `main`
- Uses `oven-sh/setup-bun@v1` to match the project's Bun toolchain
- Runs `bun install`, a type check step (`bun run typecheck || npx tsc --noEmit`), and `bun run test` (which maps to `vitest run --passWithNoTests`)

## Test plan

- [ ] Verify the Actions workflow appears under the repository's Actions tab after merge
- [ ] Open a test PR and confirm the `CI / test` check runs and passes
- [ ] Confirm a failing test causes the check to fail (blocks merge)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)