### PR TITLE
fix: add recovery feedback, empty heatmap hint, and settings discoverability

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, Switch, Match, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
@@ -25,15 +25,26 @@ export default function App() {
   const [label, setLabel] = createSignal('');
   const [todayCount, setTodayCount] = createSignal(0);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [loadError, setLoadError] = createSignal(false);
 
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
     setHeatmapData(await getHeatmapData(120));
   };
 
+  const loadState = async () => {
+    setLoadError(false);
+    try {
+      const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
+      if (!currentState) throw new Error('No state returned');
+      setState(currentState as TimerState);
+    } catch {
+      setLoadError(true);
+    }
+  };
+
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    await loadState();
 
     const pending = await getPendingCelebration();
     if (pending) {
@@ -101,6 +112,8 @@ export default function App() {
     labelTimeout = setTimeout(() => setCurrentLabel(value), 300);
   };
 
+  const isHeatmapEmpty = () => Object.keys(heatmapData()).length === 0;
+
   return (
     <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
       <div class="w-full flex justify-between items-center mb-4">
@@ -109,11 +122,25 @@ export default function App() {
           type="button"
           onClick={() => browser.runtime.openOptionsPage()}
           class="text-gray-400 hover:text-gray-600 text-lg"
-          aria-label="Settings"
+          aria-label="Open settings to configure timer durations"
+          title="Open settings to configure timer durations"
         >
           ⚙️
         </button>
       </div>
+
+      <Show when={loadError()}>
+        <div class="w-full mb-3 flex items-center justify-between rounded bg-yellow-100 px-3 py-2 text-sm text-yellow-800">
+          <span>Reconnecting…</span>
+          <button
+            type="button"
+            onClick={loadState}
+            class="ml-2 rounded bg-yellow-200 px-2 py-0.5 text-xs font-medium hover:bg-yellow-300"
+          >
+            Retry
+          </button>
+        </div>
+      </Show>
 
       <TimerRing progress={progress()} phase={state().phase} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
@@ -142,6 +169,9 @@ export default function App() {
 
       <div class="mt-2 w-full">
         <Heatmap days={120} data={heatmapData()} />
+        <Show when={isHeatmapEmpty()}>
+          <p class="mt-1 text-center text-xs text-gray-400">Complete a session to see your activity</p>
+        </Show>
       </div>
 
       <button


### PR DESCRIPTION
## Summary

- **#117** — When `GET_STATE` fails (e.g. service worker crashed), a yellow "Reconnecting…" banner with a **Retry** button appears at the top of the popup. The `loadState` function is extracted and reusable so the retry wires directly back to it.
- **#118** — Below the heatmap grid, a `Show`-guarded helper text "Complete a session to see your activity" appears whenever `heatmapData` is empty (i.e. no keys), giving first-install users clear context instead of a silent empty grid.
- **#119** — The settings gear button now has both `aria-label="Open settings to configure timer durations"` and `title="Open settings to configure timer durations"`, making its purpose discoverable via tooltip on hover and exposed to assistive technology.

## Test plan

- [ ] Fresh install: verify "Complete a session to see your activity" is visible below the heatmap
- [ ] After completing a session: verify helper text disappears and heatmap shows data
- [ ] Kill/disable the background service worker and open popup: verify yellow "Reconnecting…" banner appears
- [ ] Click Retry: verify the banner clears and state loads if the worker is back
- [ ] Hover over the gear icon: verify tooltip "Open settings to configure timer durations" appears
- [ ] `bun run build` — passes ✓
- [ ] `bun test` — 32/32 pass ✓

Closes #117
Closes #118
Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)