### PR TITLE
fix: constrain confetti to popup bounds with centered origin and reduced spread

### DIFF
--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -4,20 +4,20 @@ import { browser } from 'wxt/browser';
 const CONFETTI_CONFIGS: Record<string, confetti.Options> = {
   work: {
     particleCount: 150,
-    spread: 80,
-    origin: { y: 0.6 },
+    spread: 40,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#DC2626', '#16A34A', '#FBBF24'],
   },
   milestone: {
     particleCount: 300,
-    spread: 100,
-    origin: { y: 0.6 },
+    spread: 50,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#DC2626', '#16A34A', '#FBBF24', '#7C3AED', '#2563EB'],
   },
   break: {
     particleCount: 50,
-    spread: 60,
-    origin: { y: 0.6 },
+    spread: 40,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#60A5FA', '#34D399', '#A78BFA'],
   },
 };


### PR DESCRIPTION
## Summary

- Changed `origin` in all three `CONFETTI_CONFIGS` entries from `{ y: 0.6 }` (viewport-relative) to `{ x: 0.5, y: 0.5 }` (centered within the 360×400px popup)
- Reduced `spread` values: `work` 80→40, `milestone` 100→50, `break` 60→40 to keep particles within popup bounds

## Test plan

- [ ] Open the extension popup and complete a work session — confetti should burst from the center of the popup
- [ ] Trigger a milestone celebration — particles should stay within the popup window, not spill into the browser viewport
- [ ] Trigger a break celebration — same containment check
- [ ] Verify no confetti appears at random positions relative to the full browser window

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)