### PR TITLE
fix: preserve openBreakTab and future config fields in handleSave

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -20,7 +20,9 @@ export default function App() {
   });
 
   const handleSave = async () => {
+    const currentConfig = await getConfig();
     const config: TimerConfig = {
+      ...currentConfig,
       workDuration: work() * MS_PER_MINUTE,
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,
       longBreakDuration: longBreak() * MS_PER_MINUTE,


### PR DESCRIPTION
## Summary

- `handleSave` in `entrypoints/options/App.tsx` was building a `TimerConfig` object from scratch with only the three duration fields, silently dropping any other fields (like `openBreakTab` added by PR #228) every time the user hit Save
- Fixed by reading the current stored config first (`await getConfig()`) and spreading it before applying the form values, so all fields not managed by this form are preserved
- `getConfig` was already imported — no new imports needed

## Test plan

- [ ] Open options page, save settings — verify `openBreakTab` (and any other non-duration fields) survive in `chrome.storage.local`
- [ ] Verify the new-tab-on-break feature still works after saving settings
- [ ] Build passes with no TypeScript errors (`bun run build`)

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)