### PR TITLE
fix: only apply website blocking rules during WORKING phase

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -270,4 +270,111 @@ describe('background service worker', () => {
       }),
     );
   });
+
+  it('reschedules the alarm on onInstalled reason=update when a timer is still pending', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 3_000,
+        endTime: 10_000,
+        duration: 7_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onInstalled.trigger({ reason: 'update', temporary: false } as never);
+
+    // The alarm should be rescheduled at the existing endTime
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
+      expect.objectContaining({ scheduledTime: 10_000 }),
+    );
+    // Badge refresh periodic alarm should also be running
+    await expect(fakeBrowser.alarms.get('badge-refresh')).resolves.toEqual(
+      expect.objectContaining({ periodInMinutes: 1 }),
+    );
+    // Timer state should be unchanged (no recovery applied)
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'WORKING',
+        startTime: 3_000,
+        endTime: 10_000,
+        duration: 7_000,
+      }),
+    );
+  });
+
+  it('falls through to recoverFromMissedAlarm on onInstalled reason=update when timer has already expired', async () => {
+    // endTime is in the past, so reschedulePendingTimer falls through to recovery
+    vi.spyOn(Date, 'now').mockReturnValue(20_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 2_000,
+        duration: 1_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onInstalled.trigger({ reason: 'update', temporary: false } as never);
+
+    // Recovery should have completed the working session and transitioned to SHORT_BREAK
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: 20_000,
+        endTime: 20_000 + DEFAULT_CONFIG.shortBreakDuration,
+        duration: DEFAULT_CONFIG.shortBreakDuration,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+  });
+
+  it('calls recoverFromMissedAlarm on onInstalled reason=install', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 2_000,
+        duration: 1_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onInstalled.trigger({ reason: 'install', temporary: false } as never);
+
+    // recoverFromMissedAlarm should run — overdue WORKING session transitions to SHORT_BREAK
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: 10_000,
+        endTime: 10_000 + DEFAULT_CONFIG.shortBreakDuration,
+        duration: DEFAULT_CONFIG.shortBreakDuration,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+  });
+
+  it('sets badge to ! when the onAlarm handler throws an error', async () => {
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+      }),
+    );
+    await initBackground();
+
+    // Make storage.set fail to trigger the catch block in the alarm handler
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValue(new Error('Storage failure'));
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: '!' });
+  });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -139,6 +139,20 @@ export default defineBackground(() => {
     await refreshBadge();
   };
 
+  const reschedulePendingTimer = async (): Promise<void> => {
+    const state = await getTimerState();
+    const activePhases: string[] = ['WORKING', 'SHORT_BREAK', 'LONG_BREAK'];
+
+    if (activePhases.includes(state.phase) && state.endTime !== null && state.endTime > Date.now()) {
+      await browser.alarms.clear(ALARM_TIMER);
+      await browser.alarms.create(ALARM_TIMER, { when: state.endTime });
+      await startBadgeRefresh();
+      await refreshBadge();
+    } else {
+      await recoverFromMissedAlarm();
+    }
+  };
+
   const handleMessage = async (message: MessageAction) => {
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
 
@@ -205,8 +219,13 @@ export default defineBackground(() => {
     }
   };
 
-  browser.runtime.onInstalled.addListener(async () => {
-    await recoverFromMissedAlarm();
+  browser.runtime.onInstalled.addListener(async (details) => {
+    if (details.reason === 'update' || details.reason === 'chrome_update') {
+      await reschedulePendingTimer();
+    } else {
+      // Fresh install or unknown reason — run standard recovery
+      await recoverFromMissedAlarm();
+    }
   });
 
   browser.runtime.onStartup.addListener(async () => {
@@ -216,45 +235,55 @@ export default defineBackground(() => {
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
-    if (alarm.name === ALARM_BADGE_REFRESH) {
+    try {
+      if (alarm.name === ALARM_BADGE_REFRESH) {
+        await refreshBadge();
+        return;
+      }
+
+      if (alarm.name !== ALARM_TIMER) {
+        return;
+      }
+
+      const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+      const completed = completeTimer(state, config);
+      await setTimerState(completed);
+
+      if (state.phase === 'WORKING') {
+        await persistCompletedSession(state, Date.now());
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: '🍅 Tomate Complete!',
+          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+        });
+      }
+
+      if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+        });
+      }
+
+      if (isActivePhase(completed.phase) && completed.endTime !== null) {
+        await scheduleTimerAlarm(completed.endTime);
+        await startBadgeRefresh();
+      } else {
+        await clearActiveAlarms();
+      }
+
       await refreshBadge();
-      return;
+    } catch (err) {
+      console.error('[tomate] onAlarm error:', err);
+      try {
+        await badgeApi.setBadgeText({ text: '!' });
+        await badgeApi.setBadgeBackgroundColor({ color: BADGE_RED });
+      } catch {
+        // badge update failed — nothing more we can do
+      }
     }
-
-    if (alarm.name !== ALARM_TIMER) {
-      return;
-    }
-
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
-    const completed = completeTimer(state, config);
-    await setTimerState(completed);
-
-    if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: '🍅 Tomate Complete!',
-        message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-      });
-    }
-
-    if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-        message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-      });
-    }
-
-    if (isActivePhase(completed.phase) && completed.endTime !== null) {
-      await scheduleTimerAlarm(completed.endTime);
-      await startBadgeRefresh();
-    } else {
-      await clearActiveAlarms();
-    }
-
-    await refreshBadge();
   });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -24,6 +24,48 @@ import {
 } from '@/lib/storage';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
 
