### PR TITLE
feat: add GitHub Actions CI pipeline for tests and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Type check (build)
+        run: bun run build
+
+      - name: Run tests
+        run: bun test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary

- Creates `.github/workflows/ci.yml` to run CI on every push to `main` and every PR targeting `main`
- Workflow installs deps with Bun, validates TypeScript via `bun run build` (WXT), and runs the Vitest suite via `bun test`
- Local build verified clean before opening this PR

## Test plan

- [ ] Confirm the new `CI` workflow appears under the Actions tab after this PR is merged or on push to main
- [ ] Open a test PR targeting `main` and verify all three steps (install, build, test) pass in the workflow run
- [ ] Introduce a TypeScript error in a branch PR and confirm the `type check (build)` step fails as expected

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)