### PR TITLE
fix: use getTodayCount() for BREAK_SUGGESTION badge to fix midnight stale count

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -59,7 +59,7 @@ export default defineBackground(() => {
         break;
       }
       case 'BREAK_SUGGESTION': {
-        text = `${state.completedToday}✓`;
+        text = `${todayCount}✓`;
         color = BADGE_GOLD;
         break;
       }


### PR DESCRIPTION
## Summary

- The `BREAK_SUGGESTION` phase badge was using `state.completedToday` (an in-memory counter) instead of `getTodayCount()` from storage
- After midnight, `state.completedToday` remains stale while `getTodayCount()` resets to the correct day's count via date-keyed storage
- The fix replaces `state.completedToday` with `todayCount` in the `BREAK_SUGGESTION` case — `todayCount` is already fetched via `getTodayCount()` at the top of `refreshBadge`, so no additional async work is needed
- Both `BREAK_SUGGESTION` and `IDLE` phases now use the same data source

## Test plan

- [ ] Build passes (`bun run build`)
- [ ] All 32 tests pass (`bun test`)
- [ ] Manually verify: complete a session near midnight, leave browser open; after midnight, trigger `BREAK_SUGGESTION` — badge should show `0✓` (or next day's count) rather than the stale previous-day count

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)