### PR TITLE
perf: eliminate redundant monthLabels/columns reactive reads inside Heatmap For callback

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -133,12 +133,9 @@ export default function Heatmap(props: HeatmapProps) {
       <div class="flex" style={{ "padding-left": `${labelWidth}px` }}>
         <For each={monthLabels()}>
           {(ml, i) => {
-            const nextCol = () => {
-              const labels = monthLabels();
-              const idx = i();
-              return idx < labels.length - 1 ? labels[idx + 1].column : columns().length;
-            };
-            const width = () => (nextCol() - ml.column) * (cellSize() + gap);
+            const labels = monthLabels();
+            const nextColVal = labels[i() + 1]?.column ?? columns().length;
+            const width = () => (nextColVal - ml.column) * (cellSize() + gap);
             return (
               <span
                 class="text-[9px] text-gray-400 inline-block overflow-hidden"


### PR DESCRIPTION
## Summary

- In `components/Heatmap.tsx`, the `nextCol` arrow function inside the `For` month-labels callback was re-reading `monthLabels()` and `columns()` as reactive dependencies on every render, creating N separate subscriptions (one per label cell) that all fired on any upstream change.
- Replace the reactive arrow with a plain value `nextColVal` computed once per cell-factory invocation, using the `labels` array already read from `monthLabels()` and the current index `i()`.
- The `width` signal still correctly reacts to `cellSize()` changes since it references `nextColVal` (a plain number) and `ml.column` (a plain value from the `For` item).

## Test plan

- [x] `bun run build` passes with no errors or warnings
- [ ] Visually verify month labels still render at correct column widths in the heatmap
- [ ] Confirm no reactive subscription churn in SolidJS devtools when `props.data` or `props.days` changes

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)