### PR TITLE
fix: remove incorrect type cast on stats.html URL

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -146,7 +146,7 @@ export default function App() {
 
       <button
         type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
       >
         View all stats →


### PR DESCRIPTION
## Summary
- Removed the incorrect `as '/popup.html'` type cast on the stats.html URL
- The URL is correctly '/stats.html' and should not be cast to a different path type

Closes #164