### PR TITLE
fix: TaskLabel dark mode and add openBreakTab UI toggle

### DIFF
--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -11,7 +11,7 @@ export default function TaskLabel(props: TaskLabelProps) {
       onInput={(e) => props.onChange(e.currentTarget.value)}
       placeholder="What are you working on?"
       maxLength={50}
-      class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
+      class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-red-300 dark:focus:ring-red-500 placeholder:text-gray-400 dark:placeholder:text-gray-500"
     />
   );
 }

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -10,6 +10,7 @@ export default function App() {
   const [work, setWork] = createSignal(25);
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
+  const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [saved, setSaved] = createSignal(false);
 
   onMount(async () => {
@@ -17,6 +18,7 @@ export default function App() {
     setWork(Math.round(config.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(config.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
+    setOpenBreakTab(config.openBreakTab ?? true);
   });
 
   const handleSave = async () => {
@@ -24,6 +26,7 @@ export default function App() {
       workDuration: work() * MS_PER_MINUTE,
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,
       longBreakDuration: longBreak() * MS_PER_MINUTE,
+      openBreakTab: openBreakTab(),
     };
     await setConfig(config);
     await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
@@ -35,6 +38,7 @@ export default function App() {
     setWork(Math.round(DEFAULT_CONFIG.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(DEFAULT_CONFIG.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
+    setOpenBreakTab(DEFAULT_CONFIG.openBreakTab);
   };
 
   return (
@@ -77,6 +81,18 @@ export default function App() {
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+          </label>
+
+          <label class="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={openBreakTab()}
+              onChange={(e) => setOpenBreakTab(e.currentTarget.checked)}
+              class="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+            />
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Open stats tab when work session completes
+            </span>
           </label>
         </div>
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export type TimerConfig = {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  openBreakTab: boolean;
 };
 
 export type TimerState = {
@@ -29,6 +30,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  openBreakTab: true,
 };
 
 export const INITIAL_STATE: TimerState = {


### PR DESCRIPTION
## Summary

- Fixes TaskLabel dark mode: adds `dark:` Tailwind variants for border, background, text, ring, and placeholder classes so the input is legible in dark mode
- Adds `openBreakTab: boolean` to `TimerConfig` type and `DEFAULT_CONFIG` (default: `true`)
- Adds a checkbox to the options page — "Open stats tab when work session completes" — wired to `openBreakTab` signal with proper onMount load, handleSave write, and handleReset reset
- Dark label text variant (`dark:text-gray-300`) applied to the checkbox label

## Test plan

- [ ] Toggle the checkbox off and save — verify `openBreakTab: false` is persisted in storage
- [ ] Reload the options page — verify the checkbox state is restored from config
- [ ] Click "Reset to defaults" — verify the checkbox resets to checked (true)
- [ ] Enable system/browser dark mode — verify TaskLabel input has dark background, light text, and dimmed placeholder
- [ ] Run `bun run build` — no TypeScript or build errors

Fixes TaskLabel dark mode and adds openBreakTab UI toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)