### PR TITLE
fix: validate and clamp timer durations to prevent infinite alarm loop

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -20,6 +20,10 @@ export default function App() {
   });
 
   const handleSave = async () => {
+    if (!Number.isFinite(work()) || work() < 1) return;
+    if (!Number.isFinite(shortBreak()) || shortBreak() < 1) return;
+    if (!Number.isFinite(longBreak()) || longBreak() < 1) return;
+
     const config: TimerConfig = {
       workDuration: work() * MS_PER_MINUTE,
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -45,8 +45,18 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const config = (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? { ...DEFAULT_CONFIG };
+
+  if (!Number.isFinite(config.workDuration) || config.workDuration < 1)
+    config.workDuration = DEFAULT_CONFIG.workDuration;
+  if (!Number.isFinite(config.shortBreakDuration) || config.shortBreakDuration < 1)
+    config.shortBreakDuration = DEFAULT_CONFIG.shortBreakDuration;
+  if (!Number.isFinite(config.longBreakDuration) || config.longBreakDuration < 1)
+    config.longBreakDuration = DEFAULT_CONFIG.longBreakDuration;
+
+  return config;
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });


### PR DESCRIPTION
## Summary

- **`entrypoints/options/App.tsx`**: `handleSave` now returns early if any duration signal is non-finite or less than 1, preventing zero/negative values from ever reaching `setConfig` or the `UPDATE_CONFIG` message.
- **`lib/storage.ts`**: `getConfig` now validates each numeric field after reading from storage and falls back to `DEFAULT_CONFIG` values for any that are non-finite or less than 1, defending against corrupt or manually-set storage entries.

Together these close the infinite alarm loop where `workDuration: 0` caused `adjustDuration` to compute an `endTime` in the past, firing the alarm immediately on repeat.

## Test plan

- [ ] Open Options page, clear the Work Duration field (or type 0), click Save — settings should not be saved and "Settings saved" toast should not appear.
- [ ] Repeat for Short Break and Long Break fields.
- [ ] Manually set `chrome.storage.local` `config.workDuration` to `0`, reload the extension — `getConfig` should return the default 25-minute value instead.
- [ ] Verify normal save/load with valid durations still works.
- [ ] Confirm `bun run build` passes with no errors.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)