### PR TITLE
a11y: add role, tabindex, and aria-label to heatmap day cells

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -175,6 +175,8 @@ export default function Heatmap(props: HeatmapProps) {
 
         {/* Heatmap cells - CSS Grid: 7 rows, auto columns */}
         <div
+          role="grid"
+          aria-label="Activity heatmap"
           class="grid"
           style={{
             "grid-template-rows": `repeat(7, ${cellSize()}px)`,
@@ -189,16 +191,27 @@ export default function Heatmap(props: HeatmapProps) {
                 {(cell) =>
                   cell ? (
                     <div
-                      class="rounded-sm"
+                      role="gridcell"
+                      tabindex="0"
+                      class="rounded-sm focus:outline focus:outline-2 focus:outline-offset-1 focus:outline-blue-500"
                       style={{
                         width: `${cellSize()}px`,
                         height: `${cellSize()}px`,
                         "background-color": getIntensityColor(cell.count),
                       }}
                       title={tooltipText(cell)}
+                      aria-label={tooltipText(cell)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLDivElement).focus();
+                        }
+                      }}
                     />
                   ) : (
                     <div
+                      role="gridcell"
+                      aria-hidden="true"
                       style={{
                         width: `${cellSize()}px`,
                         height: `${cellSize()}px`,


### PR DESCRIPTION
## Summary

- Add `role="grid"` and `aria-label="Activity heatmap"` to the heatmap container div
- Add `role="gridcell"` to every cell (both filled data cells and empty spacers)
- Add `tabindex="0"` to filled cells so keyboard users can Tab through them
- Replace `title`-only tooltip with both `aria-label` (reliable screen reader announcement) and `title` (mouse hover tooltip), reusing the existing `tooltipText()` value — date + session count
- Add `onKeyDown` handler: Enter and Space prevent default scroll and keep focus on the active cell (foundation for any future click action)
- Add Tailwind `focus:outline` ring classes for a visible keyboard focus indicator
- Hide empty spacer cells from assistive technology with `aria-hidden="true"`

Closes #229

## Test plan

- [ ] Tab through the heatmap — each filled day cell should receive focus with a visible blue outline ring
- [ ] With a screen reader (VoiceOver / NVDA), navigate the grid — each cell should announce its `aria-label` (e.g. "3 tomates on 2026-04-09")
- [ ] Hover a cell with the mouse — the `title` tooltip should still appear
- [ ] Press Enter or Space on a focused cell — no page scroll, cell retains focus
- [ ] Empty spacer cells should not appear in the AT reading order

🤖 Generated with [Claude Code](https://claude.com/claude-code)