### PR TITLE
perf: avoid redundant Set recreation in computeStreak

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For } from 'solid-js';
+import { createMemo, createResource, For } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -34,10 +34,13 @@ export default function App() {
   const [sessions] = createResource(() => getSessionHistory());
   const [todayCount] = createResource(() => getTodayCount());
 
-  const total = () => computeTotalCount(sessions() ?? []);
-  const week = () => computeWeekCount(sessions() ?? []);
-  const bestDay = () => computeBestDay(sessions() ?? []);
-  const streak = () => computeStreak(sessions() ?? []);
+  const sessionList = () => sessions() ?? [];
+  const sessionDateSet = createMemo(() => new Set(sessionList().map((s) => s.date)));
+
+  const total = () => computeTotalCount(sessionList());
+  const week = () => computeWeekCount(sessionList());
+  const bestDay = () => computeBestDay(sessionList());
+  const streak = () => computeStreak(sessionList(), sessionDateSet());
 
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -42,10 +42,10 @@ export const computeBestDay = (
   return { date: bestDate, count: bestCount };
 };
 
-export const computeStreak = (sessions: CompletedSession[]): number => {
+export const computeStreak = (sessions: CompletedSession[], dateSet?: Set<string>): number => {
   if (sessions.length === 0) return 0;
 
-  const sessionDates = new Set(sessions.map((s) => s.date));
+  const sessionDates = dateSet ?? new Set(sessions.map((s) => s.date));
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary

- `computeStreak` now accepts an optional `dateSet?: Set<string>` parameter; when provided, it skips the `new Set(sessions.map(...))` allocation entirely
- In `stats/App.tsx`, a `sessionDateSet` memo is built with `createMemo`, so the Set is constructed only once when `sessions()` changes rather than on every reactive read of `streak()`
- All other stat functions continue to work unchanged; the optional parameter is fully backwards-compatible

## Test plan

- [x] `bun run build` — zero TypeScript errors
- [x] `bun test` — all 32 tests pass
- [ ] Load the stats page with a large session history and confirm streak value is correct

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)