### PR TITLE
fix: add storage schema version and migration for new config fields

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -19,14 +19,23 @@ const KEYS = {
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
 
+const STORAGE_VERSION = 2;
+
+type StoredConfig = TimerConfig & { _version?: number };
+
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 };
 
-const getStoredValue = async <T>(key: string): Promise<T | undefined> => {
+const getStoredValue = async <T>(key: string, defaultValue: T | null = null): Promise<T | null> => {
   const result = await browser.storage.local.get(key);
-  return result[key] as T | undefined;
+  const value = result[key] as T | undefined;
+  return value !== undefined ? value : defaultValue;
+};
+
+const setStoredValue = async <T>(key: string, value: T): Promise<void> => {
+  await browser.storage.local.set({ [key]: value });
 };
 
 export const toDateKey = (timestamp: number): string => {
@@ -45,8 +54,17 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<StoredConfig>(KEYS.CONFIG, null);
+  const version = stored?._version ?? 1;
+  const { _version: _v, ...storedFields } = stored ?? {};
+  const config: TimerConfig = { ...DEFAULT_CONFIG, ...storedFields };
+  if (version < STORAGE_VERSION) {
+    // v1→v2: ensure all new fields have defaults
+    await setStoredValue(KEYS.CONFIG, { ...config, _version: STORAGE_VERSION });
+  }
+  return config;
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });


### PR DESCRIPTION
## Summary

- Adds `STORAGE_VERSION = 2` constant to `lib/storage.ts`
- Rewrites `getConfig()` to read stored config with version metadata, merge with `DEFAULT_CONFIG`, and migrate v1 installs on first read after upgrade
- Adds internal `setStoredValue` helper to complement `getStoredValue`
- Strips internal `_version` field before returning `TimerConfig` so callers receive a clean object

## Test plan

- [ ] On a fresh install: `getConfig()` returns `DEFAULT_CONFIG` and writes version 2 to storage
- [ ] On an existing v1 install (no `_version` field): `getConfig()` merges stored values with `DEFAULT_CONFIG` (filling in any new fields with defaults) and writes version 2
- [ ] On a v2 install: `getConfig()` returns stored config without triggering a migration write
- [ ] `setConfig` / `getConfig` round-trip returns a clean `TimerConfig` with no `_version` field
- [ ] Run `bun test` — existing storage tests continue to pass

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)