### PR TITLE
ux: add recent session list and heatmap year boundary

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -65,6 +65,7 @@ const generateHeatmapGrid = (
 };
 
 type MonthLabel = { label: string; column: number };
+type YearLabel = { year: number; column: number };
 
 export default function Heatmap(props: HeatmapProps) {
   const cellSize = () => props.cellSize ?? 12;
@@ -119,6 +120,32 @@ export default function Heatmap(props: HeatmapProps) {
     return labels;
   });
 
+  const yearLabels = createMemo(() => {
+    const cols = columns();
+    const labels: YearLabel[] = [];
+    let lastYear = -1;
+    let yearsFound = 0;
+
+    for (let c = 0; c < cols.length; c++) {
+      const firstCell = cols[c].find((cell) => cell !== null);
+      if (firstCell) {
+        const year = Number.parseInt(firstCell.date.split('-')[0], 10);
+        if (year !== lastYear) {
+          yearsFound++;
+          // Only emit the label if there is a genuine year boundary mid-grid
+          // (i.e. this is not the very first column of the grid)
+          if (c > 0) {
+            labels.push({ year, column: c });
+          }
+          lastYear = year;
+        }
+      }
+    }
+
+    // Only return labels when the grid actually spans two different years
+    return yearsFound > 1 ? labels : [];
+  });
+
   const tooltipText = (cell: HeatmapCell) => {
     const count = cell.count;
     const label = count === 0 ? 'No tomates' : `${count} tomate${count !== 1 ? 's' : ''}`;
@@ -150,6 +177,25 @@ export default function Heatmap(props: HeatmapProps) {
           }}
         </For>
       </div>
+
+      {/* Year boundary labels (only rendered when grid spans two calendar years) */}
+      {yearLabels().length > 0 && (
+        <div class="relative" style={{ "padding-left": `${labelWidth}px`, height: "14px" }}>
+          <For each={yearLabels()}>
+            {(yl) => {
+              const left = () => yl.column * (cellSize() + gap);
+              return (
+                <span
+                  class="absolute text-[9px] font-semibold text-gray-500 leading-none"
+                  style={{ left: `${left()}px` }}
+                >
+                  {yl.year}
+                </span>
+              );
+            }}
+          </For>
+        </div>
+      )}
 
       {/* Grid with day labels */}
       <div class="flex">

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For } from 'solid-js';
+import { createResource, For, createMemo } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -77,6 +77,64 @@ export default function App() {
             <span>More</span>
           </div>
         </div>
+
+        <RecentSessions sessions={sessions() ?? []} />
+      </div>
+    </div>
+  );
+}
+
+const MONTH_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+] as const;
+
+function formatSessionDate(ts: number): string {
+  const d = new Date(ts);
+  return `${MONTH_SHORT[d.getMonth()]} ${d.getDate()}`;
+}
+
+function formatDuration(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  return `${minutes} min`;
+}
+
+type RecentSessionsProps = {
+  sessions: import('@/lib/types').CompletedSession[];
+};
+
+function RecentSessions(props: RecentSessionsProps) {
+  const recent = createMemo(() =>
+    [...props.sessions]
+      .sort((a, b) => b.startTime - a.startTime)
+      .slice(0, 20),
+  );
+
+  return (
+    <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100 mt-4">
+      <h2 class="text-sm font-semibold text-gray-700 mb-3">Recent sessions</h2>
+      <div class="flex flex-col gap-1 max-h-80 overflow-y-auto">
+        <For
+          each={recent()}
+          fallback={
+            <p class="text-xs text-gray-400 py-2">No sessions yet.</p>
+          }
+        >
+          {(session) => {
+            const durationMs = session.endTime - session.startTime;
+            const dateStr = formatSessionDate(session.startTime);
+            const durStr = formatDuration(durationMs);
+            return (
+              <div class="flex items-center gap-2 py-1.5 border-b border-gray-50 last:border-0">
+                <span class="text-xs text-gray-500 w-16 shrink-0">{dateStr}</span>
+                <span class="text-xs text-red-500 font-medium w-14 shrink-0">{durStr}</span>
+                {session.label && (
+                  <span class="text-xs text-gray-400 truncate">"{session.label}"</span>
+                )}
+              </div>
+            );
+          }}
+        </For>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- #193: Recent sessions list (last 20) shown below stats heatmap
- #198: Year label shown at year boundary in heatmap grid

Closes #193
Closes #198