### PR TITLE
test: add coverage for invalid/corrupted message payloads in background handler

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -240,6 +240,54 @@ describe('background service worker', () => {
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
   });
 
+  describe('invalid / corrupted message payloads', () => {
+    it('does not throw when the action field is missing and returns undefined', async () => {
+      await initBackground();
+
+      await expect(fakeBrowser.runtime.sendMessage({} as never)).resolves.toBeUndefined();
+    });
+
+    it('does not throw for an unknown action and returns the current state', async () => {
+      const storedState = createState({ phase: 'IDLE', completedToday: 2 });
+      await setTimerState(storedState);
+      await initBackground();
+
+      await expect(
+        fakeBrowser.runtime.sendMessage({ action: 'UNKNOWN_ACTION' } as never),
+      ).resolves.toEqual(storedState);
+    });
+
+    it('rejects UPDATE_CONFIG with a negative workDuration and leaves state unchanged', async () => {
+      const storedState = createState({ phase: 'IDLE' });
+      await setTimerState(storedState);
+      await initBackground();
+
+      const badConfig = createConfig({ workDuration: -1 });
+      const response = await fakeBrowser.runtime.sendMessage({
+        action: 'UPDATE_CONFIG',
+        config: badConfig,
+      });
+
+      expect(response).toEqual(storedState);
+      await expect(getConfig()).resolves.toEqual(DEFAULT_CONFIG);
+    });
+
+    it('rejects UPDATE_CONFIG with NaN workDuration and leaves state unchanged', async () => {
+      const storedState = createState({ phase: 'IDLE' });
+      await setTimerState(storedState);
+      await initBackground();
+
+      const badConfig = createConfig({ workDuration: NaN });
+      const response = await fakeBrowser.runtime.sendMessage({
+        action: 'UPDATE_CONFIG',
+        config: badConfig,
+      });
+
+      expect(response).toEqual(storedState);
+      await expect(getConfig()).resolves.toEqual(DEFAULT_CONFIG);
+    });
+  });
+
   it('updates config during an active timer and recreates the timer alarm', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000);
     const updatedConfig = createConfig({ workDuration: 20_000, shortBreakDuration: 1_000 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -139,8 +139,17 @@ export default defineBackground(() => {
     await refreshBadge();
   };
 
+  const isValidConfig = (config: TimerConfig): boolean => {
+    const durations = [config.workDuration, config.shortBreakDuration, config.longBreakDuration];
+    return durations.every((d) => typeof d === 'number' && Number.isFinite(d) && d >= 1);
+  };
+
   const handleMessage = async (message: MessageAction) => {
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+
+    if (!message || !('action' in message)) {
+      return undefined;
+    }
 
     switch (message.action) {
       case 'START_TIMER': {
@@ -185,6 +194,9 @@ export default defineBackground(() => {
         return nextState;
       }
       case 'UPDATE_CONFIG': {
+        if (!isValidConfig(message.config)) {
+          return state;
+        }
         await setConfig(message.config);
         const nextState = adjustDuration(state, message.config);
         await setTimerState(nextState);


### PR DESCRIPTION
## Summary

- Adds `isValidConfig()` guard inside `handleMessage` so `UPDATE_CONFIG` messages with invalid duration fields (negative, `NaN`, non-finite) are rejected early, returning the current state unchanged without touching storage
- Adds an `action`-presence guard so messages missing the `action` field return `undefined` safely instead of falling through to the switch
- Adds 4 new tests in a dedicated `'invalid / corrupted message payloads'` describe block in `entrypoints/__tests__/background.test.ts`

## Overlap with PR #252

PR #252 (Closes #237, #238) covers:
- The missing-action guard (planned for `handleMessage`)
- Unknown action falling to the default switch case
- Duration validation in `getConfig()` in `lib/storage.ts`

This PR adds the guard **at the `handleMessage` boundary** rather than inside `getConfig`, which is the appropriate layer for rejecting corrupted incoming messages. The tests here are also explicit — verifying the behavior against the specific cases requested in #78 (`workDuration: -1`, `workDuration: NaN`, missing `action`, unknown action).

## Test plan

- [x] `bun test` — 36 tests pass, 0 fail
- [x] Message with no `action` field returns `undefined` without throwing
- [x] Message with `action: 'UNKNOWN_ACTION'` returns current state unchanged
- [x] `UPDATE_CONFIG` with `workDuration: -1` returns current state, config in storage is unchanged
- [x] `UPDATE_CONFIG` with `workDuration: NaN` returns current state, config in storage is unchanged

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)