### PR TITLE
fix: guard alarm handler against non-active phases and log audio errors

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -226,6 +226,12 @@ export default defineBackground(() => {
     }
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+
+    if (!isActivePhase(state.phase) && state.phase !== 'BREAK_SUGGESTION') {
+      await browser.alarms.clear(ALARM_TIMER);
+      return;
+    }
+
     const completed = completeTimer(state, config);
     await setTimerState(completed);
 

--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -27,5 +27,7 @@ export const playCelebration = (type: 'work' | 'milestone' | 'break'): void => {
 
   try {
     new Audio(browser.runtime.getURL('/sounds/completion.mp3' as '/popup.html')).play();
-  } catch {}
+  } catch (e) {
+    console.warn('Celebration audio failed:', e);
+  }
 };


### PR DESCRIPTION
## Summary

- **#45**: Added a phase guard in the `onAlarm` handler in `entrypoints/background.ts`. After loading state, if `!isActivePhase(state.phase) && state.phase !== 'BREAK_SUGGESTION'` (i.e. the phase is `IDLE`), the handler now clears the stale `tomate-timer` alarm and returns early instead of calling `completeTimer` on idle state.
- **#46**: Replaced the empty `catch {}` in `lib/celebration.ts` with `catch (e) { console.warn('Celebration audio failed:', e); }` so audio failures are visible in the console rather than silently swallowed.

## Test plan

- [x] `bun run build` — passes cleanly (72 kB output)
- [x] `bun test` — all 32 tests pass
- [ ] Manually verify: with an idle state, triggering the timer alarm should no longer call `completeTimer` and the stale alarm is cleared
- [ ] Manually verify: with audio blocked/unavailable, the service worker console should show a `console.warn` rather than silently failing

Closes #45
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)