### PR TITLE
fix: add dark mode color variants to options page

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -38,44 +38,44 @@ export default function App() {
   };
 
   return (
-    <div class="min-h-screen bg-red-50 flex items-start justify-center pt-16">
-      <div class="w-full max-w-[400px] bg-white rounded-lg shadow-sm p-6">
-        <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 flex items-start justify-center pt-16">
+      <div class="w-full max-w-[400px] bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400 mb-6">Tomate Settings</h1>
 
         <div class="space-y-4">
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Work Duration (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Work Duration (minutes)</span>
             <input
               type="number"
               min={1}
               max={120}
               value={work()}
               onInput={(e) => setWork(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-gray-100 focus:border-red-500 dark:focus:border-red-400 focus:outline-none focus:ring-1 focus:ring-red-500 dark:focus:ring-red-400"
             />
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Short Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Short Break (minutes)</span>
             <input
               type="number"
               min={1}
               max={30}
               value={shortBreak()}
               onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-gray-100 focus:border-red-500 dark:focus:border-red-400 focus:outline-none focus:ring-1 focus:ring-red-500 dark:focus:ring-red-400"
             />
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Long Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Long Break (minutes)</span>
             <input
               type="number"
               min={5}
               max={60}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-gray-100 focus:border-red-500 dark:focus:border-red-400 focus:outline-none focus:ring-1 focus:ring-red-500 dark:focus:ring-red-400"
             />
           </label>
         </div>
@@ -92,13 +92,13 @@ export default function App() {
           <button
             type="button"
             onClick={handleReset}
-            class="text-sm text-gray-500 hover:text-gray-700 underline"
+            class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 underline"
           >
             Reset to defaults
           </button>
 
           <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
+            <span class="text-sm text-green-600 dark:text-green-400">Settings saved ✓</span>
           </Show>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Adds `dark:` Tailwind variants to all color classes in `entrypoints/options/App.tsx` that were missing dark mode support
- Covers the page background (`bg-red-50` → `dark:bg-gray-900`), card background (`bg-white` → `dark:bg-gray-800`), heading, form labels, input borders, input backgrounds, focus ring/border, helper text, and saved confirmation text
- Inputs also get `dark:bg-gray-700 dark:text-gray-100` so they are readable in dark mode

## Changes
- `bg-red-50` → added `dark:bg-gray-900`
- `bg-white` (card) → added `dark:bg-gray-800`
- `text-red-600` (h1) → added `dark:text-red-400`
- `text-gray-700` (labels) → added `dark:text-gray-300`
- `border-gray-300` (inputs) → added `dark:border-gray-600`
- `focus:border-red-500` → added `dark:focus:border-red-400`
- `focus:ring-red-500` → added `dark:focus:ring-red-400`
- Input `bg-white` → added `dark:bg-gray-700 dark:text-gray-100`
- `text-gray-500` (reset button) → added `dark:text-gray-400`
- `text-green-600` (saved confirmation) → added `dark:text-green-400`

## Test plan
- [ ] Toggle `html.dark` class in DevTools and verify options page renders correctly in dark mode
- [ ] Verify all text is legible against dark backgrounds
- [ ] Verify input fields have visible borders and readable text in dark mode
- [ ] Verify focus rings are visible in dark mode
- [ ] `bun run build` completes with no errors

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)