### PR TITLE
perf: run persistCompletedSession and notification in parallel; fix stats.html type cast

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -230,13 +230,15 @@ export default defineBackground(() => {
     await setTimerState(completed);
 
     if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: '🍅 Tomate Complete!',
-        message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-      });
+      await Promise.all([
+        persistCompletedSession(state, Date.now()),
+        browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: '🍅 Tomate Complete!',
+          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+        }),
+      ]);
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -146,7 +146,7 @@ export default function App() {
 
       <button
         type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
       >
         View all stats →


### PR DESCRIPTION
## Summary

- **#176**: In `entrypoints/background.ts`, after a WORKING session completes, `persistCompletedSession()` and `browser.notifications.create()` were called sequentially with `await`. Since neither depends on the other's result, they are now wrapped in `Promise.all([...])` to run concurrently.
- **#164**: In `entrypoints/popup/App.tsx`, `browser.runtime.getURL('/stats.html' as '/popup.html')` had an incorrect type cast that made the IDE believe the argument was `'/popup.html'` instead of `'/stats.html'`. The `as '/popup.html'` cast has been removed.

## Test plan

- [x] `bun run build` passes cleanly
- [x] `bun test` — 32 tests pass, 0 fail
- [x] Verify the "View all stats" button in the popup still navigates to `stats.html` (type cast removal is purely cosmetic for runtime, but IDE hints are now correct)
- [x] Verify that on WORKING session completion, persist and notification fire in parallel without error

Closes #176
Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)