### PR TITLE
feat: add year navigation to heatmap

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -4,6 +4,8 @@ type HeatmapProps = {
   data: Record<string, number>;
   days: number;
   cellSize?: number;
+  /** ISO date string (YYYY-MM-DD) for the last day shown. Defaults to today. */
+  anchorDate?: string;
 };
 
 type HeatmapCell = {
@@ -45,13 +47,14 @@ const toDateKey = (date: Date): string => {
 const generateHeatmapGrid = (
   data: Record<string, number>,
   days: number,
+  anchorDate?: string,
 ): HeatmapCell[] => {
   const cells: HeatmapCell[] = [];
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  const anchor = anchorDate ? new Date(`${anchorDate}T00:00:00`) : new Date();
+  anchor.setHours(0, 0, 0, 0);
 
   for (let i = days - 1; i >= 0; i--) {
-    const date = new Date(today);
+    const date = new Date(anchor);
     date.setDate(date.getDate() - i);
     const key = toDateKey(date);
     cells.push({
@@ -70,7 +73,7 @@ export default function Heatmap(props: HeatmapProps) {
   const cellSize = () => props.cellSize ?? 12;
   const gap = 2;
 
-  const grid = createMemo(() => generateHeatmapGrid(props.data, props.days));
+  const grid = createMemo(() => generateHeatmapGrid(props.data, props.days, props.anchorDate));
 
   const toMonRow = (jsDay: number) => (jsDay === 0 ? 6 : jsDay - 1);
 

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,6 +1,6 @@
-import { createResource, For } from 'solid-js';
+import { createResource, createSignal, For } from 'solid-js';
 
-import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
+import { getSessionHistory, getHeatmapDataForRange, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
 
 import Heatmap from '@/components/Heatmap';
@@ -29,8 +29,55 @@ function StatCard(props: StatCardProps) {
   );
 }
 
+/** Return the last calendar day of the given year as a YYYY-MM-DD string. */
+function yearEndKey(year: number): string {
+  return `${year}-12-31`;
+}
+
+/** Return the first calendar day of the given year as a YYYY-MM-DD string. */
+function yearStartKey(year: number): string {
+  return `${year}-01-01`;
+}
+
 export default function App() {
-  const [yearData] = createResource(() => getHeatmapData(365));
+  const currentYear = new Date().getFullYear();
+
+  // 0 = current year, 1 = last year, etc.
+  const [yearOffset, setYearOffset] = createSignal(0);
+
+  const selectedYear = () => currentYear - yearOffset();
+
+  /** The anchor date passed to the heatmap: Dec 31 of the selected year,
+   *  but capped at today for the current year so we don't show future cells. */
+  const anchorDate = () => {
+    if (yearOffset() === 0) {
+      // current year — anchor to today
+      const today = new Date();
+      const y = today.getFullYear();
+      const m = String(today.getMonth() + 1).padStart(2, '0');
+      const d = String(today.getDate()).padStart(2, '0');
+      return `${y}-${m}-${d}`;
+    }
+    return yearEndKey(selectedYear());
+  };
+
+  const heatmapRange = () => {
+    const end = anchorDate();
+    // Always show 365 days ending on anchorDate
+    const endDate = new Date(`${end}T00:00:00`);
+    const startDate = new Date(endDate);
+    startDate.setDate(startDate.getDate() - 364);
+    const sy = startDate.getFullYear();
+    const sm = String(startDate.getMonth() + 1).padStart(2, '0');
+    const sd = String(startDate.getDate()).padStart(2, '0');
+    return { start: `${sy}-${sm}-${sd}`, end };
+  };
+
+  const [yearData] = createResource(
+    () => heatmapRange(),
+    ({ start, end }) => getHeatmapDataForRange(start, end),
+  );
+
   const [sessions] = createResource(() => getSessionHistory());
   const [todayCount] = createResource(() => getTodayCount());
 
@@ -38,6 +85,9 @@ export default function App() {
   const week = () => computeWeekCount(sessions() ?? []);
   const bestDay = () => computeBestDay(sessions() ?? []);
   const streak = () => computeStreak(sessions() ?? []);
+
+  const heatmapHeading = () =>
+    yearOffset() === 0 ? 'This year' : String(selectedYear());
 
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
@@ -60,8 +110,27 @@ export default function App() {
         </div>
 
         <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-          <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
-          <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+          {/* Heading row with year navigation */}
+          <div class="flex items-center justify-between mb-3">
+            <h2 class="text-sm font-semibold text-gray-700">{heatmapHeading()}</h2>
+            <div class="flex items-center gap-2">
+              <button
+                class="text-xs px-2 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
+                onClick={() => setYearOffset((o) => o + 1)}
+              >
+                ← {selectedYear() - 1}
+              </button>
+              <button
+                class="text-xs px-2 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
+                disabled={yearOffset() === 0}
+                onClick={() => setYearOffset((o) => Math.max(0, o - 1))}
+              >
+                {selectedYear() + 1} →
+              </button>
+            </div>
+          </div>
+
+          <Heatmap days={365} cellSize={14} data={yearData() ?? {}} anchorDate={anchorDate()} />
 
           <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
             <span>Less</span>

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -83,6 +83,20 @@ export const getHeatmapData = async (days: number): Promise<Record<string, numbe
   }, {});
 };
 
+export const getHeatmapDataForRange = async (
+  startKey: string,
+  endKey: string,
+): Promise<Record<string, number>> => {
+  const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
+
+  return sessions
+    .filter((s) => s.date >= startKey && s.date <= endKey)
+    .reduce<Record<string, number>>((acc, session) => {
+      acc[session.date] = (acc[session.date] ?? 0) + 1;
+      return acc;
+    }, {});
+};
+
 export const getTodayCount = async (): Promise<number> => {
   const todayKey = toDateKey(Date.now());
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];


### PR DESCRIPTION
## Summary

- Adds `← YYYY` / `YYYY →` navigation buttons to the heatmap panel on the stats page so users can browse historical activity beyond the last 52 weeks
- Introduces `getHeatmapDataForRange(startKey, endKey)` in `lib/storage.ts` to efficiently filter sessions by an arbitrary date range
- Adds an `anchorDate` prop to `components/Heatmap.tsx` so the grid can be anchored to any end date instead of always using today
- Uses a `yearOffset` signal (0 = current year, 1 = last year, etc.) in the stats `App.tsx`; the "→" button is disabled when viewing the current year
- The heatmap heading updates to show the selected year number ("This year" → "2025") when navigating
- Dark-mode variants included on the nav buttons
- `bun run build` passes with no errors or warnings

## Test plan

- [ ] Load the stats page — heatmap heading shows "This year", "→" button is disabled
- [ ] Click "← YYYY" — heading changes to the previous year's number, heatmap data shifts back one year
- [ ] Click "YYYY →" — heading returns to "This year", "→" button becomes disabled again
- [ ] Verify sessions from previous years appear correctly in the heatmap cells
- [ ] Verify the current-year view still matches the previous behaviour

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)