### PR TITLE
test: add getConfig v1→v2 migration and quota exceeded retry coverage

### DIFF
--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -149,4 +149,91 @@ describe('storage helpers', () => {
     await setPendingCelebration(false);
     await expect(getPendingCelebration()).resolves.toBe(false);
   });
+
+  // #178 — getConfig() v1→v2 schema migration
+  it('applies v2 defaults when stored config is missing new fields (v1 migration)', async () => {
+    // Simulate a v1 config stored before dailyGoal and openBreakTab existed
+    const v1Config = {
+      workDuration: 30 * 60 * 1000,
+      shortBreakDuration: 10 * 60 * 1000,
+      longBreakDuration: 20 * 60 * 1000,
+    };
+
+    await fakeBrowser.storage.local.set({ config: v1Config });
+
+    const result = await getConfig();
+
+    // v1 values must be preserved
+    expect(result.workDuration).toBe(30 * 60 * 1000);
+    expect(result.shortBreakDuration).toBe(10 * 60 * 1000);
+    expect(result.longBreakDuration).toBe(20 * 60 * 1000);
+
+    // v2 fields must be filled in with their defaults
+    expect(result.dailyGoal).toBe(DEFAULT_CONFIG.dailyGoal);
+    expect(result.openBreakTab).toBe(DEFAULT_CONFIG.openBreakTab);
+  });
+
+  it('preserves explicitly stored v2 fields and does not overwrite them with defaults', async () => {
+    const v2Config = {
+      workDuration: 25 * 60 * 1000,
+      shortBreakDuration: 5 * 60 * 1000,
+      longBreakDuration: 30 * 60 * 1000,
+      dailyGoal: 4,
+      openBreakTab: false,
+    };
+
+    await fakeBrowser.storage.local.set({ config: v2Config });
+
+    const result = await getConfig();
+
+    expect(result.dailyGoal).toBe(4);
+    expect(result.openBreakTab).toBe(false);
+  });
+
+  // #180 — addCompletedSession() quota-exceeded auto-prune and retry
+  it('prunes the oldest 10 sessions and retries when storage throws QuotaExceededError', async () => {
+    // Pre-populate 15 sessions so there is history to prune
+    const existingSessions = Array.from({ length: 15 }, (_, i) =>
+      createSession(new Date(2026, 2, 1, 9, i, 0).getTime(), { id: `old-${i}` }),
+    );
+    await fakeBrowser.storage.local.set({ sessions: existingSessions });
+
+    const newSession = createSession(new Date(2026, 2, 20, 9, 0, 0).getTime(), {
+      id: 'new-session',
+    });
+
+    const quotaError = Object.assign(new Error('QuotaExceeded'), { name: 'QuotaExceededError' });
+
+    // First call throws; subsequent calls succeed (fakeBrowser default behaviour)
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    let callCount = 0;
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+      if (callCount === 0) {
+        callCount++;
+        throw quotaError;
+      }
+      return originalSet(items);
+    });
+
+    await addCompletedSession(newSession);
+
+    const stored = (await fakeBrowser.storage.local.get('sessions')) as {
+      sessions: CompletedSession[];
+    };
+    const saved = stored.sessions;
+
+    // The first 10 of the 15 original sessions must have been pruned
+    const survivingOld = existingSessions.slice(10);
+    expect(saved).toEqual([...survivingOld, newSession]);
+    expect(saved).toHaveLength(6); // 15 - 10 pruned + 1 new
+  });
+
+  it('re-throws non-quota errors from storage.set', async () => {
+    const genericError = new Error('disk failure');
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValue(genericError);
+
+    const session = createSession(new Date(2026, 2, 20, 9, 0, 0).getTime());
+
+    await expect(addCompletedSession(session)).rejects.toThrow('disk failure');
+  });
 });

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -248,6 +248,8 @@ describe('timer state machine', () => {
       workDuration: 25 * 60 * 1000,
       shortBreakDuration: 5 * 60 * 1000,
       longBreakDuration: 30 * 60 * 1000,
+      dailyGoal: 8,
+      openBreakTab: true,
     });
   });
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -45,16 +45,36 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+const migrateConfig = (raw: Partial<TimerConfig>): TimerConfig => ({
+  ...DEFAULT_CONFIG,
+  ...raw,
+});
+
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<Partial<TimerConfig>>(KEYS.CONFIG);
+  if (!stored) return DEFAULT_CONFIG;
+  return migrateConfig(stored);
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
 };
 
+const QUOTA_EXCEEDED_ERROR = 'QuotaExceededError';
+const PRUNE_COUNT = 10;
+
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  } catch (err) {
+    if (err instanceof Error && err.name === QUOTA_EXCEEDED_ERROR) {
+      const pruned = sessions.slice(PRUNE_COUNT);
+      await browser.storage.local.set({ [KEYS.SESSIONS]: [...pruned, session] });
+    } else {
+      throw err;
+    }
+  }
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,8 @@ export type TimerConfig = {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  dailyGoal: number;
+  openBreakTab: boolean;
 };
 
 export type TimerState = {
@@ -29,6 +31,8 @@ export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  dailyGoal: 8,
+  openBreakTab: true,
 };
 
 export const INITIAL_STATE: TimerState = {


### PR DESCRIPTION
## Summary

- Adds `dailyGoal` and `openBreakTab` fields to `TimerConfig` (v2 schema)
- Implements `migrateConfig()` in `storage.ts` so `getConfig()` back-fills defaults for missing fields when loading a v1 config from storage
- Implements quota-exceeded retry in `addCompletedSession()`: on `QuotaExceededError`, prunes the oldest 10 sessions and retries the write
- Adds 4 new tests in `lib/__tests__/storage.test.ts` covering both paths
- Updates `lib/__tests__/timer.test.ts` to include the new `DEFAULT_CONFIG` fields in the snapshot assertion

## Test plan

- [ ] `bun test lib/__tests__/storage.test.ts` → 14 pass, 0 fail
- [ ] `bun test lib/__tests__/timer.test.ts` → 14 pass, 0 fail
- [ ] v1 migration test: seeds storage with a config missing `dailyGoal`/`openBreakTab`, calls `getConfig()`, verifies defaults are applied while existing values are preserved
- [ ] Quota retry test: mocks `storage.local.set` to throw `QuotaExceededError` on the first call, verifies the oldest 10 sessions are pruned and the new session is saved on retry
- [ ] Non-quota errors are re-thrown unchanged

Closes #178
Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)