### PR TITLE
fix: add dark mode variants to Controls, TimerRing, and Heatmap

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -17,7 +17,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
-            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
+            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 dark:bg-red-700 dark:hover:bg-red-800 transition-colors"
           >
             Start
           </button>
@@ -26,7 +26,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
           >
             Abandon
           </button>
@@ -35,7 +35,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
           >
             Skip Break
           </button>
@@ -51,7 +51,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onSkipLongBreak}
-            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
           >
             Skip
           </button>

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -12,13 +12,24 @@ type HeatmapCell = {
   dayOfWeek: number;
 };
 
-const INTENSITY_COLORS = [
-  '#F3F4F6',
-  '#FCA5A5',
-  '#EF4444',
-  '#DC2626',
-  '#991B1B',
+const INTENSITY_COLORS_LIGHT = [
+  '#F3F4F6', // 0 — gray-100
+  '#FCA5A5', // 1 — red-300
+  '#EF4444', // 2-3 — red-500
+  '#DC2626', // 4-5 — red-600
+  '#991B1B', // 6+ — red-800
 ] as const;
+
+const INTENSITY_COLORS_DARK = [
+  '#374151', // 0 — gray-700
+  '#7F1D1D', // 1 — red-900
+  '#B91C1C', // 2-3 — red-700
+  '#DC2626', // 4-5 — red-600
+  '#EF4444', // 6+ — red-500
+] as const;
+
+const isDark = () =>
+  typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
 
 const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', ''] as const;
 
@@ -28,11 +39,12 @@ const MONTH_NAMES = [
 ] as const;
 
 const getIntensityColor = (count: number): string => {
-  if (count === 0) return INTENSITY_COLORS[0];
-  if (count === 1) return INTENSITY_COLORS[1];
-  if (count <= 3) return INTENSITY_COLORS[2];
-  if (count <= 5) return INTENSITY_COLORS[3];
-  return INTENSITY_COLORS[4];
+  const colors = isDark() ? INTENSITY_COLORS_DARK : INTENSITY_COLORS_LIGHT;
+  if (count === 0) return colors[0];
+  if (count === 1) return colors[1];
+  if (count <= 3) return colors[2];
+  if (count <= 5) return colors[3];
+  return colors[4];
 };
 
 const toDateKey = (date: Date): string => {

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -5,7 +5,8 @@ type TimerRingProps = {
   phase: TimerPhase;
 };
 
-const PHASE_COLORS: Record<TimerPhase, string> = {
+// Light-mode colors
+const PHASE_COLORS_LIGHT: Record<TimerPhase, string> = {
   IDLE: '#9CA3AF',
   WORKING: '#DC2626',
   SHORT_BREAK: '#16A34A',
@@ -13,14 +14,28 @@ const PHASE_COLORS: Record<TimerPhase, string> = {
   BREAK_SUGGESTION: '#CA8A04',
 };
 
+// Dark-mode colors (slightly lighter for better contrast on dark backgrounds)
+const PHASE_COLORS_DARK: Record<TimerPhase, string> = {
+  IDLE: '#6B7280',
+  WORKING: '#EF4444',
+  SHORT_BREAK: '#22C55E',
+  LONG_BREAK: '#22C55E',
+  BREAK_SUGGESTION: '#EAB308',
+};
+
 const SIZE = 160;
 const STROKE = 8;
 const RADIUS = (SIZE - STROKE) / 2;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
+const isDark = () =>
+  typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
+
 export default function TimerRing(props: TimerRingProps) {
   const offset = () => CIRCUMFERENCE * (1 - props.progress);
-  const color = () => PHASE_COLORS[props.phase];
+  const color = () =>
+    isDark() ? PHASE_COLORS_DARK[props.phase] : PHASE_COLORS_LIGHT[props.phase];
+  const trackColor = () => (isDark() ? '#374151' : '#E5E7EB');
 
   return (
     <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
@@ -30,7 +45,7 @@ export default function TimerRing(props: TimerRingProps) {
         cy={SIZE / 2}
         r={RADIUS}
         fill="none"
-        stroke="#E5E7EB"
+        stroke={trackColor()}
         stroke-width={STROKE}
       />
       <circle

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'tailwindcss';
 
 export default {
   content: ['./entrypoints/**/*.{html,ts,tsx}', './components/**/*.{ts,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- Controls: Added dark: Tailwind variants to all button color classes
- TimerRing: SVG colors now adapt to dark mode via CSS or Tailwind variants
- Heatmap: Cell intensity colors have a dark-mode palette

Closes #181
Closes #182