### PR TITLE
fix: sync state with background when countdown reaches 0 to prevent frozen display

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -51,7 +51,18 @@ export default function App() {
   createEffect(() => {
     const s = state();
     if (isActivePhase(s.phase) && s.endTime) {
-      const tick = () => setRemaining(Math.max(0, s.endTime! - Date.now()));
+      let synced = false;
+      const tick = () => {
+        const r = Math.max(0, s.endTime! - Date.now());
+        setRemaining(r);
+        if (r === 0 && !synced) {
+          synced = true;
+          // Timer expired - sync with background to get the new phase
+          browser.runtime.sendMessage({ action: 'GET_STATE' })
+            .then((newState) => { if (newState) setState(newState as TimerState); })
+            .catch(() => {}); // background may be busy processing
+        }
+      };
       tick();
       const id = setInterval(tick, 1000);
       onCleanup(() => clearInterval(id));


### PR DESCRIPTION
## Summary

- When the popup countdown hits `00:00`, the interval kept firing with `remaining === 0` but never synced with the background service worker
- The background had already processed the timer completion and moved to a new phase, while the popup was stuck showing a frozen `00:00`
- Added a `synced` guard flag inside the `createEffect` closure so that exactly once per timer expiry the popup sends a `GET_STATE` message to the background and updates its local state with the response

## Test plan

- [ ] Start a work timer and let it run to zero — confirm the popup transitions away from `00:00` to the next phase (break suggestion or idle) automatically
- [ ] Verify the `synced` guard prevents repeated `GET_STATE` messages (only one request fires per expiry)
- [ ] Confirm abandoning or starting a new timer still works normally (the `createEffect` re-runs with a fresh `synced = false`)
- [ ] Run `bun run build` — no type errors

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)