### PR TITLE
fix(a11y): establish explicit tab order for popup interactive elements

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -16,6 +16,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'IDLE'}>
           <button
             type="button"
+            tabindex="0"
             onClick={props.onStart}
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
           >
@@ -25,6 +26,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'WORKING'}>
           <button
             type="button"
+            tabindex="0"
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
@@ -34,6 +36,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'SHORT_BREAK' || props.phase === 'LONG_BREAK'}>
           <button
             type="button"
+            tabindex="0"
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
@@ -43,6 +46,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'BREAK_SUGGESTION'}>
           <button
             type="button"
+            tabindex="0"
             onClick={props.onAcceptLongBreak}
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
           >
@@ -50,6 +54,7 @@ export default function Controls(props: ControlsProps) {
           </button>
           <button
             type="button"
+            tabindex="0"
             onClick={props.onSkipLongBreak}
             class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >

--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -7,10 +7,12 @@ export default function TaskLabel(props: TaskLabelProps) {
   return (
     <input
       type="text"
+      tabindex="0"
       value={props.value}
       onInput={(e) => props.onChange(e.currentTarget.value)}
       placeholder="What are you working on?"
       maxLength={50}
+      aria-label="Task label"
       class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
     />
   );

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -103,22 +103,33 @@ export default function App() {
 
   return (
     <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
+      {/* Tab order: 1 — Settings */}
       <div class="w-full flex justify-between items-center mb-4">
         <h1 class="text-xl font-bold text-red-600">Tomate</h1>
         <button
           type="button"
+          tabindex="0"
           onClick={() => browser.runtime.openOptionsPage()}
           class="text-gray-400 hover:text-gray-600 text-lg"
-          aria-label="Settings"
+          aria-label="Open settings"
         >
           ⚙️
         </button>
       </div>
 
+      {/* Timer ring — decorative, not interactive */}
       <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
+      {/* Timer time and phase label — informational only, not in tab sequence */}
+      <div
+        class="text-4xl font-mono font-bold text-gray-800 mt-2"
+        aria-live="off"
+        aria-hidden="true"
+      >
+        {formatTime()}
+      </div>
+
+      <div class="text-sm text-gray-500 mt-1" aria-hidden="true">
         <Switch>
           <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
           <Match when={state().phase === 'WORKING'}>Working</Match>
@@ -128,8 +139,10 @@ export default function App() {
         </Switch>
       </div>
 
+      {/* Tab order: 2 — Task label input */}
       <TaskLabel value={label()} onChange={handleLabelChange} />
 
+      {/* Tab order: 3 — Control buttons (Start / Abandon / Skip Break / Long Break + Skip) */}
       <Controls
         phase={state().phase}
         onStart={startTimer}
@@ -144,13 +157,18 @@ export default function App() {
         <Heatmap days={120} data={heatmapData()} />
       </div>
 
-      <button
-        type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+      {/* Tab order: 4 — View stats link */}
+      <a
+        href={browser.runtime.getURL('/stats.html' as '/popup.html')}
+        onClick={(e) => {
+          e.preventDefault();
+          browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') });
+        }}
+        tabindex="0"
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
       >
         View all stats →
-      </button>
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Settings button, task label, control buttons, and stats link all get explicit `tabindex="0"`
- Logical tab sequence: Settings → Task Label → Controls → View Stats
- Timer display and phase label marked `aria-hidden` (informational only)
- Stats link converted to semantic `<a>` tag for correct screen reader navigation
- Fixes #150 (which was incorrectly claimed closed by PR #162 — that PR only touched stats page)

Closes #150