### PR TITLE
fix: add aria-live to phase label and scope storage listener to session keys

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -44,8 +44,13 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const onStorageChanged = (changes: Record<string, chrome.storage.StorageChange>) => {
+      if ('sessions' in changes || 'completedToday' in changes) {
+        refreshStats();
+      }
+    };
+    browser.storage.onChanged.addListener(onStorageChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onStorageChanged));
   });
 
   createEffect(() => {
@@ -118,7 +123,7 @@ export default function App() {
       <TimerRing progress={progress()} phase={state().phase} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
+      <div class="text-sm text-gray-500 mt-1" aria-live="polite">
         <Switch>
           <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
           <Match when={state().phase === 'WORKING'}>Working</Match>


### PR DESCRIPTION
## Summary

- **#153**: Added `aria-live="polite"` to the phase label `<div>` (`entrypoints/popup/App.tsx` line 126) so screen readers announce phase transitions (e.g. "Ready to focus" → "Working").
- **#156**: Replaced the bare `refreshStats` storage listener with a scoped `onStorageChanged` handler that only calls `refreshStats()` when `'sessions'` or `'completedToday'` keys appear in the changes object, preventing spurious re-renders on every config/settings write.

## Test plan

- [ ] Build passes (`bun run build`) — verified ✓
- [ ] All 32 unit tests pass (`bun test`) — verified ✓
- [ ] Manual: load extension, open popup, start/complete a session — phase text changes are announced by VoiceOver/NVDA
- [ ] Manual: change a config setting in options — popup stats do NOT re-fetch (confirm via devtools storage listener logs)
- [ ] Manual: complete a session — popup stats DO re-fetch (completedToday key changes)

Closes #153
Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)