### PR TITLE
feat(stats): add empty state and CSV export

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For } from 'solid-js';
+import { createResource, For, Show } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -29,6 +29,22 @@ function StatCard(props: StatCardProps) {
   );
 }
 
+function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
+  const header = 'startTime,endTime,duration,label';
+  const rows = sessions.map((s) => {
+    const label = `"${s.label.replace(/"/g, '""')}"`;
+    return `${s.startTime},${s.endTime},${s.duration},${label}`;
+  });
+  const csv = [header, ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `tomate-sessions-${new Date().toISOString().slice(0, 10)}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export default function App() {
   const [yearData] = createResource(() => getHeatmapData(365));
   const [sessions] = createResource(() => getSessionHistory());
@@ -42,41 +58,60 @@ export default function App() {
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
-        <h1 class="text-2xl font-bold text-red-600 mb-6">Tomate Stats</h1>
-
-        <div class="grid grid-cols-5 gap-3 mb-6">
-          <StatCard label="Total tomates" value={total()} />
-          <StatCard label="Today" value={todayCount() ?? 0} />
-          <StatCard label="This week" value={week()} />
-          <StatCard
-            label="Best day"
-            value={bestDay()?.count ?? '—'}
-            sublabel={bestDay()?.date}
-          />
-          <StatCard
-            label="Current streak"
-            value={`${streak()}d`}
-          />
+        <div class="flex items-center justify-between mb-6">
+          <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
+          <Show when={(sessions() ?? []).length > 0}>
+            <button
+              class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
+              onClick={() => exportCSV(sessions() ?? [])}
+            >
+              Export CSV
+            </button>
+          </Show>
         </div>
 
-        <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-          <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
-          <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
-
-          <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
-            <span>Less</span>
-            <For each={INTENSITY_LEGEND}>
-              {(item) => (
-                <div
-                  class="w-3 h-3 rounded-sm"
-                  style={{ "background-color": item.color }}
-                  title={item.label}
-                />
-              )}
-            </For>
-            <span>More</span>
+        <Show when={(sessions() ?? []).length === 0}>
+          <div class="text-center py-8 text-gray-500 dark:text-gray-400">
+            <p class="text-lg">No sessions yet</p>
+            <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
           </div>
-        </div>
+        </Show>
+
+        <Show when={(sessions() ?? []).length > 0}>
+          <div class="grid grid-cols-5 gap-3 mb-6">
+            <StatCard label="Total tomates" value={total()} />
+            <StatCard label="Today" value={todayCount() ?? 0} />
+            <StatCard label="This week" value={week()} />
+            <StatCard
+              label="Best day"
+              value={bestDay()?.count ?? '—'}
+              sublabel={bestDay()?.date}
+            />
+            <StatCard
+              label="Current streak"
+              value={`${streak()}d`}
+            />
+          </div>
+
+          <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
+            <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
+            <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+
+            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
+              <span>Less</span>
+              <For each={INTENSITY_LEGEND}>
+                {(item) => (
+                  <div
+                    class="w-3 h-3 rounded-sm"
+                    style={{ "background-color": item.color }}
+                    title={item.label}
+                  />
+                )}
+              </For>
+              <span>More</span>
+            </div>
+          </div>
+        </Show>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Empty state (Gap 1):** When `sessions()` is empty the stats page now shows a centred "No sessions yet / Complete your first Pomodoro to see your stats here." message instead of zeros and a blank heatmap. The stat cards and heatmap are hidden until there is at least one session.
- **CSV export (Gap 2):** An "Export CSV" button appears in the top-right of the header whenever sessions exist. Clicking it builds a `startTime,endTime,duration,label` CSV, packages it as a Blob, and triggers a filename-stamped download (`tomate-sessions-YYYY-MM-DD.csv`). Labels containing quotes are escaped per RFC 4180.

Both features are gated on the same `sessions()` resource already loaded by the page — no new storage calls.

## Test plan
- [ ] Open stats page with no storage data → empty-state message is visible; no stat cards, no heatmap
- [ ] Complete one Pomodoro, reopen stats → empty state is gone, stat cards and heatmap appear, Export CSV button appears in header
- [ ] Click Export CSV → file downloads with correct header row and session rows
- [ ] Verify label values containing commas/quotes are properly quoted in the CSV
- [ ] `bun run build` passes with no errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)