### PR TITLE
fix: disable Controls buttons based on current timer phase

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -17,7 +17,8 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
-            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
+            disabled={props.phase !== 'IDLE'}
+            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Start
           </button>
@@ -26,7 +27,8 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={props.phase === 'IDLE'}
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Abandon
           </button>
@@ -35,7 +37,8 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={props.phase === 'IDLE'}
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Skip Break
           </button>
@@ -44,14 +47,16 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAcceptLongBreak}
-            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
+            disabled={props.phase === 'IDLE' || props.phase === 'WORKING'}
+            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Long Break
           </button>
           <button
             type="button"
             onClick={props.onSkipLongBreak}
-            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={props.phase === 'IDLE' || props.phase === 'WORKING'}
+            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Skip
           </button>


### PR DESCRIPTION
## Summary

- Added `disabled` attribute to all buttons in `components/Controls.tsx` based on the current `phase` prop
- Added `disabled:opacity-50 disabled:cursor-not-allowed` Tailwind classes to each button for visual feedback
- Disabled logic:
  - **Start**: `disabled={props.phase !== 'IDLE'}`
  - **Abandon**: `disabled={props.phase === 'IDLE'}`
  - **Skip Break**: `disabled={props.phase === 'IDLE'}`
  - **Long Break** and **Skip** (shown during `BREAK_SUGGESTION`): `disabled={props.phase === 'IDLE' || props.phase === 'WORKING'}`

The component already used `Switch`/`Match` to conditionally render buttons per phase, so in practice these disabled states will rarely be visually active. They serve as defense-in-depth against race conditions where phase state may lag briefly during a transition, preventing spurious `ABANDON_TIMER` messages from reaching the background service worker.

## Test plan

- [ ] Verify Start button renders only in IDLE and is not disabled in that state
- [ ] Verify Abandon button renders only in WORKING phase and is not disabled
- [ ] Verify Skip Break button renders only in SHORT_BREAK / LONG_BREAK and is not disabled
- [ ] Verify Long Break and Skip buttons render only in BREAK_SUGGESTION and are not disabled
- [ ] `bun run build` completes with no errors

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)