### PR TITLE
fix: clear saved-banner timeout before each save and on component cleanup

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,10 +1,12 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, onCleanup, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
 import { DEFAULT_CONFIG, type TimerConfig } from '@/lib/types';
 
 const MS_PER_MINUTE = 60_000;
+
+let savedTimer: ReturnType<typeof setTimeout> | undefined;
 
 export default function App() {
   const [work, setWork] = createSignal(25);
@@ -19,6 +21,10 @@ export default function App() {
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
   });
 
+  onCleanup(() => {
+    clearTimeout(savedTimer);
+  });
+
   const handleSave = async () => {
     const config: TimerConfig = {
       workDuration: work() * MS_PER_MINUTE,
@@ -28,7 +34,8 @@ export default function App() {
     await setConfig(config);
     await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
     setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    clearTimeout(savedTimer);
+    savedTimer = setTimeout(() => setSaved(false), 2000);
   };
 
   const handleReset = () => {


### PR DESCRIPTION
## Summary

- Adds a module-level `savedTimer` ref (`ReturnType<typeof setTimeout> | undefined`) to track the active banner-hide timeout.
- Calls `clearTimeout(savedTimer)` before each new `setTimeout` in `handleSave`, preventing stacked timers from causing the banner to flicker on rapid clicks (Closes #261).
- Adds `onCleanup(() => clearTimeout(savedTimer))` so the pending timer is cancelled if the options page is closed within 2 seconds of saving, preventing `setSaved` from firing on a disposed component (Closes #262).

## Test plan

- [ ] Click Save once — banner appears, disappears after ~2 s.
- [ ] Click Save rapidly (3–4 times in < 2 s) — banner stays visible for exactly 2 s after the *last* click, no flicker.
- [ ] Click Save then close the options page within 2 s — no console errors about setting state on a disposed component.
- [ ] `bun run build` passes with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)