### PR TITLE
feat: add daily goal input to options page

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -10,6 +10,7 @@ export default function App() {
   const [work, setWork] = createSignal(25);
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
+  const [dailyGoal, setDailyGoal] = createSignal(8);
   const [saved, setSaved] = createSignal(false);
 
   onMount(async () => {
@@ -17,6 +18,7 @@ export default function App() {
     setWork(Math.round(config.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(config.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
+    setDailyGoal(config.dailyGoal ?? DEFAULT_CONFIG.dailyGoal);
   });
 
   const handleSave = async () => {
@@ -24,6 +26,7 @@ export default function App() {
       workDuration: work() * MS_PER_MINUTE,
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,
       longBreakDuration: longBreak() * MS_PER_MINUTE,
+      dailyGoal: dailyGoal(),
     };
     await setConfig(config);
     await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
@@ -35,6 +38,7 @@ export default function App() {
     setWork(Math.round(DEFAULT_CONFIG.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(DEFAULT_CONFIG.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
+    setDailyGoal(DEFAULT_CONFIG.dailyGoal);
   };
 
   return (
@@ -75,6 +79,18 @@ export default function App() {
               max={60}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
+              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+            />
+          </label>
+
+          <label class="block">
+            <span class="text-sm font-medium text-gray-700">Daily goal (sessions)</span>
+            <input
+              type="number"
+              min={1}
+              max={20}
+              value={dailyGoal()}
+              onInput={(e) => setDailyGoal(Number(e.currentTarget.value))}
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export type TimerConfig = {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  dailyGoal: number;
 };
 
 export type TimerState = {
@@ -29,6 +30,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  dailyGoal: 8,
 };
 
 export const INITIAL_STATE: TimerState = {


### PR DESCRIPTION
## Summary
- Adds `dailyGoal: number` field to `TimerConfig` type and `DEFAULT_CONFIG` (default: 8) in `lib/types.ts`
- Adds a "Daily goal (sessions)" numeric input (min 1, max 20) to the options page as the last field, matching the style and pattern of the existing duration inputs
- Initial value is loaded from stored config in `onMount`, saved via `handleSave`, and reset to default via `handleReset`

## Test plan
- [ ] Open the extension options page — a "Daily goal (sessions)" input should appear below "Long Break"
- [ ] Change the value and click Save — confirm the new value persists after reopening options
- [ ] Click "Reset to defaults" — confirm the field resets to 8
- [ ] Verify values outside 1–20 are constrained by the browser's number input

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)