### PR TITLE
fix: handle QuotaExceededError in addCompletedSession

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -12,6 +12,7 @@ import {
   startTimer,
 } from '@/lib/timer';
 import {
+  StorageQuotaError,
   addCompletedSession,
   getConfig,
   getCurrentLabel,
@@ -92,6 +93,18 @@ export default defineBackground(() => {
     await Promise.all([browser.alarms.clear(ALARM_TIMER), browser.alarms.clear(ALARM_BADGE_REFRESH)]);
   };
 
+  const showStorageFullFeedback = async (): Promise<void> => {
+    await badgeApi.setBadgeText({ text: '!' });
+    await badgeApi.setBadgeBackgroundColor({ color: '#B91C1C' });
+    await browser.notifications.create({
+      type: 'basic',
+      iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+      title: 'Storage Full — Session Not Saved',
+      message:
+        'Your tomate session could not be saved because storage is full. Clear some history in settings to free up space.',
+    });
+  };
+
   const persistCompletedSession = async (
     state: Awaited<ReturnType<typeof getTimerState>>,
     endTime: number,
@@ -110,8 +123,16 @@ export default defineBackground(() => {
       duration: state.duration,
     };
 
-    await addCompletedSession(session);
-    await setPendingCelebration(true);
+    try {
+      await addCompletedSession(session);
+      await setPendingCelebration(true);
+    } catch (error) {
+      if (error instanceof StorageQuotaError) {
+        await showStorageFullFeedback();
+      } else {
+        throw error;
+      }
+    }
   };
 
   const recoverFromMissedAlarm = async (): Promise<void> => {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -52,9 +52,51 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
 };
 
+const isQuotaError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes('QUOTA_BYTES') ||
+    error.message.includes('QuotaExceededError') ||
+    error.message.includes('quota') ||
+    (error as { name?: string }).name === 'QuotaExceededError'
+  );
+};
+
+const pruneOldestSessions = (sessions: CompletedSession[]): CompletedSession[] => {
+  const pruneCount = Math.max(1, Math.ceil(sessions.length * 0.1));
+  return sessions.slice(pruneCount);
+};
+
+export class StorageQuotaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StorageQuotaError';
+  }
+}
+
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  } catch (error) {
+    if (!isQuotaError(error)) {
+      throw error;
+    }
+
+    // Storage is full — prune oldest 10% of sessions and retry once
+    const pruned = pruneOldestSessions(sessions);
+    try {
+      await browser.storage.local.set({ [KEYS.SESSIONS]: [...pruned, session] });
+    } catch (retryError) {
+      if (isQuotaError(retryError)) {
+        throw new StorageQuotaError(
+          'Storage is full. Session could not be saved even after pruning old sessions.',
+        );
+      }
+      throw retryError;
+    }
+  }
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
## Summary
- Added try/catch in `addCompletedSession()` for `QuotaExceededError`
- On quota exceeded: auto-prunes oldest sessions (10%) and retries write
- On retry failure: surfaces error to caller with badge indicator "Storage full"

## Verification
- [ ] TypeScript type check passes

Closes #138