### PR TITLE
fix: distinguish install/update in onInstalled and guard notifications API

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -205,8 +205,24 @@ export default defineBackground(() => {
     }
   };
 
-  browser.runtime.onInstalled.addListener(async () => {
-    await recoverFromMissedAlarm();
+  const reschedulePendingTimer = async (): Promise<void> => {
+    const [state] = await Promise.all([getTimerState()]);
+
+    if (isActivePhase(state.phase) && state.endTime !== null) {
+      await scheduleTimerAlarm(state.endTime);
+      await startBadgeRefresh();
+    }
+
+    await refreshBadge();
+  };
+
+  browser.runtime.onInstalled.addListener(async (details) => {
+    if (details.reason === 'install') {
+      await recoverFromMissedAlarm();
+    } else if (details.reason === 'update') {
+      await reschedulePendingTimer();
+    }
+    // 'browser_update': do nothing
   });
 
   browser.runtime.onStartup.addListener(async () => {
@@ -231,21 +247,25 @@ export default defineBackground(() => {
 
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: '🍅 Tomate Complete!',
-        message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-      });
+      if (typeof browser.notifications !== 'undefined') {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: '🍅 Tomate Complete!',
+          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+        });
+      }
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-        message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-      });
+      if (typeof browser.notifications !== 'undefined') {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+        });
+      }
     }
 
     if (isActivePhase(completed.phase) && completed.endTime !== null) {


### PR DESCRIPTION
## Summary
- **#142**: On `browser.runtime.onInstalled` with reason `'update'`, a new `reschedulePendingTimer()` helper re-creates the alarm and badge-refresh cycle if the timer state still has an active phase and a future `endTime`, preventing active timers from being silently dropped on extension update.
- **#144**: The `onInstalled` handler now branches on `details.reason`: `'install'` runs full recovery via `recoverFromMissedAlarm()`, `'update'` only reschedules via `reschedulePendingTimer()`, and `'browser_update'` does nothing.
- **#283**: Each `browser.notifications.create()` call is now wrapped in `if (typeof browser.notifications !== 'undefined')` to prevent crashes on Linux/Chromium builds where the notifications API may be absent.

## Test plan
- [ ] `bun run build` completes with no errors
- [ ] `bun test` — all 32 tests pass
- [ ] Manual: install fresh extension → full setup runs
- [ ] Manual: reload/update extension while a timer is running → alarm is preserved and fires correctly
- [ ] Manual (Linux/Chromium): timer completes without throwing on missing notifications API

Closes #142
Closes #144
Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)