### PR TITLE
fix: declare web_accessible_resources and content_security_policy for MV3

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -14,5 +14,16 @@ export default defineConfig({
         '128': '/icons/icon-128.png',
       },
     },
+    web_accessible_resources: [
+      {
+        resources: ['sounds/*.mp3', 'icons/*.png'],
+        matches: ['<all_urls>'],
+        use_dynamic_url: true,
+      },
+    ],
+    content_security_policy: {
+      extension_pages:
+        "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Adds `web_accessible_resources` declaration for `sounds/*.mp3` and `icons/*.png` so runtime-fetched resources (e.g. `browser.runtime.getURL('/sounds/completion.mp3')`) are accessible from extension pages (fixes #109)
- Adds explicit `content_security_policy` with `extension_pages` key including `'wasm-unsafe-eval'` in `script-src` to allow canvas-confetti to function correctly under MV3 defaults (fixes #110)
- `use_dynamic_url: true` on the WAR entry uses Chrome's opaque dynamic URL feature for better security

## Test plan

- [ ] Run `bun run build` and confirm `.output/chrome-mv3/manifest.json` contains `web_accessible_resources` and `content_security_policy`
- [ ] Load unpacked extension in Chrome, open popup — verify confetti fires on session complete without CSP errors in DevTools console
- [ ] Verify completion sound plays (confirms `sounds/completion.mp3` is accessible at runtime via `browser.runtime.getURL`)
- [ ] Check DevTools console for any remaining CSP violations

Closes #109
Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)