### PR TITLE
fix: add config schema versioning with automatic default-filling for new fields

### DIFF
--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -82,6 +82,51 @@ describe('storage helpers', () => {
     await expect(getConfig()).resolves.toEqual(config);
   });
 
+  it('fills defaults for v1 configs that are missing new fields', async () => {
+    // Simulate a stored v1 config (only the original 3 fields, no configVersion)
+    const v1Config = {
+      workDuration: 30 * 60 * 1000,
+      shortBreakDuration: 5 * 60 * 1000,
+      longBreakDuration: 20 * 60 * 1000,
+    };
+    await fakeBrowser.storage.local.set({ config: v1Config });
+
+    const result = await getConfig();
+
+    // Preserved v1 user-customised values
+    expect(result.workDuration).toBe(30 * 60 * 1000);
+    expect(result.shortBreakDuration).toBe(5 * 60 * 1000);
+    expect(result.longBreakDuration).toBe(20 * 60 * 1000);
+    // New v2 fields filled with defaults
+    expect(result.dailyGoal).toBe(DEFAULT_CONFIG.dailyGoal);
+    expect(result.openBreakTab).toBe(DEFAULT_CONFIG.openBreakTab);
+    // Version bumped to current
+    expect(result.configVersion).toBe(2);
+  });
+
+  it('fills defaults for configs with an explicit configVersion of 1', async () => {
+    const v1Config = {
+      configVersion: 1,
+      workDuration: 25 * 60 * 1000,
+      shortBreakDuration: 5 * 60 * 1000,
+      longBreakDuration: 30 * 60 * 1000,
+    };
+    await fakeBrowser.storage.local.set({ config: v1Config });
+
+    const result = await getConfig();
+
+    expect(result.dailyGoal).toBe(DEFAULT_CONFIG.dailyGoal);
+    expect(result.openBreakTab).toBe(DEFAULT_CONFIG.openBreakTab);
+    expect(result.configVersion).toBe(2);
+  });
+
+  it('returns a v2 config unchanged', async () => {
+    const v2Config = createConfig({ dailyGoal: 10, openBreakTab: false });
+    await setConfig(v2Config);
+
+    await expect(getConfig()).resolves.toEqual(v2Config);
+  });
+
   it('adds a completed session and returns it from history', async () => {
     const session = createSession(new Date(2026, 2, 15, 9, 0, 0).getTime());
 

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -245,9 +245,12 @@ describe('timer state machine', () => {
 
   it('uses the default 25/5/30 minute config values', () => {
     expect(DEFAULT_CONFIG).toEqual({
+      configVersion: 2,
       workDuration: 25 * 60 * 1000,
       shortBreakDuration: 5 * 60 * 1000,
       longBreakDuration: 30 * 60 * 1000,
+      dailyGoal: 8,
+      openBreakTab: true,
     });
   });
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -45,8 +45,22 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<Partial<TimerConfig>>(KEYS.CONFIG);
+
+  if (!stored) {
+    return DEFAULT_CONFIG;
+  }
+
+  // v1 configs are missing configVersion (and any fields added in v2+).
+  // Merge stored values on top of DEFAULT_CONFIG so every new field gets its
+  // default while any value the user already customised is preserved.
+  if (!stored.configVersion || stored.configVersion < 2) {
+    return { ...DEFAULT_CONFIG, ...stored, configVersion: 2 };
+  }
+
+  return stored as TimerConfig;
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,9 +1,12 @@
 export type TimerPhase = 'IDLE' | 'WORKING' | 'SHORT_BREAK' | 'LONG_BREAK' | 'BREAK_SUGGESTION';
 
 export type TimerConfig = {
+  configVersion: number;
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
+  dailyGoal: number;
+  openBreakTab: boolean;
 };
 
 export type TimerState = {
@@ -26,9 +29,12 @@ export type CompletedSession = {
 };
 
 export const DEFAULT_CONFIG: TimerConfig = {
+  configVersion: 2,
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
+  dailyGoal: 8,
+  openBreakTab: true,
 };
 
 export const INITIAL_STATE: TimerState = {


### PR DESCRIPTION
## Summary

- Adds `configVersion: number`, `dailyGoal: number`, and `openBreakTab: boolean` to the `TimerConfig` type and `DEFAULT_CONFIG` (bumped to v2)
- `getConfig()` now reads the stored config as `Partial<TimerConfig>`, detects v1 data (missing `configVersion` or `configVersion < 2`), and merges `DEFAULT_CONFIG` defaults for any absent fields while preserving user-customised values
- Version is set to `2` in all returned configs going forward

## Test plan

- [ ] Empty storage returns full `DEFAULT_CONFIG` (existing test, still passes)
- [ ] Full v2 config roundtrips unchanged (existing test, still passes)
- [ ] Stored v1 config (no `configVersion`) gets new fields filled with defaults; old values preserved
- [ ] Stored config with `configVersion: 1` gets same migration treatment
- [ ] Stored v2 config is returned as-is
- [ ] `bun run build` succeeds with no type errors
- [ ] `bun test lib/__tests__` — all 27 tests pass

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)