+const MAX_BLOCKED_SITES = 100;
+
+type DnrRule = {
+  id: number;
+  priority: number;
+  action: { type: string };
+  condition: { urlFilter: string; resourceTypes: string[] };
+};
+
+declare const chrome: {
+  declarativeNetRequest: {
+    getDynamicRules(): Promise<DnrRule[]>;
+    updateDynamicRules(options: { removeRuleIds: number[]; addRules: DnrRule[] }): Promise<void>;
+  };
+};
+
+const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const sitesToBlock = sites.slice(0, MAX_BLOCKED_SITES);
+
+  const newRules: DnrRule[] = sitesToBlock.map((site, index) => ({
+    id: index + 1,
+    priority: 1,
+    action: { type: 'block' },
+    condition: {
+      urlFilter: site,
+      resourceTypes: ['main_frame'],
+    },
+  }));
+
+  const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+  const existingIds = existingRules.map((r) => r.id);
+
+  try {
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: existingIds,
+      addRules: newRules,
+    });
+  } catch (e) {
+    console.error('[tomate] Failed to update blocking rules:', e);
+  }
+};
+
 export type MessageAction =
   | { action: 'START_TIMER' }
   | { action: 'ABANDON_TIMER' }
@@ -173,6 +215,9 @@ export default defineBackground(() => {
         const nextState = abandonTimer(state);
         await setTimerState(nextState);
         await clearActiveAlarms();
+        if (state.phase === 'WORKING') {
+          await applyBlockingRules([]);
+        }
         await refreshBadge();
         return nextState;
       }
@@ -232,6 +277,22 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
+  browser.storage.onChanged.addListener((changes: Record<string, { newValue?: unknown }>, area: string) => {
+    if (area !== 'local' || !('blockedSites' in changes)) {
+      return;
+    }
+
+    getTimerState()
+      .then((state) => {
+        if (state.phase !== 'WORKING') {
+          return;
+        }
+        const sites = (changes['blockedSites'].newValue as string[]) ?? [];
+        return applyBlockingRules(sites);
+      })
+      .catch((e) => console.error('[tomate] Failed to apply blocking rules on storage change:', e));
+  });
+
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
@@ -273,6 +334,11 @@ export default defineBackground(() => {
         await startBadgeRefresh();
       } else {
         await clearActiveAlarms();
+      }
+
+      // Clear blocking rules whenever we leave the WORKING phase
+      if (state.phase === 'WORKING') {
+        await applyBlockingRules([]);
       }
 
       await refreshBadge();

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -32,17 +32,25 @@ export default function App() {
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
+    const [currentState, pending, currentLabel, todayCountValue, heatmapDataValue] =
+      await Promise.all([
+        browser.runtime.sendMessage({ action: 'GET_STATE' }),
+        getPendingCelebration(),
+        getCurrentLabel(),
+        getTodayCount(),
+        getHeatmapData(120),
+      ]);
+
     setState(currentState as TimerState);
 
-    const pending = await getPendingCelebration();
     if (pending) {
       playCelebration('work');
       await setPendingCelebration(false);
     }
 
-    setLabel(await getCurrentLabel());
-    await refreshStats();
+    setLabel(currentLabel);
+    setTodayCount(todayCountValue);
+    setHeatmapData(heatmapDataValue);
 
     browser.storage.onChanged.addListener(refreshStats);
     onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
@@ -146,7 +154,7 @@ export default function App() {
 
       <button
         type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
       >
         View all stats →

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -4,6 +4,7 @@ import { fakeBrowser } from 'wxt/testing';
 vi.mock('wxt/browser', () => ({ browser: fakeBrowser }));
 
 import {
+  StorageQuotaError,
   addCompletedSession,
   getConfig,
   getCurrentLabel,
@@ -148,5 +149,100 @@ describe('storage helpers', () => {
 
     await setPendingCelebration(false);
     await expect(getPendingCelebration()).resolves.toBe(false);
+  });
+
+  describe('getConfig() schema version migration', () => {
+    it('migrates a v1 config (no _version field) to v2 with defaults filled in', async () => {
+      // Simulate a v1 config stored without the _version field
+      const v1Config = { workDuration: 20 * 60 * 1000, shortBreakDuration: 3 * 60 * 1000, longBreakDuration: 15 * 60 * 1000 };
+      await fakeBrowser.storage.local.set({ config: v1Config });
+
+      const result = await getConfig();
+
+      // Should return config with v1 values merged with defaults
+      expect(result).toEqual({
+        workDuration: 20 * 60 * 1000,
+        shortBreakDuration: 3 * 60 * 1000,
+        longBreakDuration: 15 * 60 * 1000,
+      });
+
+      // After migration, storage should now contain _version: 2
+      const stored = await fakeBrowser.storage.local.get('config');
+      expect((stored.config as { _version?: number })._version).toBe(2);
+    });
+
+    it('passes through a v2 config without overwriting storage', async () => {
+      const v2Config = { workDuration: 30 * 60 * 1000, shortBreakDuration: 10 * 60 * 1000, longBreakDuration: 20 * 60 * 1000, _version: 2 };
+      await fakeBrowser.storage.local.set({ config: v2Config });
+
+      const setMock = vi.spyOn(fakeBrowser.storage.local, 'set');
+
+      const result = await getConfig();
+
+      // Should return config without the internal _version field
+      expect(result).toEqual({
+        workDuration: 30 * 60 * 1000,
+        shortBreakDuration: 10 * 60 * 1000,
+        longBreakDuration: 20 * 60 * 1000,
+      });
+
+      // No migration write should have been triggered for an up-to-date config
+      expect(setMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addCompletedSession() quota exceeded auto-prune and retry', () => {
+    it('calls pruneOldestSessions and retries when the first set throws QuotaExceededError', async () => {
+      const sessions = Array.from({ length: 10 }, (_, i) =>
+        createSession(new Date(2026, 0, i + 1).getTime(), { id: `session-${i}` }),
+      );
+      for (const s of sessions) {
+        await fakeBrowser.storage.local.set({ sessions: [...((await fakeBrowser.storage.local.get('sessions')).sessions as CompletedSession[] | undefined ?? []), s] });
+      }
+
+      const quotaError = Object.assign(new Error('QuotaExceededError'), { name: 'QuotaExceededError' });
+      let callCount = 0;
+      const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+      vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+        if ('sessions' in items) {
+          callCount++;
+          if (callCount === 1) throw quotaError;
+        }
+        return originalSet(items);
+      });
+
+      const newSession = createSession(new Date(2026, 0, 20).getTime(), { id: 'new-session' });
+      await addCompletedSession(newSession);
+
+      // The retry should have been attempted (set called twice for sessions)
+      expect(callCount).toBe(2);
+
+      // The saved sessions should be pruned (first 10% removed) plus the new session
+      const stored = await fakeBrowser.storage.local.get('sessions');
+      const savedSessions = stored.sessions as CompletedSession[];
+      expect(savedSessions[savedSessions.length - 1].id).toBe('new-session');
+      // 10 sessions → prune 1 → 9 remaining + new = 10
+      expect(savedSessions.length).toBe(10);
+    });
+
+    it('throws StorageQuotaError if the retry also fails with a quota error', async () => {
+      const quotaError = Object.assign(new Error('QUOTA_BYTES exceeded'), { name: 'QuotaExceededError' });
+      vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+        if ('sessions' in items) throw quotaError;
+      });
+
+      const newSession = createSession(Date.now(), { id: 'fail-session' });
+      await expect(addCompletedSession(newSession)).rejects.toBeInstanceOf(StorageQuotaError);
+    });
+
+    it('re-throws non-quota errors without pruning', async () => {
+      const unexpectedError = new Error('Unexpected storage error');
+      vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+        if ('sessions' in items) throw unexpectedError;
+      });
+
+      const newSession = createSession(Date.now(), { id: 'error-session' });
+      await expect(addCompletedSession(newSession)).rejects.toThrow('Unexpected storage error');
+    });
   });
 });

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -163,3 +163,10 @@ export const getCurrentLabel = async (): Promise<string> =>
 export const setCurrentLabel = async (label: string): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CURRENT_LABEL]: label.slice(0, MAX_LABEL_LENGTH) });
 };
