### PR TITLE
fix: validate message sender identity and action field at runtime

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -139,10 +139,15 @@ export default defineBackground(() => {
     await refreshBadge();
   };
 
-  const handleMessage = async (message: MessageAction) => {
+  const handleMessage = async (message: unknown): Promise<ReturnType<typeof getTimerState> | undefined> => {
+    if (!message || typeof message !== 'object' || !('action' in message)) {
+      console.warn('[tomate] received message with no action:', message);
+      return;
+    }
+
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
 
-    switch (message.action) {
+    switch ((message as MessageAction).action) {
       case 'START_TIMER': {
         const nextState = startTimer(state, config);
         await setTimerState(nextState);
@@ -185,8 +190,9 @@ export default defineBackground(() => {
         return nextState;
       }
       case 'UPDATE_CONFIG': {
-        await setConfig(message.config);
-        const nextState = adjustDuration(state, message.config);
+        const { config: newConfig } = message as Extract<MessageAction, { action: 'UPDATE_CONFIG' }>;
+        await setConfig(newConfig);
+        const nextState = adjustDuration(state, newConfig);
         await setTimerState(nextState);
 
         if (isActivePhase(nextState.phase) && nextState.endTime !== null) {
@@ -213,7 +219,10 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  browser.runtime.onMessage.addListener((message, sender) => {
+    if (sender.id !== browser.runtime.id) return; // reject cross-extension messages
+    return handleMessage(message);
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {


### PR DESCRIPTION
## Summary

- **#238** — `handleMessage` now accepts `unknown` instead of the compile-time-only `MessageAction` cast. A runtime guard checks that the message is an object with an `action` key before entering the switch; malformed messages log a warning and return `undefined` early rather than silently falling through to the `default` case and returning stale state.
- **#236** — The `onMessage.addListener` callback now receives `sender` and rejects any message whose `sender.id` does not match `browser.runtime.id`, preventing cross-extension messages from being processed.
- The `UPDATE_CONFIG` branch was updated to use `Extract<MessageAction, { action: 'UPDATE_CONFIG' }>` to safely narrow the type after the guard, avoiding access to `.config` on `unknown`.

## Test plan

- [ ] Build passes: `bun run build` exits cleanly (verified)
- [ ] Send a message with no `action` field from the extension popup — confirm the warning is logged and no stale state is returned
- [ ] Simulate a cross-extension message (different `sender.id`) — confirm it is silently dropped
- [ ] Verify all existing actions (START_TIMER, ABANDON_TIMER, GET_STATE, ACCEPT_LONG_BREAK, SKIP_LONG_BREAK, UPDATE_CONFIG) still work correctly end-to-end

Closes #236
Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)