### PR TITLE
fix: refresh stats page in real time when sessions storage changes

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For, Show } from 'solid-js';
+import { createResource, For, Show, onMount, onCleanup } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -46,9 +46,22 @@ function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
 }
 
 export default function App() {
-  const [yearData] = createResource(() => getHeatmapData(365));
-  const [sessions] = createResource(() => getSessionHistory());
-  const [todayCount] = createResource(() => getTodayCount());
+  const [yearData, { refetch: refetchYearData }] = createResource(() => getHeatmapData(365));
+  const [sessions, { refetch: refetchSessions }] = createResource(() => getSessionHistory());
+  const [todayCount, { refetch: refetchTodayCount }] = createResource(() => getTodayCount());
+
+  onMount(() => {
+    const handleStorageChange = (changes: Record<string, chrome.storage.StorageChange>) => {
+      if ('sessions' in changes || 'heatmap' in changes) {
+        refetchSessions();
+        refetchYearData();
+        refetchTodayCount();
+      }
+    };
+
+    chrome.storage.onChanged.addListener(handleStorageChange);
+    onCleanup(() => chrome.storage.onChanged.removeListener(handleStorageChange));
+  });
 
   const total = () => computeTotalCount(sessions() ?? []);
   const week = () => computeWeekCount(sessions() ?? []);


### PR DESCRIPTION
## Summary

- Adds `onMount` + `onCleanup` from solid-js to register/unregister the storage listener within the component lifecycle
- Adds a `chrome.storage.onChanged` listener that triggers when either the `'sessions'` or `'heatmap'` storage key changes
- When triggered, all three `createResource` signals (`sessions`, `yearData`, `todayCount`) are refetched automatically via the `{ refetch }` return value from `createResource`
- The listener is removed in `onCleanup` to prevent memory leaks
- Preserves all existing UI: empty-state view, Export CSV button, and conditional `Show` blocks from main

## Test plan

- [ ] Open the stats page in a Chrome tab
- [ ] Start and complete a Pomodoro session via the extension popup
- [ ] Verify that the stats page (Total tomates, Today, This week, streak, heatmap) updates without a manual page refresh
- [ ] Verify no duplicate/stale listeners appear after navigating away and back
- [ ] Run \`bun run build\` — passes
- [ ] Run \`bun test\` — all 32 tests pass

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)