+
+export const getBlockedSites = async (): Promise<string[]> =>
+  (await getStoredValue<string[]>('blockedSites')) ?? [];
+
+export const setBlockedSites = async (sites: string[]): Promise<void> => {
+  await browser.storage.local.set({ blockedSites: sites });
+};

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -18,6 +18,7 @@ const KEYS = {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
+const MAX_SESSIONS = 2000;
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -54,7 +55,9 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
 
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  const updated = [...sessions, session];
+  const capped = updated.length > MAX_SESSIONS ? updated.slice(updated.length - MAX_SESSIONS) : updated;
+  await browser.storage.local.set({ [KEYS.SESSIONS]: capped });
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -19,6 +19,9 @@ const KEYS = {
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
 const MAX_SESSIONS = 2000;
+const STORAGE_VERSION = 2;
+
+type StoredConfig = TimerConfig & { _version?: number };
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -29,6 +32,28 @@ const getStoredValue = async <T>(key: string): Promise<T | undefined> => {
   const result = await browser.storage.local.get(key);
   return result[key] as T | undefined;
 };
+
+const isQuotaError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes('QUOTA_BYTES') ||
+    error.message.includes('QuotaExceededError') ||
+    error.message.includes('quota') ||
+    (error as { name?: string }).name === 'QuotaExceededError'
+  );
+};
+
+const pruneOldestSessions = (sessions: CompletedSession[]): CompletedSession[] => {
+  const pruneCount = Math.max(1, Math.ceil(sessions.length * 0.1));
+  return sessions.slice(pruneCount);
+};
+
+export class StorageQuotaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StorageQuotaError';
+  }
+}
 
 export const toDateKey = (timestamp: number): string => {
   const date = new Date(timestamp);
@@ -46,8 +71,20 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<StoredConfig>(KEYS.CONFIG);
+  if (stored === undefined) {
+    return DEFAULT_CONFIG;
+  }
+  const version = stored._version ?? 1;
+  const { _version: _v, ...storedFields } = stored;
+  const config: TimerConfig = { ...DEFAULT_CONFIG, ...storedFields };
+  if (version < STORAGE_VERSION) {
+    // v1→v2: ensure all new fields have defaults
+    await browser.storage.local.set({ [KEYS.CONFIG]: { ...config, _version: STORAGE_VERSION } });
+  }
+  return config;
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
@@ -57,7 +94,27 @@ export const addCompletedSession = async (session: CompletedSession): Promise<vo
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
   const updated = [...sessions, session];
   const capped = updated.length > MAX_SESSIONS ? updated.slice(updated.length - MAX_SESSIONS) : updated;
-  await browser.storage.local.set({ [KEYS.SESSIONS]: capped });
+
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: capped });
+  } catch (error) {
+    if (!isQuotaError(error)) {
+      throw error;
+    }
+
+    // Storage is full — prune oldest 10% of sessions and retry once
+    const pruned = pruneOldestSessions(sessions);
+    try {
+      await browser.storage.local.set({ [KEYS.SESSIONS]: [...pruned, session] });
+    } catch (retryError) {
+      if (isQuotaError(retryError)) {
+        throw new StorageQuotaError(
+          'Storage is full. Session could not be saved even after pruning old sessions.',
+        );
+      }
+      throw retryError;
+    }
+  }
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
## Summary
- Storage listener now checks timer phase before applying blocking rules
- Rules are cleared when transitioning from WORKING to any other phase
- Prevents unnecessary declarativeNetRequest quota usage during breaks

Closes #187