### PR TITLE
fix: read reactive state inside RAF tick to prevent stale closure

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -51,7 +51,10 @@ export default function App() {
   createEffect(() => {
     const s = state();
     if (isActivePhase(s.phase) && s.endTime) {
-      const tick = () => setRemaining(Math.max(0, s.endTime! - Date.now()));
+      const tick = () => {
+        const current = state();
+        setRemaining(Math.max(0, (current.endTime ?? 0) - Date.now()));
+      };
       tick();
       const id = setInterval(tick, 1000);
       onCleanup(() => clearInterval(id));


### PR DESCRIPTION
## Summary
- Fixed stale closure in RAF animation loop in popup App.tsx
- The tick() function now reads fresh reactive state() on each frame instead of capturing it at effect start
- Prevents visual artifacts when timer state changes mid-countdown

## Verification
- [ ] TypeScript type check passes
- [ ] Timer countdown reflects state changes immediately

Closes #11