### PR TITLE
ux: session list, goal celebration, and heatmap year boundary

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -65,6 +65,7 @@ const generateHeatmapGrid = (
 };
 
 type MonthLabel = { label: string; column: number };
+type YearLabel = { label: string; column: number };
 
 export default function Heatmap(props: HeatmapProps) {
   const cellSize = () => props.cellSize ?? 12;
@@ -112,6 +113,25 @@ export default function Heatmap(props: HeatmapProps) {
         if (month !== lastMonth) {
           labels.push({ label: MONTH_NAMES[month], column: c });
           lastMonth = month;
+        }
+      }
+    }
+
+    return labels;
+  });
+
+  const yearLabels = createMemo(() => {
+    const cols = columns();
+    const labels: YearLabel[] = [];
+    let lastYear = -1;
+
+    for (let c = 0; c < cols.length; c++) {
+      const firstCell = cols[c].find((cell) => cell !== null);
+      if (firstCell) {
+        const year = Number.parseInt(firstCell.date.split('-')[0], 10);
+        if (year !== lastYear) {
+          labels.push({ label: String(year), column: c });
+          lastYear = year;
         }
       }
     }
@@ -175,7 +195,7 @@ export default function Heatmap(props: HeatmapProps) {
 
         {/* Heatmap cells - CSS Grid: 7 rows, auto columns */}
         <div
-          class="grid"
+          class="grid relative"
           style={{
             "grid-template-rows": `repeat(7, ${cellSize()}px)`,
             "grid-auto-flow": "column",
@@ -184,30 +204,50 @@ export default function Heatmap(props: HeatmapProps) {
           }}
         >
           <For each={columns()}>
-            {(col) => (
-              <For each={col}>
-                {(cell) =>
-                  cell ? (
+            {(col, colIndex) => {
+              const yearLabel = () =>
+                yearLabels().find((yl) => yl.column === colIndex());
+
+              return (
+                <>
+                  <For each={col}>
+                    {(cell) =>
+                      cell ? (
+                        <div
+                          class="rounded-sm"
+                          style={{
+                            width: `${cellSize()}px`,
+                            height: `${cellSize()}px`,
+                            "background-color": getIntensityColor(cell.count),
+                          }}
+                          title={tooltipText(cell)}
+                        />
+                      ) : (
+                        <div
+                          style={{
+                            width: `${cellSize()}px`,
+                            height: `${cellSize()}px`,
+                          }}
+                        />
+                      )
+                    }
+                  </For>
+                  {yearLabel() && (
                     <div
-                      class="rounded-sm"
+                      class="absolute bottom-0 text-[8px] font-semibold text-red-400 pointer-events-none"
                       style={{
-                        width: `${cellSize()}px`,
-                        height: `${cellSize()}px`,
-                        "background-color": getIntensityColor(cell.count),
+                        left: `${colIndex() * (cellSize() + gap)}px`,
+                        "white-space": "nowrap",
+                        "line-height": "1",
+                        transform: "translateY(100%) translateY(2px)",
                       }}
-                      title={tooltipText(cell)}
-                    />
-                  ) : (
-                    <div
-                      style={{
-                        width: `${cellSize()}px`,
-                        height: `${cellSize()}px`,
-                      }}
-                    />
-                  )
-                }
-              </For>
-            )}
+                    >
+                      {yearLabel()!.label}
+                    </div>
+                  )}
+                </>
+              );
+            }}
           </For>
         </div>
       </div>

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,7 +1,8 @@
-import { createResource, For } from 'solid-js';
+import { createResource, For, Show } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
+import type { CompletedSession } from '@/lib/types';
 
 import Heatmap from '@/components/Heatmap';
 
@@ -11,6 +12,13 @@ const INTENSITY_LEGEND = [
   { color: '#EF4444', label: '2-3' },
   { color: '#DC2626', label: '4-5' },
   { color: '#991B1B', label: '6+' },
+] as const;
+
+const DAILY_GOAL = 8;
+
+const MONTH_ABBR = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
 ] as const;
 
 type StatCardProps = {
@@ -29,6 +37,35 @@ function StatCard(props: StatCardProps) {
   );
 }
 
+function formatSessionDate(dateKey: string): string {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+  return `${MONTH_ABBR[date.getMonth()]} ${date.getDate()}`;
+}
+
+function formatDuration(durationMs: number): string {
+  const minutes = Math.round(durationMs / 60_000);
+  return `${minutes} min`;
+}
+
+function SessionRow(props: { session: CompletedSession }) {
+  const dateLabel = () => formatSessionDate(props.session.date);
+  const durLabel = () => formatDuration(props.session.duration);
+  const hasLabel = () => props.session.label && props.session.label.trim().length > 0;
+
+  return (
+    <div class="flex items-center gap-1 py-2 border-b border-gray-100 last:border-0 text-sm text-gray-700">
+      <span class="text-gray-400 font-medium w-14 flex-shrink-0">{dateLabel()}</span>
+      <span class="text-gray-300 mx-1">·</span>
+      <span class="text-gray-500 w-14 flex-shrink-0">{durLabel()}</span>
+      <Show when={hasLabel()}>
+        <span class="text-gray-300 mx-1">·</span>
+        <span class="text-gray-600 truncate italic">"{props.session.label}"</span>
+      </Show>
+    </div>
+  );
+}
+
 export default function App() {
   const [yearData] = createResource(() => getHeatmapData(365));
   const [sessions] = createResource(() => getSessionHistory());
@@ -39,10 +76,24 @@ export default function App() {
   const bestDay = () => computeBestDay(sessions() ?? []);
   const streak = () => computeStreak(sessions() ?? []);
 
+  const recentSessions = () => {
+    const all = sessions() ?? [];
+    return all.slice(-20).reverse();
+  };
+
+  const goalReached = () => (todayCount() ?? 0) >= DAILY_GOAL;
+
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
-        <h1 class="text-2xl font-bold text-red-600 mb-6">Tomate Stats</h1>
+        <div class="flex items-center gap-3 mb-6">
+          <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
+          <Show when={goalReached()}>
+            <span class="inline-flex items-center gap-1 bg-green-100 text-green-700 text-xs font-semibold px-2.5 py-1 rounded-full border border-green-200">
+              🎯 Goal reached!
+            </span>
+          </Show>
+        </div>
 
         <div class="grid grid-cols-5 gap-3 mb-6">
           <StatCard label="Total tomates" value={total()} />
@@ -59,7 +110,7 @@ export default function App() {
           />
         </div>
 
-        <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
+        <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100 mb-4">
           <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
           <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
 
@@ -76,6 +127,22 @@ export default function App() {
             </For>
             <span>More</span>
           </div>
+        </div>
+
+        <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
+          <h2 class="text-sm font-semibold text-gray-700 mb-2">Recent sessions</h2>
+          <Show
+            when={(sessions() ?? []).length > 0}
+            fallback={
+              <p class="text-sm text-gray-400 py-4 text-center">No sessions recorded yet.</p>
+            }
+          >
+            <div class="max-h-72 overflow-y-auto">
+              <For each={recentSessions()}>
+                {(session) => <SessionRow session={session} />}
+              </For>
+            </div>
+          </Show>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- #193: Added scrollable recent session list (last 20) below the heatmap
- #196: "Goal reached!" indicator when today's sessions >= daily goal
- #198: Year label shown at year boundary in heatmap grid

Closes #193
Closes #196
Closes #198