### PR TITLE
fix: validate and sanitize blocked site hostname input

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,10 +1,26 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, For, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
-import { getConfig, setConfig } from '@/lib/storage';
+import { getBlockedSites, getConfig, setBlockedSites, setConfig } from '@/lib/storage';
 import { DEFAULT_CONFIG, type TimerConfig } from '@/lib/types';
 
 const MS_PER_MINUTE = 60_000;
+
+const sanitizeHostname = (raw: string): string => {
+  let value = raw.trim();
+  // Strip leading scheme
+  value = value.replace(/^https?:\/\//i, '');
+  // Strip leading www.
+  value = value.replace(/^www\./i, '');
+  return value;
+};
+
+const validateHostname = (value: string): string | null => {
+  if (value.length === 0) return 'Enter a hostname only (e.g. twitter.com)';
+  if (/\s/.test(value)) return 'Enter a hostname only (e.g. twitter.com)';
+  if (value.includes('/')) return 'Enter a hostname only (e.g. twitter.com)';
+  return null;
+};
 
 export default function App() {
   const [work, setWork] = createSignal(25);
@@ -12,11 +28,18 @@ export default function App() {
   const [longBreak, setLongBreak] = createSignal(30);
   const [saved, setSaved] = createSignal(false);
 
+  const [blockedSites, setBlockedSitesSignal] = createSignal<string[]>([]);
+  const [hostnameInput, setHostnameInput] = createSignal('');
+  const [hostnameError, setHostnameError] = createSignal<string | null>(null);
+
   onMount(async () => {
     const config = await getConfig();
     setWork(Math.round(config.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(config.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
+
+    const sites = await getBlockedSites();
+    setBlockedSitesSignal(sites);
   });
 
   const handleSave = async () => {
@@ -35,6 +58,47 @@ export default function App() {
     setWork(Math.round(DEFAULT_CONFIG.workDuration / MS_PER_MINUTE));
     setShortBreak(Math.round(DEFAULT_CONFIG.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
+  };
+
+  const handleHostnameInput = (value: string) => {
+    setHostnameInput(value);
+    // Clear error as soon as the user starts typing
+    if (hostnameError() !== null) {
+      setHostnameError(null);
+    }
+  };
+
+  const handleAddSite = async () => {
+    const sanitized = sanitizeHostname(hostnameInput());
+    const error = validateHostname(sanitized);
+    if (error !== null) {
+      setHostnameError(error);
+      return;
+    }
+
+    // Skip duplicates silently
+    if (blockedSites().includes(sanitized)) {
+      setHostnameInput('');
+      return;
+    }
+
+    const updated = [...blockedSites(), sanitized];
+    setBlockedSitesSignal(updated);
+    await setBlockedSites(updated);
+    setHostnameInput('');
+    setHostnameError(null);
+  };
+
+  const handleRemoveSite = async (site: string) => {
+    const updated = blockedSites().filter((s) => s !== site);
+    setBlockedSitesSignal(updated);
+    await setBlockedSites(updated);
+  };
+
+  const handleHostnameKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleAddSite();
+    }
   };
 
   return (
@@ -99,6 +163,60 @@ export default function App() {
 
           <Show when={saved()}>
             <span class="text-sm text-green-600">Settings saved ✓</span>
+          </Show>
+        </div>
+
+        <div class="mt-8">
+          <h2 class="text-sm font-medium text-gray-700 mb-2">Blocked Sites</h2>
+          <p class="text-xs text-gray-500 mb-3">
+            Add hostnames to block during work sessions (e.g. twitter.com).
+          </p>
+
+          <div class="flex gap-2">
+            <div class="flex-1">
+              <input
+                type="text"
+                placeholder="twitter.com"
+                value={hostnameInput()}
+                onInput={(e) => handleHostnameInput(e.currentTarget.value)}
+                onKeyDown={handleHostnameKeyDown}
+                class={`block w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 ${
+                  hostnameError() !== null
+                    ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                    : 'border-gray-300 focus:border-red-500 focus:ring-red-500'
+                }`}
+              />
+              <Show when={hostnameError() !== null}>
+                <p class="mt-1 text-xs text-red-600">{hostnameError()}</p>
+              </Show>
+            </div>
+            <button
+              type="button"
+              onClick={handleAddSite}
+              class="shrink-0 bg-red-600 text-white px-3 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            >
+              Add
+            </button>
+          </div>
+
+          <Show when={blockedSites().length > 0}>
+            <ul class="mt-3 space-y-1">
+              <For each={blockedSites()}>
+                {(site) => (
+                  <li class="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm">
+                    <span class="text-gray-800">{site}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveSite(site)}
+                      class="ml-2 text-gray-400 hover:text-red-600 focus:outline-none"
+                      aria-label={`Remove ${site}`}
+                    >
+                      ✕
+                    </button>
+                  </li>
+                )}
+              </For>
+            </ul>
           </Show>
         </div>
       </div>

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -14,6 +14,7 @@ const KEYS = {
   SESSIONS: 'sessions',
   PENDING_CELEBRATION: 'pendingCelebration',
   CURRENT_LABEL: 'currentLabel',
+  BLOCKED_SITES: 'blockedSites',
 } as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -102,4 +103,11 @@ export const getCurrentLabel = async (): Promise<string> =>
 
 export const setCurrentLabel = async (label: string): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CURRENT_LABEL]: label.slice(0, MAX_LABEL_LENGTH) });
+};
+
+export const getBlockedSites = async (): Promise<string[]> =>
+  (await getStoredValue<string[]>(KEYS.BLOCKED_SITES)) ?? [];
+
+export const setBlockedSites = async (sites: string[]): Promise<void> => {
+  await browser.storage.local.set({ [KEYS.BLOCKED_SITES]: sites });
 };


### PR DESCRIPTION
## Summary

- Adds a Blocked Sites section to the options page with a hostname input
- Automatically strips `http://`, `https://`, and `www.` prefixes on entry
- Rejects empty/whitespace-only strings, strings with spaces, and strings containing `/` (paths)
- Displays an inline error message `"Enter a hostname only (e.g. twitter.com)"` on invalid input
- Error clears immediately when the user starts typing again
- Persists the blocked sites list via `browser.storage.local`

## Test plan

- [ ] Type `https://twitter.com/home` → strips to `twitter.com`, saves correctly
- [ ] Type `www.reddit.com` → strips to `reddit.com`, saves correctly
- [ ] Submit empty input → shows error message
- [ ] Submit `bad hostname` (with space) → shows error message
- [ ] Submit `example.com/path` → shows error message
- [ ] Start typing after an error → error disappears
- [ ] Added sites appear in the list; remove button works
- [ ] Sites persist after closing and reopening the options page
- [ ] `bun run build` passes with no errors

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)