### PR TITLE
test: update DEFAULT_CONFIG snapshot and add celebration.ts confetti coverage

### DIFF
--- a/lib/__tests__/celebration.test.ts
+++ b/lib/__tests__/celebration.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockConfetti = vi.fn();
+
+vi.mock('canvas-confetti', () => ({ default: mockConfetti }));
+vi.mock('wxt/browser', () => ({
+  browser: {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://fake/${path}`,
+    },
+  },
+}));
+
+import { playCelebration } from '../celebration';
+
+describe('playCelebration', () => {
+  beforeEach(() => {
+    mockConfetti.mockReset();
+  });
+
+  it('calls confetti with centered origin and spread 40 for work celebration', () => {
+    playCelebration('work');
+
+    expect(mockConfetti).toHaveBeenCalledOnce();
+    expect(mockConfetti).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: { x: 0.5, y: 0.5 },
+        spread: 40,
+      }),
+    );
+  });
+
+  it('calls confetti with centered origin and spread 50 for milestone celebration', () => {
+    playCelebration('milestone');
+
+    expect(mockConfetti).toHaveBeenCalledOnce();
+    expect(mockConfetti).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: { x: 0.5, y: 0.5 },
+        spread: 50,
+      }),
+    );
+  });
+
+  it('calls confetti with centered origin and spread 40 for break celebration', () => {
+    playCelebration('break');
+
+    expect(mockConfetti).toHaveBeenCalledOnce();
+    expect(mockConfetti).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: { x: 0.5, y: 0.5 },
+        spread: 40,
+      }),
+    );
+  });
+
+  it('does not throw an unhandled rejection when confetti throws', () => {
+    mockConfetti.mockImplementation(() => {
+      throw new Error('confetti unavailable');
+    });
+
+    expect(() => playCelebration('work')).not.toThrow();
+  });
+});

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -5,6 +5,7 @@ import {
   acceptLongBreak,
   adjustDuration,
   completeTimer,
+  goalReached,
   getRemainingMs,
   isActivePhase,
   recoverMissedAlarm,
@@ -243,12 +244,38 @@ describe('timer state machine', () => {
     expect(getRemainingMs(state, 10_500)).toBe(0);
   });
 
-  it('uses the default 25/5/30 minute config values', () => {
+  it('uses the default 25/5/30 minute config values with daily goal of 8', () => {
     expect(DEFAULT_CONFIG).toEqual({
       workDuration: 25 * 60 * 1000,
       shortBreakDuration: 5 * 60 * 1000,
       longBreakDuration: 30 * 60 * 1000,
+      dailyGoal: 8,
     });
+  });
+
+  it('goalReached returns false when completedToday is below the daily goal', () => {
+    const state = createState({ completedToday: 7 });
+    const config = createConfig({ dailyGoal: 8 });
+
+    expect(goalReached(state, config)).toBe(false);
+  });
+
+  it('goalReached returns true when completedToday equals the daily goal', () => {
+    const state = createState({ completedToday: 8 });
+    const config = createConfig({ dailyGoal: 8 });
+
+    expect(goalReached(state, config)).toBe(true);
+  });
+
+  it('goalReached returns true when completedToday exceeds the daily goal', () => {
+    const state = createState({ completedToday: 10 });
+    const config = createConfig({ dailyGoal: 8 });
+
+    expect(goalReached(state, config)).toBe(true);
+  });
+
+  it('goalReached returns false when completedToday is zero', () => {
+    expect(goalReached(createState(), DEFAULT_CONFIG)).toBe(false);
   });
 
   it('identifies active phases correctly', () => {

--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -4,28 +4,27 @@ import { browser } from 'wxt/browser';
 const CONFETTI_CONFIGS: Record<string, confetti.Options> = {
   work: {
     particleCount: 150,
-    spread: 80,
-    origin: { y: 0.6 },
+    spread: 40,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#DC2626', '#16A34A', '#FBBF24'],
   },
   milestone: {
     particleCount: 300,
-    spread: 100,
-    origin: { y: 0.6 },
+    spread: 50,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#DC2626', '#16A34A', '#FBBF24', '#7C3AED', '#2563EB'],
   },
   break: {
     particleCount: 50,
-    spread: 60,
-    origin: { y: 0.6 },
+    spread: 40,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#60A5FA', '#34D399', '#A78BFA'],
   },
 };
 
 export const playCelebration = (type: 'work' | 'milestone' | 'break'): void => {
-  confetti(CONFETTI_CONFIGS[type]);
-
   try {
+    confetti(CONFETTI_CONFIGS[type]);
     new Audio(browser.runtime.getURL('/sounds/completion.mp3' as '/popup.html')).play();
   } catch {}
 };

--- a/lib/timer.ts
+++ b/lib/timer.ts
@@ -157,3 +157,6 @@ export const recoverMissedAlarm = (
 
 export const getRemainingMs = (state: TimerState, now?: number): number =>
   Math.max(0, (state.endTime ?? 0) - getNow(now));
+
+export const goalReached = (state: TimerState, config: TimerConfig): boolean =>
+  state.completedToday >= config.dailyGoal;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export type TimerConfig = {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  dailyGoal: number;
 };
 
 export type TimerState = {
@@ -29,6 +30,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  dailyGoal: 8,
 };
 
 export const INITIAL_STATE: TimerState = {


### PR DESCRIPTION
## Summary

- Fixes Issue #271: adds `dailyGoal: 8` to `TimerConfig` type and `DEFAULT_CONFIG`, exports a `goalReached(state, config)` helper from `timer.ts`, updates the snapshot assertion in `timer.test.ts` to include the new field, and adds four `goalReached` behaviour tests (below/at/above/zero)
- Fixes Issue #272: creates `lib/__tests__/celebration.test.ts` with `vi.mock('canvas-confetti')` assertions that `playCelebration` passes `origin: {x: 0.5, y: 0.5}` and the corrected `spread` values (40 for `work`, 50 for `milestone`, 40 for `break`); also covers the try/catch guard so a confetti error does not surface as an unhandled rejection
- Updates `lib/celebration.ts`: applies the confetti bounds fix (centered origin, reduced spread) and moves the `confetti()` call inside the existing try/catch

## Test plan

- [ ] `bun test` passes with 33 tests (only pre-existing `background.test.ts` path-alias error remains)
- [ ] `lib/__tests__/timer.test.ts` — snapshot test now includes `dailyGoal: 8`; four new `goalReached` tests all pass
- [ ] `lib/__tests__/celebration.test.ts` — four new tests pass: correct origin/spread per celebration type, no throw when confetti errors

Closes #271
Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)