### PR TITLE
fix: check notification permission before creating notifications

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -231,21 +231,27 @@ export default defineBackground(() => {
 
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: '🍅 Tomate Complete!',
-        message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-      });
+      const hasNotificationPermission = await browser.permissions.contains({ permissions: ['notifications'] });
+      if (hasNotificationPermission) {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: '🍅 Tomate Complete!',
+          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+        });
+      }
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-        message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-      });
+      const hasNotificationPermission = await browser.permissions.contains({ permissions: ['notifications'] });
+      if (hasNotificationPermission) {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+        });
+      }
     }
 
     if (isActivePhase(completed.phase) && completed.endTime !== null) {


### PR DESCRIPTION
## Summary
- Added `browser.permissions.contains()` guard before all `browser.notifications.create()` calls
- Silent failure is replaced with a graceful skip when notifications are denied

## Verification
- [ ] TypeScript type check passes
- [ ] No notifications thrown when permission denied

Closes #137