### PR TITLE
fix: use startTime-based session ID to prevent duplicate persistence

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -102,7 +102,7 @@ export default defineBackground(() => {
 
     const label = await getCurrentLabel();
     const session: CompletedSession = {
-      id: crypto.randomUUID(),
+      id: `session-${state.startTime}`,
       label,
       startTime: state.startTime,
       endTime,

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -54,6 +54,8 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
 
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
+  const existing = sessions.find(s => s.id === session.id);
+  if (existing) return; // already persisted, skip
   await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
 };
 


### PR DESCRIPTION
## Summary

- Replaces `crypto.randomUUID()` with `\`session-${state.startTime}\`` for session IDs in `persistCompletedSession`, making IDs deterministic and tied to the work session's start time
- Adds an idempotency guard in `addCompletedSession()` (`lib/storage.ts`) that checks for an existing session with the same ID before appending, skipping the write if a duplicate is found
- Together these changes ensure that concurrent calls to `persistCompletedSession` (e.g., alarm firing while a `START_TIMER` message is in flight) will only ever produce one persisted record per session

## Test plan

- [ ] Start a work session and let the alarm fire naturally — verify exactly one session is recorded
- [ ] Simulate duplicate calls to `persistCompletedSession` with the same `startTime` — verify only one session is stored
- [ ] Verify existing sessions continue to be stored and retrieved correctly after the ID format change

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)