### PR TITLE
fix: reset completedToday at midnight, clear rules on reinstall, deduplicate alarms

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -45,6 +45,10 @@ describe('background service worker', () => {
 
     fakeBrowser.action.setBadgeText = vi.fn().mockResolvedValue(undefined);
     fakeBrowser.action.setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+
+    // Stub declarativeNetRequest methods not implemented by fakeBrowser
+    fakeBrowser.declarativeNetRequest.getDynamicRules = vi.fn().mockResolvedValue([]);
+    fakeBrowser.declarativeNetRequest.updateDynamicRules = vi.fn().mockResolvedValue(undefined);
   });
 
   it('starts a timer, persists working state, and creates the timer alarm', async () => {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -40,6 +40,9 @@ export default defineBackground(() => {
   const BADGE_GOLD = '#CA8A04';
   const badgeApi = browser.action;
 
+  // Issue #146: dedup set to prevent double-processing if an alarm fires twice within the same tick
+  const recentlyHandledAlarms = new Set<string>();
+
   const refreshBadge = async (): Promise<void> => {
     const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
 
@@ -205,7 +208,17 @@ export default defineBackground(() => {
     }
   };
 
-  browser.runtime.onInstalled.addListener(async () => {
+  browser.runtime.onInstalled.addListener(async (details) => {
+    // Issue #103: clear stale blocking rules from previous installation on fresh install or update
+    if (details.reason === 'install' || details.reason === 'update') {
+      const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+      if (existingRules.length > 0) {
+        await browser.declarativeNetRequest.updateDynamicRules({
+          removeRuleIds: existingRules.map((rule) => rule.id),
+        });
+      }
+    }
+
     await recoverFromMissedAlarm();
   });
 
@@ -225,12 +238,28 @@ export default defineBackground(() => {
       return;
     }
 
+    // Issue #146: prevent duplicate processing if the alarm fires more than once within the same second
+    const dedupKey = `${alarm.name}:${alarm.scheduledTime}`;
+    if (recentlyHandledAlarms.has(dedupKey)) {
+      return;
+    }
+    recentlyHandledAlarms.add(dedupKey);
+    setTimeout(() => recentlyHandledAlarms.delete(dedupKey), 2_000);
+
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
-    const completed = completeTimer(state, config);
+
+    // Issue #6: reset completedToday if the calendar date has changed since the session began
+    const now = Date.now();
+    const stateWithResetIfNeeded: typeof state =
+      state.phase === 'WORKING' && state.startTime !== null && toDateKey(state.startTime) !== toDateKey(now)
+        ? { ...state, completedToday: 0 }
+        : state;
+
+    const completed = completeTimer(stateWithResetIfNeeded, config);
     await setTimerState(completed);
 
-    if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
+    if (stateWithResetIfNeeded.phase === 'WORKING') {
+      await persistCompletedSession(stateWithResetIfNeeded, now);
       await browser.notifications.create({
         type: 'basic',
         iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
@@ -239,12 +268,12 @@ export default defineBackground(() => {
       });
     }
 
-    if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
+    if (stateWithResetIfNeeded.phase === 'SHORT_BREAK' || stateWithResetIfNeeded.phase === 'LONG_BREAK') {
       await browser.notifications.create({
         type: 'basic',
         iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-        message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+        title: stateWithResetIfNeeded.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+        message: stateWithResetIfNeeded.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
       });
     }
 


### PR DESCRIPTION
## Summary

- **#6 (midnight reset):** In the `onAlarm` handler, before passing state to `completeTimer`, compare `toDateKey(state.startTime)` against `toDateKey(Date.now())`. If the date has changed since the session started, `completedToday` is reset to 0 so the new day starts from 1 after the completion.
- **#103 (stale rules on reinstall):** The `onInstalled` listener now receives `details` and, when `reason` is `'install'` or `'update'`, calls `getDynamicRules()` then `updateDynamicRules({ removeRuleIds: [...] })` to clear any blocking rules left over from the previous installation.
- **#146 (idempotent alarm handler):** Added a `recentlyHandledAlarms: Set<string>` keyed by `alarm.name + scheduledTime`. The handler returns early if the key is already in the set, adds it on first processing, and removes it after 2 seconds. `recentlyHandledAlarms` was not previously present in the code.

The test's `beforeEach` also stubs `fakeBrowser.declarativeNetRequest.getDynamicRules` and `updateDynamicRules` (returning empty/void) since `@webext-core/fake-browser` throws "not implemented" for these methods.

## Test plan

- [x] `bun run build` — TypeScript compiles cleanly
- [x] `bun test` — all 32 tests pass
- [ ] Manual: complete a tomate just after midnight and verify `completedToday` shows 1, not N+1
- [ ] Manual: reinstall/update the extension and verify no sites remain blocked
- [ ] Manual: verify no duplicate session is created if the alarm fires twice rapidly

Closes #6
Closes #103
Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)