### PR TITLE
fix: loop recoverFromMissedAlarm until endTime is in future or IDLE

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -115,24 +115,42 @@ export default defineBackground(() => {
   };
 
   const recoverFromMissedAlarm = async (): Promise<void> => {
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
-    const recovered = recoverMissedAlarm(state, config);
+    const [initialState, config] = await Promise.all([getTimerState(), getConfig()]);
+    const firstRecovered = recoverMissedAlarm(initialState, config);
 
-    if (!recovered) {
+    if (!firstRecovered) {
       await refreshBadge();
       return;
     }
 
-    await setTimerState(recovered);
-
-    if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
+    // Track whether the original WORKING phase needs a session persisted
+    if (initialState.phase === 'WORKING') {
+      await persistCompletedSession(initialState, Date.now());
     }
 
-    if (recovered.phase === 'SHORT_BREAK' && recovered.endTime !== null) {
-      await scheduleTimerAlarm(recovered.endTime);
+    // Loop until the resulting state's endTime is in the future, or we reach
+    // a terminal phase (IDLE / BREAK_SUGGESTION). Cap at 10 iterations for safety.
+    const MAX_ITERATIONS = 10;
+    let current = firstRecovered;
+    let iterations = 0;
+
+    while (
+      iterations < MAX_ITERATIONS &&
+      current.endTime !== null &&
+      current.endTime <= Date.now() &&
+      isActivePhase(current.phase)
+    ) {
+      const next = completeTimer(current, config);
+      current = next;
+      iterations++;
+    }
+
+    await setTimerState(current);
+
+    if (isActivePhase(current.phase) && current.endTime !== null) {
+      await scheduleTimerAlarm(current.endTime);
       await startBadgeRefresh();
-    } else if (!isActivePhase(recovered.phase)) {
+    } else {
       await clearActiveAlarms();
     }
 


### PR DESCRIPTION
## Summary

- Fixes #250: multi-phase dormancy left the timer stuck in a spurious SHORT_BREAK after wakeup
- `recoverFromMissedAlarm` in `entrypoints/background.ts` previously called `recoverMissedAlarm` (which calls `completeTimer`) exactly once — enough to transition WORKING→SHORT_BREAK, but not enough to advance past a break that had also already expired
- The fix adds a loop (max 10 iterations) that keeps calling `completeTimer` on the recovered state until `endTime` is in the future, or the phase is terminal (IDLE / BREAK_SUGGESTION)
- Alarm scheduling and badge refresh are deferred to run once on the final settled state

## Test plan

- [ ] Simulate single missed alarm (WORKING expires, browser dormant < break duration): confirm normal SHORT_BREAK recovery
- [ ] Simulate double missed alarm (WORKING + SHORT_BREAK both expire): confirm state lands on IDLE, no spurious break alarm scheduled
- [ ] Simulate 4+ expired phases (stress test): confirm max-iteration cap prevents infinite loop
- [ ] Normal usage (no missed alarm): confirm `recoverMissedAlarm` returns null and path is unchanged
- [ ] `bun run build` passes with no errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)