### PR TITLE
fix: add help text and maxlength to task label input

### DIFF
--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -5,13 +5,16 @@ type TaskLabelProps = {
 
 export default function TaskLabel(props: TaskLabelProps) {
   return (
-    <input
-      type="text"
-      value={props.value}
-      onInput={(e) => props.onChange(e.currentTarget.value)}
-      placeholder="What are you working on?"
-      maxLength={50}
-      class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
-    />
+    <div class="mt-4">
+      <input
+        type="text"
+        value={props.value}
+        onInput={(e) => props.onChange(e.currentTarget.value)}
+        placeholder="Label this session..."
+        maxLength={100}
+        class="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
+      />
+      <p class="text-xs text-gray-400 mt-1">Optional label for this session (max 100 characters)</p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Updated placeholder text to `"Label this session..."` for clarity
- Increased `maxLength` from 50 to 100 characters
- Added helper text below the input: `"Optional label for this session (max 100 characters)"`
- Wrapped the input in a `div` to accommodate the helper text layout

## Test plan
- [ ] Open the extension popup
- [ ] Verify the task label input shows `"Label this session..."` as placeholder
- [ ] Verify helper text appears below the input
- [ ] Verify typing stops at 100 characters
- [ ] Verify the input still functions correctly (updates timer label)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)