### PR TITLE
fix: re-apply MAX_SESSIONS cap in quota error retry path

### DIFF
--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -140,6 +140,55 @@ describe('storage helpers', () => {
     await expect(getCurrentLabel()).resolves.toBe('x'.repeat(50));
   });
 
+  it('caps stored sessions at MAX_SESSIONS (10 000)', async () => {
+    // Seed storage with MAX_SESSIONS sessions directly so addCompletedSession
+    // can observe the cap on a single add.
+    const MAX_SESSIONS = 10_000;
+    const seed: CompletedSession[] = Array.from({ length: MAX_SESSIONS }, (_, i) =>
+      createSession(i, { id: `seed-${i}` }),
+    );
+    await fakeBrowser.storage.local.set({ sessions: seed });
+
+    const extra = createSession(MAX_SESSIONS, { id: 'extra' });
+    await addCompletedSession(extra);
+
+    const stored = await fakeBrowser.storage.local.get('sessions');
+    const result = stored['sessions'] as CompletedSession[];
+    expect(result).toHaveLength(MAX_SESSIONS);
+    expect(result[result.length - 1].id).toBe('extra');
+  });
+
+  it('prunes ~10 % of sessions on quota error and still applies MAX_SESSIONS cap on retry', async () => {
+    const MAX_SESSIONS = 10_000;
+    const seed: CompletedSession[] = Array.from({ length: MAX_SESSIONS }, (_, i) =>
+      createSession(i, { id: `seed-${i}` }),
+    );
+    await fakeBrowser.storage.local.set({ sessions: seed });
+
+    // Make the first storage.set throw a quota error, but let the retry through.
+    let callCount = 0;
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+      if (callCount === 0 && 'sessions' in items) {
+        callCount++;
+        throw new Error('QUOTA_BYTES_PER_ITEM quota exceeded');
+      }
+      callCount++;
+      return originalSet(items);
+    });
+
+    const extra = createSession(MAX_SESSIONS, { id: 'retry-extra' });
+    await addCompletedSession(extra);
+
+    const stored = await fakeBrowser.storage.local.get('sessions');
+    const result = stored['sessions'] as CompletedSession[];
+
+    // Must never exceed MAX_SESSIONS
+    expect(result.length).toBeLessThanOrEqual(MAX_SESSIONS);
+    // The new session must be present
+    expect(result[result.length - 1].id).toBe('retry-extra');
+  });
+
   it('roundtrips the pending celebration flag', async () => {
     await expect(getPendingCelebration()).resolves.toBe(false);
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -18,6 +18,7 @@ const KEYS = {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
+const MAX_SESSIONS = 10_000;
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -52,9 +53,25 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
 };
 
+const isQuotaError = (err: unknown): boolean =>
+  err instanceof Error && err.message.toLowerCase().includes('quota');
+
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  const updated = [...sessions, session];
+  const capped = updated.slice(-MAX_SESSIONS);
+
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: capped });
+  } catch (err) {
+    if (!isQuotaError(err)) throw err;
+
+    const pruneCount = Math.max(1, Math.floor(sessions.length * 0.1));
+    const pruned = sessions.slice(pruneCount);
+    await browser.storage.local.set({
+      [KEYS.SESSIONS]: [...pruned, session].slice(-MAX_SESSIONS),
+    });
+  }
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
## Summary

- `addCompletedSession` previously had no `MAX_SESSIONS` constant, no cap on the initial write, and no quota-exceeded retry path at all.
- This PR introduces `MAX_SESSIONS = 10_000`, applies `.slice(-MAX_SESSIONS)` on the initial write, and adds a quota-error retry that prunes the oldest ~10 % of sessions and **also** slices the retry result to `MAX_SESSIONS` — fixing the bug described in #202.
- Two new tests cover: (1) the cap enforced on a normal add when storage is already at the limit, and (2) the cap enforced on the quota-error retry path.

## Test plan

- [x] `bun test lib/__tests__/storage.test.ts` — all 12 tests pass (10 pre-existing + 2 new)
- [x] Manual: verify `bun run build` compiles without errors

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)