### PR TITLE
fix: make onAlarm handler mutually exclusive to prevent concurrent race

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -35,6 +35,7 @@ export type MessageAction =
 export default defineBackground(() => {
   const ALARM_TIMER = 'tomate-timer';
   const ALARM_BADGE_REFRESH = 'badge-refresh';
+  const recentlyHandledAlarms = new Set<string>();
   const BADGE_RED = '#DC2626';
   const BADGE_GREEN = '#16A34A';
   const BADGE_GOLD = '#CA8A04';
@@ -225,36 +226,45 @@ export default defineBackground(() => {
       return;
     }
 
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
-    const completed = completeTimer(state, config);
-    await setTimerState(completed);
-
-    if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: '🍅 Tomate Complete!',
-        message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-      });
+    if (recentlyHandledAlarms.has(alarm.name)) {
+      return;
     }
+    recentlyHandledAlarms.add(alarm.name);
 
-    if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-        message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-      });
+    try {
+      const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+      const completed = completeTimer(state, config);
+      await setTimerState(completed);
+
+      if (state.phase === 'WORKING') {
+        await persistCompletedSession(state, Date.now());
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: '🍅 Tomate Complete!',
+          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+        });
+      }
+
+      if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+        });
+      }
+
+      if (isActivePhase(completed.phase) && completed.endTime !== null) {
+        await scheduleTimerAlarm(completed.endTime);
+        await startBadgeRefresh();
+      } else {
+        await clearActiveAlarms();
+      }
+
+      await refreshBadge();
+    } finally {
+      setTimeout(() => recentlyHandledAlarms.delete(alarm.name), 2000);
     }
-
-    if (isActivePhase(completed.phase) && completed.endTime !== null) {
-      await scheduleTimerAlarm(completed.endTime);
-      await startBadgeRefresh();
-    } else {
-      await clearActiveAlarms();
-    }
-
-    await refreshBadge();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a module-scoped `recentlyHandledAlarms = new Set<string>()` inside `defineBackground`
- In the `onAlarm` handler, checks `recentlyHandledAlarms.has(alarm.name)` synchronously before any `await` — concurrent invocations return early immediately
- Adds `alarm.name` to the set synchronously right after the check so subsequent concurrent calls also see it
- Wraps the entire handler body in `try/finally`; removes the name from the set after 2 000 ms via `setTimeout`, allowing future legitimate firings

## Why

When the extension updates, `onInstalled` calls `reschedulePendingTimer()` which clears and recreates the timer alarm. If the alarm fires at that exact moment, `onAlarm` runs concurrently with the still-in-flight `onInstalled`. Because `onAlarm` is not idempotent — it reads state, marks complete, and persists a session — the second concurrent invocation reads the pre-write state and saves a duplicate session.

The synchronous `Set` membership check acts as a mutex: the first invocation claims the slot before yielding to `await`, so any race-condition duplicate sees the entry and returns early.

## Test plan

- [ ] Load the extension, start a timer near expiry, then trigger a simulated update (reload background); confirm only one session is recorded
- [ ] Normal timer completion flow continues to work (session saved, notification shown, badge updated)
- [ ] `bun run build` passes cleanly (verified locally)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)