### PR TITLE
fix: clear blocking rules when blockedSites changes outside WORKING phase

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -24,6 +24,48 @@ import {
 } from '@/lib/storage';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
 
+const MAX_BLOCKED_SITES = 100;
+
+type DnrRule = {
+  id: number;
+  priority: number;
+  action: { type: string };
+  condition: { urlFilter: string; resourceTypes: string[] };
+};
+
+declare const chrome: {
+  declarativeNetRequest: {
+    getDynamicRules(): Promise<DnrRule[]>;
+    updateDynamicRules(options: { removeRuleIds: number[]; addRules: DnrRule[] }): Promise<void>;
+  };
+};
+
+const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const sitesToBlock = sites.slice(0, MAX_BLOCKED_SITES);
+
+  const newRules: DnrRule[] = sitesToBlock.map((site, index) => ({
+    id: index + 1,
+    priority: 1,
+    action: { type: 'block' },
+    condition: {
+      urlFilter: site,
+      resourceTypes: ['main_frame'],
+    },
+  }));
+
+  const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+  const existingIds = existingRules.map((r) => r.id);
+
+  try {
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: existingIds,
+      addRules: newRules,
+    });
+  } catch (e) {
+    console.error('[tomate] Failed to update blocking rules:', e);
+  }
+};
+
 export type MessageAction =
   | { action: 'START_TIMER' }
   | { action: 'ABANDON_TIMER' }
@@ -211,6 +253,23 @@ export default defineBackground(() => {
 
   browser.runtime.onStartup.addListener(async () => {
     await recoverFromMissedAlarm();
+  });
+
+  browser.storage.onChanged.addListener((changes: Record<string, { newValue?: unknown }>, area: string) => {
+    if (area !== 'local' || !('blockedSites' in changes)) {
+      return;
+    }
+
+    getTimerState()
+      .then((state) => {
+        if (state.phase === 'WORKING') {
+          const sites = (changes['blockedSites'].newValue as string[]) ?? [];
+          return applyBlockingRules(sites);
+        }
+        // Not in WORKING phase — clear any existing blocking rules
+        return applyBlockingRules([]);
+      })
+      .catch((e) => console.error('[tomate] Failed to apply blocking rules on storage change:', e));
   });
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));


### PR DESCRIPTION
## Summary

PR #194 partially addresses issue #187 but has a gap: in the `storage.onChanged` listener, when the current phase is not `WORKING`, the handler returns early without clearing any existing dynamic rules. This means if a user updates their blocked-sites list while on a break, previously-applied rules remain in effect.

This PR corrects that by:
- Adding `applyBlockingRules` (DNR helper) and the `storage.onChanged` listener to `main`'s `background.ts`
- In the listener, calling `applyBlockingRules(sites)` only when `state.phase === 'WORKING'`
- Calling `applyBlockingRules([])` (clears all dynamic rules) for every other phase

**Diff from PR #194's listener:**
```diff
- if (state.phase !== 'WORKING') {
-   return;  // ← rules were NOT cleared
- }
- const sites = (changes['blockedSites'].newValue as string[]) ?? [];
- return applyBlockingRules(sites);
+ if (state.phase === 'WORKING') {
+   const sites = (changes['blockedSites'].newValue as string[]) ?? [];
+   return applyBlockingRules(sites);
+ }
+ // Not in WORKING phase — clear any existing blocking rules
+ return applyBlockingRules([]);
```

Closes #187

## Test plan
- [ ] Start a WORKING timer with blocked sites configured; verify sites are blocked
- [ ] Update the blocked-sites list during a BREAK; verify rules are cleared (sites become accessible)
- [ ] Update the blocked-sites list while IDLE; verify rules are not applied
- [ ] Start a new WORKING session after a list update during BREAK; verify the updated list is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)