### PR TITLE
a11y: add aria-describedby, aria-invalid, and range hints to options inputs

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -51,8 +51,12 @@ export default function App() {
               max={120}
               value={work()}
               onInput={(e) => setWork(Number(e.currentTarget.value))}
+              aria-describedby="work-hint"
+              aria-invalid={work() < 1 || work() > 120 ? 'true' : 'false'}
+              aria-required="true"
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="work-hint" class="sr-only">Enter a value between 1 and 120</span>
           </label>
 
           <label class="block">
@@ -63,8 +67,12 @@ export default function App() {
               max={30}
               value={shortBreak()}
               onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
+              aria-describedby="short-break-hint"
+              aria-invalid={shortBreak() < 1 || shortBreak() > 30 ? 'true' : 'false'}
+              aria-required="true"
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="short-break-hint" class="sr-only">Enter a value between 1 and 30</span>
           </label>
 
           <label class="block">
@@ -75,8 +83,12 @@ export default function App() {
               max={60}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
+              aria-describedby="long-break-hint"
+              aria-invalid={longBreak() < 5 || longBreak() > 60 ? 'true' : 'false'}
+              aria-required="true"
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="long-break-hint" class="sr-only">Enter a value between 5 and 60</span>
           </label>
         </div>
 


### PR DESCRIPTION
## Summary

- Added `aria-describedby` to each numeric input, pointing to a visually-hidden `<span>` that describes the valid range (e.g. "Enter a value between 1 and 120")
- Added reactive `aria-invalid` on each input — evaluates to `'true'` when the current signal value is outside `min`/`max`, `'false'` otherwise
- Added `aria-required="true"` to all three inputs since they must always hold a value

Affects: Work Duration (1–120 min), Short Break (1–30 min), Long Break (5–60 min).

## Test plan

- [ ] Load the extension options page with a screen reader (e.g. VoiceOver or NVDA); confirm the range hint is announced when each input receives focus
- [ ] Type an out-of-range value (e.g. 200 for Work Duration); confirm `aria-invalid="true"` is reflected in the accessibility tree
- [ ] Restore a valid value; confirm `aria-invalid` returns to `"false"`
- [ ] Confirm `aria-required="true"` is present on all three inputs
- [ ] `bun run build` completes without errors

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)