### PR TITLE
a11y: wrap save confirmation in persistent aria-live region

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, onMount } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
@@ -97,9 +97,9 @@ export default function App() {
             Reset to defaults
           </button>
 
-          <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
-          </Show>
+          <div aria-live="polite" role="status" class="text-sm h-5">
+            <span class={saved() ? 'text-green-600 dark:text-green-400' : ''}>{saved() ? 'Settings saved ✓' : ''}</span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Replaces the `<Show>`-mounted span with a persistent `<div aria-live="polite" role="status">` that stays in the DOM at all times
- Screen readers now receive a polite announcement when "Settings saved ✓" text appears, because the live region is already registered in the accessibility tree before the content changes
- `h-5` on the container prevents layout shift when the message appears/disappears
- Added `dark:text-green-400` alongside `text-green-600` for dark-mode contrast
- Removed the now-unused `Show` import from solid-js

## Test plan

- [ ] Save settings and verify a screen reader (VoiceOver / NVDA) announces "Settings saved ✓" within ~2 seconds
- [ ] Confirm no layout shift occurs in the button row before and after saving
- [ ] Verify the confirmation text appears green in light mode and a lighter green in dark mode
- [ ] `bun run build` passes with no errors

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)