### PR TITLE
fix: add assertNever to handleMessage switch for compile-time exhaustiveness

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -32,6 +32,10 @@ export type MessageAction =
   | { action: 'SKIP_LONG_BREAK' }
   | { action: 'UPDATE_CONFIG'; config: TimerConfig };
 
+function assertNever(x: never): never {
+  throw new Error(`Unhandled message action: ${(x as { action: string }).action}`);
+}
+
 export default defineBackground(() => {
   const ALARM_TIMER = 'tomate-timer';
   const ALARM_BADGE_REFRESH = 'badge-refresh';
@@ -200,7 +204,7 @@ export default defineBackground(() => {
         return nextState;
       }
       default: {
-        return state;
+        return assertNever(message);
       }
     }
   };


### PR DESCRIPTION
## Summary
- Adds an `assertNever` helper at module scope in `entrypoints/background.ts`
- Replaces `default: return state` in the `handleMessage` switch with `default: return assertNever(message)`
- TypeScript will now emit a compile-time error if a new `MessageAction` variant is added without a matching case — the `never` type on `message` makes unhandled cases impossible to miss
- Build verified clean (`bun run build`) with all existing cases handled

## Test plan
- [ ] `bun run build` completes with no TypeScript errors (verified locally)
- [ ] Manually add a new variant to `MessageAction` (e.g. `{ action: 'FOO' }`) without a case — confirm TypeScript reports an error on the `assertNever(message)` call
- [ ] Remove the test variant and confirm the build is clean again
- [ ] Smoke-test the extension in Chrome to confirm runtime behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)