### PR TITLE
fix: add dark mode color variants to popup

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -102,13 +102,13 @@ export default function App() {
   };
 
   return (
-    <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
+    <div class="w-[360px] min-h-[400px] bg-red-50 dark:bg-gray-900 p-4 flex flex-col items-center">
       <div class="w-full flex justify-between items-center mb-4">
-        <h1 class="text-xl font-bold text-red-600">Tomate</h1>
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400">Tomate</h1>
         <button
           type="button"
           onClick={() => browser.runtime.openOptionsPage()}
-          class="text-gray-400 hover:text-gray-600 text-lg"
+          class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 text-lg"
           aria-label="Settings"
         >
           ⚙️
@@ -116,9 +116,9 @@ export default function App() {
       </div>
 
       <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+      <div class="text-4xl font-mono font-bold text-gray-800 dark:text-gray-100 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
+      <div class="text-sm text-gray-500 dark:text-gray-400 mt-1">
         <Switch>
           <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
           <Match when={state().phase === 'WORKING'}>Working</Match>
@@ -147,7 +147,7 @@ export default function App() {
       <button
         type="button"
         onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
-        class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        class="mt-2 text-xs text-red-400 hover:text-red-600 dark:text-red-300 dark:hover:text-red-400 underline"
       >
         View all stats →
       </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'tailwindcss';
 
 export default {
   content: ['./entrypoints/**/*.{html,ts,tsx}', './components/**/*.{ts,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary

- Add `darkMode: 'class'` to `tailwind.config.ts` (was missing, required for `dark:` variants to work)
- Add `dark:` Tailwind variants to all hardcoded light-mode colors in `entrypoints/popup/App.tsx`:
  - `bg-red-50` → `dark:bg-gray-900` (root container)
  - `text-red-600` → `dark:text-red-400` (app title)
  - `text-gray-400 hover:text-gray-600` → `dark:text-gray-500 dark:hover:text-gray-300` (settings icon)
  - `text-gray-800` → `dark:text-gray-100` (timer display)
  - `text-gray-500` → `dark:text-gray-400` (phase label)
  - `text-red-400 hover:text-red-600` → `dark:text-red-300 dark:hover:text-red-400` (stats link)

No `connectionError` or `isSending` UI elements exist in the popup's `App.tsx`, so no additional banner/overlay changes were needed.

## Test plan

- [ ] Toggle `html.dark` class (via `lib/theme.ts`) and confirm popup background switches from red-50 to gray-900
- [ ] Verify title, timer, phase label, settings icon, and stats link all render with appropriate dark-mode contrast
- [ ] Run `bun run build` — exits cleanly with no errors

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)