### PR TITLE
feat: add CSS transitions to phase label and ring color on phase change

### DIFF
--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -44,7 +44,7 @@ export default function TimerRing(props: TimerRingProps) {
         stroke-dasharray={String(CIRCUMFERENCE)}
         stroke-dashoffset={offset()}
         transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
-        class="transition-[stroke-dashoffset] duration-500 ease-linear"
+        style="transition: stroke 400ms ease-in-out, stroke-dashoffset 500ms linear"
       />
     </svg>
   );

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -102,7 +102,7 @@ export default function App() {
   };
 
   return (
-    <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
+    <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center transition-colors duration-300">
       <div class="w-full flex justify-between items-center mb-4">
         <h1 class="text-xl font-bold text-red-600">Tomate</h1>
         <button
@@ -118,7 +118,7 @@ export default function App() {
       <TimerRing progress={progress()} phase={state().phase} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
+      <div class="text-sm text-gray-500 mt-1 transition-opacity duration-200 ease-in-out">
         <Switch>
           <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
           <Match when={state().phase === 'WORKING'}>Working</Match>


### PR DESCRIPTION
## Summary

- **Phase label** (`entrypoints/popup/App.tsx`): added `transition-opacity duration-200 ease-in-out` to the wrapper `<div>` around the `<Switch>` block so the text fades smoothly instead of snapping on phase change
- **TimerRing stroke** (`components/TimerRing.tsx`): replaced the Tailwind `class="transition-[stroke-dashoffset] ..."` with an inline `style` that applies both `stroke 400ms ease-in-out` (new — cross-fades the ring color) and `stroke-dashoffset 500ms linear` (preserves the existing progress animation)
- **Root container** (`entrypoints/popup/App.tsx`): added `transition-colors duration-300` to the outermost div for background color smoothing

## Test plan

- [ ] Build passes: `bun run build` exits clean
- [ ] Open popup while IDLE — ring is grey; start a session — ring smoothly cross-fades to red over ~400 ms
- [ ] Phase label text ("Ready to focus" → "Working") fades rather than snapping
- [ ] Dashoffset progress animation still works normally during an active session
- [ ] No visual regressions on SHORT_BREAK (green) or BREAK_SUGGESTION (amber) phases

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)