### PR TITLE
perf: wrap stats derived values in createMemo (#260)

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For } from 'solid-js';
+import { createMemo, createResource, For } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -34,10 +34,10 @@ export default function App() {
   const [sessions] = createResource(() => getSessionHistory());
   const [todayCount] = createResource(() => getTodayCount());
 
-  const total = () => computeTotalCount(sessions() ?? []);
-  const week = () => computeWeekCount(sessions() ?? []);
-  const bestDay = () => computeBestDay(sessions() ?? []);
-  const streak = () => computeStreak(sessions() ?? []);
+  const total = createMemo(() => computeTotalCount(sessions() ?? []));
+  const week = createMemo(() => computeWeekCount(sessions() ?? []));
+  const bestDay = createMemo(() => computeBestDay(sessions() ?? []));
+  const streak = createMemo(() => computeStreak(sessions() ?? []));
 
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">


### PR DESCRIPTION
## Summary

- Imports `createMemo` from `solid-js` in `entrypoints/stats/App.tsx`
- Wraps `total`, `week`, `bestDay`, and `streak` in `createMemo()` instead of plain arrow functions
- `bestDay()` was previously called twice in JSX, causing `computeBestDay` to iterate all sessions twice per render; `createMemo` caches the result so the computation runs once and both JSX reads share the cached value
- Each plain function also created an independent reactive subscription to `sessions()`; `createMemo` deduplicates those into a single subscription per derived value

## Test plan

- [x] `bun run build` passes with no errors
- [ ] Open the stats page and verify all five stat cards render correct values
- [ ] Confirm no console errors or reactivity warnings

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)