### PR TITLE
perf: lazy-load config in handleMessage (skip for GET_STATE, ABANDON, SKIP)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -140,10 +140,11 @@ export default defineBackground(() => {
   };
 
   const handleMessage = async (message: MessageAction) => {
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+    const state = await getTimerState();
 
     switch (message.action) {
       case 'START_TIMER': {
+        const config = await getConfig();
         const nextState = startTimer(state, config);
         await setTimerState(nextState);
 
@@ -166,6 +167,7 @@ export default defineBackground(() => {
         return state;
       }
       case 'ACCEPT_LONG_BREAK': {
+        const config = await getConfig();
         const nextState = acceptLongBreak(state, config);
         await setTimerState(nextState);
 


### PR DESCRIPTION
## Summary

- `handleMessage` previously called `Promise.all([getTimerState(), getConfig()])` unconditionally for all 6 message types
- `GET_STATE`, `ABANDON_TIMER`, and `SKIP_LONG_BREAK` never read `config` — they only use `state`
- `config` is now fetched lazily (`await getConfig()`) only inside the three arms that need it: `START_TIMER`, `ACCEPT_LONG_BREAK`, and `UPDATE_CONFIG`

## Test plan

- [ ] Build passes (`bun run build`) — verified ✓
- [ ] Load extension in Chrome, verify timer start/stop/abandon/skip all work correctly
- [ ] Verify settings save and live-adjust active timer duration via `UPDATE_CONFIG`
- [ ] Verify `GET_STATE` and `SKIP_LONG_BREAK` messages no longer trigger a `getConfig` storage read (DevTools > Application > Storage or console instrumentation)

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)