### PR TITLE
feat: add date range period selector to stats page

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,7 +1,7 @@
-import { createResource, For } from 'solid-js';
+import { createResource, createSignal, For } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
-import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
+import { computeTotalCount, computeBestDay, computeStreak } from '@/lib/stats';
 
 import Heatmap from '@/components/Heatmap';
 
@@ -13,6 +13,15 @@ const INTENSITY_LEGEND = [
   { color: '#991B1B', label: '6+' },
 ] as const;
 
+type Period = 7 | 30 | 90 | 0;
+
+const PERIODS: { value: Period; label: string }[] = [
+  { value: 7, label: '7d' },
+  { value: 30, label: '30d' },
+  { value: 90, label: '90d' },
+  { value: 0, label: 'All' },
+];
+
 type StatCardProps = {
   label: string;
   value: string | number;
@@ -21,33 +30,65 @@ type StatCardProps = {
 
 function StatCard(props: StatCardProps) {
   return (
-    <div class="bg-white rounded-xl p-4 shadow-sm border border-red-100 flex flex-col items-center gap-1">
-      <span class="text-2xl font-bold text-red-600">{props.value}</span>
-      <span class="text-xs text-gray-500 font-medium">{props.label}</span>
-      {props.sublabel && <span class="text-[10px] text-gray-400">{props.sublabel}</span>}
+    <div class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-red-100 dark:border-red-900 flex flex-col items-center gap-1">
+      <span class="text-2xl font-bold text-red-600 dark:text-red-400">{props.value}</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400 font-medium">{props.label}</span>
+      {props.sublabel && <span class="text-[10px] text-gray-400 dark:text-gray-500">{props.sublabel}</span>}
     </div>
   );
 }
 
 export default function App() {
-  const [yearData] = createResource(() => getHeatmapData(365));
-  const [sessions] = createResource(() => getSessionHistory());
+  const [period, setPeriod] = createSignal<Period>(30);
+
+  const heatmapDays = () => (period() === 0 ? 365 : period());
+
+  const [heatmapData] = createResource(period, (p) =>
+    getHeatmapData(p === 0 ? 365 : p),
+  );
+  const [sessions] = createResource(period, (p) =>
+    getSessionHistory(p === 0 ? undefined : p),
+  );
   const [todayCount] = createResource(() => getTodayCount());
 
   const total = () => computeTotalCount(sessions() ?? []);
-  const week = () => computeWeekCount(sessions() ?? []);
   const bestDay = () => computeBestDay(sessions() ?? []);
   const streak = () => computeStreak(sessions() ?? []);
 
-  return (
-    <div class="min-h-screen bg-red-50 py-10 px-4">
-      <div class="max-w-[800px] mx-auto">
-        <h1 class="text-2xl font-bold text-red-600 mb-6">Tomate Stats</h1>
+  const periodLabel = () => {
+    const p = period();
+    if (p === 0) return 'All time';
+    return `Last ${p} days`;
+  };
 
-        <div class="grid grid-cols-5 gap-3 mb-6">
-          <StatCard label="Total tomates" value={total()} />
+  return (
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 py-10 px-4">
+      <div class="max-w-[800px] mx-auto">
+        <div class="flex items-center justify-between mb-6">
+          <h1 class="text-2xl font-bold text-red-600 dark:text-red-400">Tomate Stats</h1>
+
+          {/* Period selector */}
+          <div class="flex items-center gap-1 bg-white dark:bg-gray-800 border border-red-100 dark:border-red-900 rounded-lg p-1 shadow-sm">
+            <For each={PERIODS}>
+              {(item) => (
+                <button
+                  class={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                    period() === item.value
+                      ? 'bg-red-600 text-white dark:bg-red-500'
+                      : 'text-gray-600 dark:text-gray-300 hover:bg-red-50 dark:hover:bg-gray-700'
+                  }`}
+                  onClick={() => setPeriod(item.value)}
+                >
+                  {item.label}
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-4 gap-3 mb-6">
           <StatCard label="Today" value={todayCount() ?? 0} />
-          <StatCard label="This week" value={week()} />
+          <StatCard label={periodLabel()} value={total()} />
           <StatCard
             label="Best day"
             value={bestDay()?.count ?? '—'}
@@ -59,11 +100,13 @@ export default function App() {
           />
         </div>
 
-        <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-          <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
-          <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+        <div class="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-red-100 dark:border-red-900">
+          <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+            {period() === 0 ? '365-day' : `${period()}-day`} activity
+          </h2>
+          <Heatmap days={heatmapDays()} cellSize={14} data={heatmapData() ?? {}} />
 
-          <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
+          <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400 dark:text-gray-500">
             <span>Less</span>
             <For each={INTENSITY_LEGEND}>
               {(item) => (


### PR DESCRIPTION
## Summary

- Adds a **7d / 30d / 90d / All** pill button group to the stats page header (default: 30d)
- Stat cards (period total, best day, streak) re-fetch reactively when the period changes via `createResource` keyed on the period signal
- Heatmap window shrinks/expands to match the selected period (7 / 30 / 90 days, or 365 for "All")
- "Today" card remains independent and always shows today's count
- All new elements include `dark:` Tailwind variants
- `computeWeekCount` import removed (no longer used); period-aware total replaces the old "This week" card

## Test plan

- [ ] Open the stats page and verify the **7d | 30d | 90d | All** button group appears in the header
- [ ] Click each button and confirm stat cards and heatmap update accordingly
- [ ] Verify "Today" card is always correct regardless of selected period
- [ ] Confirm dark mode styles render correctly
- [ ] Run `bun run build` — no errors

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)