### PR TITLE
fix: correct heatmap grid layout when fewer than 2 weeks of data

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -76,16 +76,18 @@ export default function Heatmap(props: HeatmapProps) {
 
   const columns = createMemo(() => {
     const cells = grid();
-    const cols: (HeatmapCell | null)[][] = [];
-    let currentCol: (HeatmapCell | null)[] = Array(7).fill(null);
+    if (cells.length === 0) return [];
 
-    const firstRow = cells.length > 0 ? toMonRow(cells[0].dayOfWeek) : 0;
-    for (let r = 0; r < firstRow; r++) {
-      currentCol[r] = null;
-    }
+    const cols: (HeatmapCell | null)[][] = [];
+    // Each column is a 7-element array (Mon–Sun). Slots for days before the
+    // first cell stay null so the grid rows align with the day-of-week axis.
+    // Array(7).fill(null) pre-fills all spacer positions — no extra loop needed.
+    let currentCol: (HeatmapCell | null)[] = Array(7).fill(null);
 
     for (const cell of cells) {
       const row = toMonRow(cell.dayOfWeek);
+      // A new Monday starts a new week column (only if the current one is non-empty,
+      // which avoids a spurious push when the very first cell lands on Monday).
       if (row === 0 && currentCol.some((c) => c !== null)) {
         cols.push(currentCol);
         currentCol = Array(7).fill(null);
@@ -93,6 +95,7 @@ export default function Heatmap(props: HeatmapProps) {
       currentCol[row] = cell;
     }
 
+    // Flush the last (possibly partial) column.
     if (currentCol.some((c) => c !== null)) {
       cols.push(currentCol);
     }


### PR DESCRIPTION
## Summary

- Investigated issue #104 by tracing all column-builder edge cases (1–13 days of data, starting on any day of the week, crossing the Mon→Sun boundary)
- The grid was already functionally correct after PR #273; however the `columns` memo contained dead code that confused the layout intent
- Removed the no-op `firstRow` spacer loop — `Array(7).fill(null)` already pre-fills all offset slots, so the manual null-setting loop was redundant
- Added an early `return []` guard for the empty-cells case
- Added clarifying inline comments so future readers don't re-introduce the redundant loop

## Root cause analysis

The spacer loop (`for (let r = 0; r < firstRow; r++) { currentCol[r] = null; }`) set `null` on array positions that were already `null` from the `Array(7).fill(null)` initialisation. It was a no-op in every code path, but made it look like active layout logic was needed. No cells were ever mis-placed or mis-aligned as a result.

The actual column-push trigger (`row === 0 && currentCol.some(c => c !== null)`) correctly handles all scenarios:
- Data starting on Monday (row=0): no premature push on the first cell
- Data starting mid-week: nulls already fill the leading slots
- Data spanning the Mon boundary: push fires exactly once per new week
- Final partial week: flushed by the trailing `if` block

## Test plan

- [x] `bun run build` passes with no errors
- [x] Manually traced 1-day, 3-day, 5-day, 7-day, 8-day, 14-day scenarios starting on Mon, Wed, Fri, Sat, Sun
- [x] Verified 0-day (empty) case returns `[]` immediately

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)