### PR TITLE
perf: pass local state to refreshBadge to avoid redundant storage read

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -40,8 +40,13 @@ export default defineBackground(() => {
   const BADGE_GOLD = '#CA8A04';
   const badgeApi = browser.action;
 
-  const refreshBadge = async (): Promise<void> => {
-    const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
+  const refreshBadge = async (
+    preloadedState?: Awaited<ReturnType<typeof getTimerState>>,
+  ): Promise<void> => {
+    const [state, todayCount] = await Promise.all([
+      preloadedState ?? getTimerState(),
+      getTodayCount(),
+    ]);
 
     let text = '';
     let color = BADGE_RED;
@@ -255,6 +260,6 @@ export default defineBackground(() => {
       await clearActiveAlarms();
     }
 
-    await refreshBadge();
+    await refreshBadge(completed);
   });
 });


### PR DESCRIPTION
## Summary
- `refreshBadge()` now accepts an optional `preloadedState` parameter of type `Awaited<ReturnType<typeof getTimerState>>`
- When `preloadedState` is provided, it is used directly in `Promise.all` instead of fetching `TimerState` from storage again
- The `onAlarm` handler passes the already-computed `completed` state to `refreshBadge(completed)`, eliminating the redundant `getTimerState()` call that previously followed `persistCompletedSession()`

## Test plan
- [ ] Build passes (`bun run build`)
- [ ] Trigger a work session completion via alarm — badge should update correctly without an extra storage read
- [ ] All other `refreshBadge()` call sites (message handler, badge-refresh alarm, recover paths) continue to work as before (no argument passed, storage read still happens)

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)