### PR TITLE
fix: catch sendMessage connection error on cold start and fallback to storage

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -32,8 +32,16 @@ export default function App() {
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    try {
+      const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
+      setState(currentState as TimerState);
+    } catch (e) {
+      console.warn('Background not ready, reading storage directly:', e);
+      const result = await chrome.storage.local.get('timerState');
+      if (result.timerState) {
+        setState(result.timerState as TimerState);
+      }
+    }
 
     const pending = await getPendingCelebration();
     if (pending) {


### PR DESCRIPTION
## Summary

- Wraps `browser.runtime.sendMessage({ action: 'GET_STATE' })` in `onMount` in a try/catch
- On connection error (service worker cold start race), falls back to reading `timerState` directly from `chrome.storage.local.get('timerState')`
- Logs a `console.warn` on the fallback path for debuggability
- All remaining `onMount` work (pending celebration, current label, stats refresh, storage listener registration) executes unconditionally after the try/catch — the storage listener is never gated on the sendMessage succeeding

## Test plan

- [ ] Build passes: `bun run build`
- [ ] All 32 tests pass: `bun test`
- [ ] Manual: load extension, kill the service worker via `chrome://extensions`, open popup immediately — popup renders with correct state instead of blank/INITIAL_STATE
- [ ] Normal start: open popup normally — sendMessage succeeds, no regression

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)