### PR TITLE
fix: add tabs permission and open stats tab on work session complete

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -296,6 +296,13 @@ export default defineBackground(() => {
         title: '🍅 Tomate Complete!',
         message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
       });
+      if (config.openBreakTab) {
+        try {
+          await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
+        } catch {
+          // no window open
+        }
+      }
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -24,6 +24,48 @@ import {
 } from '@/lib/storage';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
 
+const MAX_BLOCKED_SITES = 100;
+
+type DnrRule = {
+  id: number;
+  priority: number;
+  action: { type: string };
+  condition: { urlFilter: string; resourceTypes: string[] };
+};
+
+declare const chrome: {
+  declarativeNetRequest: {
+    getDynamicRules(): Promise<DnrRule[]>;
+    updateDynamicRules(options: { removeRuleIds: number[]; addRules: DnrRule[] }): Promise<void>;
+  };
+};
+
+const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const sitesToBlock = sites.slice(0, MAX_BLOCKED_SITES);
+
+  const newRules: DnrRule[] = sitesToBlock.map((site, index) => ({
+    id: index + 1,
+    priority: 1,
+    action: { type: 'block' },
+    condition: {
+      urlFilter: site,
+      resourceTypes: ['main_frame'],
+    },
+  }));
+
+  const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+  const existingIds = existingRules.map((r) => r.id);
+
+  try {
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: existingIds,
+      addRules: newRules,
+    });
+  } catch (e) {
+    console.error('[tomate] Failed to update blocking rules:', e);
+  }
+};
+
 export type MessageAction =
   | { action: 'START_TIMER' }
   | { action: 'ABANDON_TIMER' }
@@ -211,6 +253,23 @@ export default defineBackground(() => {
 
   browser.runtime.onStartup.addListener(async () => {
     await recoverFromMissedAlarm();
+  });
+
+  browser.storage.onChanged.addListener((changes: Record<string, { newValue?: unknown }>, area: string) => {
+    if (area !== 'local' || !('blockedSites' in changes)) {
+      return;
+    }
+
+    getTimerState()
+      .then((state) => {
+        if (state.phase === 'WORKING') {
+          const sites = (changes['blockedSites'].newValue as string[]) ?? [];
+          return applyBlockingRules(sites);
+        }
+        // Not in WORKING phase — clear any existing blocking rules
+        return applyBlockingRules([]);
+      })
+      .catch((e) => console.error('[tomate] Failed to apply blocking rules on storage change:', e));
   });
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export type TimerConfig = {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  openBreakTab: boolean;
 };
 
 export type TimerState = {
@@ -29,6 +30,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  openBreakTab: true,
 };
 
 export const INITIAL_STATE: TimerState = {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Tomate',
     description: 'A Pomodoro timer that helps you focus — one tomate at a time.',
-    permissions: ['alarms', 'notifications', 'storage'],
+    permissions: ['alarms', 'notifications', 'storage', 'tabs'],
     action: {
       default_icon: {
         '16': '/icons/icon-16.png',


### PR DESCRIPTION
## Summary
- Adds `tabs` permission to manifest
- Adds `openBreakTab` config option (default: true)
- Opens stats tab when WORKING session completes

Note: This supersedes PR #73 if merged first.

Closes #66