### PR TITLE
a11y: make TimerRing SVG title dynamic with phase and remaining time

### DIFF
--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -3,6 +3,15 @@ import type { TimerPhase } from '@/lib/types';
 type TimerRingProps = {
   progress: number;
   phase: TimerPhase;
+  remaining: string;
+};
+
+const PHASE_LABELS: Record<TimerPhase, string> = {
+  IDLE: 'Timer ready',
+  WORKING: 'Working',
+  SHORT_BREAK: 'Short break',
+  LONG_BREAK: 'Long break',
+  BREAK_SUGGESTION: 'Time for a long break',
 };
 
 const PHASE_COLORS: Record<TimerPhase, string> = {
@@ -21,10 +30,21 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 export default function TimerRing(props: TimerRingProps) {
   const offset = () => CIRCUMFERENCE * (1 - props.progress);
   const color = () => PHASE_COLORS[props.phase];
+  const accessibleTitle = () => {
+    const label = PHASE_LABELS[props.phase];
+    if (props.phase === 'IDLE' || props.phase === 'BREAK_SUGGESTION') return label;
+    return `${label} — ${props.remaining} remaining`;
+  };
 
   return (
-    <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      <title>Timer progress</title>
+    <svg
+      width={SIZE}
+      height={SIZE}
+      class="timer-ring"
+      viewBox={`0 0 ${SIZE} ${SIZE}`}
+      aria-label={accessibleTitle()}
+    >
+      <title>{accessibleTitle()}</title>
       <circle
         cx={SIZE / 2}
         cy={SIZE / 2}

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -115,7 +115,7 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
+      <TimerRing progress={progress()} phase={state().phase} remaining={formatTime()} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
       <div class="text-sm text-gray-500 mt-1">


### PR DESCRIPTION
## Summary

- Fixes the static `<title>Timer progress</title>` in `TimerRing.tsx` — screen readers now hear something meaningful like **"Working — 23:45 remaining"** instead of the same string always
- Adds a `remaining: string` prop to `TimerRingProps` so the formatted countdown can flow into the SVG title
- Adds `aria-label` on the `<svg>` element as a belt-and-suspenders approach for screen readers that do not expose SVG `<title>` elements

**Title output by phase:**
| Phase | Announced title |
|---|---|
| WORKING | `Working — 23:45 remaining` |
| SHORT_BREAK | `Short break — 04:52 remaining` |
| LONG_BREAK | `Long break — 14:30 remaining` |
| IDLE | `Timer ready` |
| BREAK_SUGGESTION | `Time for a long break` |

## Test plan

- [ ] With a screen reader (VoiceOver / NVDA), open the popup — the ring should announce the phase and remaining time
- [ ] Advance the timer; the announced text should update each second
- [ ] When IDLE, confirm "Timer ready" is announced (no time suffix)
- [ ] `bun run build` passes with no errors

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)