### PR TITLE
a11y: add aria-label to heatmap legend swatches and stats link button

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -148,6 +148,7 @@ export default function App() {
         type="button"
         onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        aria-label="View all stats"
       >
         View all stats →
       </button>

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -6,11 +6,11 @@ import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } fr
 import Heatmap from '@/components/Heatmap';
 
 const INTENSITY_LEGEND = [
-  { color: '#F3F4F6', label: '0' },
-  { color: '#FCA5A5', label: '1' },
-  { color: '#EF4444', label: '2-3' },
-  { color: '#DC2626', label: '4-5' },
-  { color: '#991B1B', label: '6+' },
+  { color: '#F3F4F6', label: '0', ariaLabel: '0 sessions' },
+  { color: '#FCA5A5', label: '1', ariaLabel: '1 session' },
+  { color: '#EF4444', label: '2-3', ariaLabel: '2-3 sessions' },
+  { color: '#DC2626', label: '4-5', ariaLabel: '4-5 sessions' },
+  { color: '#991B1B', label: '6+', ariaLabel: '6+ sessions' },
 ] as const;
 
 type StatCardProps = {
@@ -70,7 +70,8 @@ export default function App() {
                 <div
                   class="w-3 h-3 rounded-sm"
                   style={{ "background-color": item.color }}
-                  title={item.label}
+                  title={item.ariaLabel}
+                  aria-label={item.ariaLabel}
                 />
               )}
             </For>


### PR DESCRIPTION
## Summary

- **#230** — Heatmap intensity legend swatches in `entrypoints/stats/App.tsx` now carry `aria-label` attributes (e.g. "0 sessions", "1 session", "2-3 sessions") in addition to the existing `title` tooltip, so screen readers announce a meaningful label instead of relying on the unreliable `title` attribute.
- **#234** — The "View all stats →" button in `entrypoints/popup/App.tsx` now has `aria-label="View all stats"`, giving screen readers a clean accessible name free of the arrow character.

## Test plan

- [ ] Open the stats page with a screen reader (e.g. VoiceOver); tab to the legend swatches and confirm each announces "0 sessions", "1 session", "2-3 sessions", "4-5 sessions", "6+ sessions".
- [ ] Mouse-hover each swatch and confirm the tooltip still shows (title attribute retained).
- [ ] Open the popup with a screen reader; navigate to the stats link button and confirm it announces "View all stats" without the arrow character.
- [ ] `bun run build` produces no errors.

Closes #230
Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)