### PR TITLE
fix: prevent double recovery when onInstalled and onStartup both fire

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -33,6 +33,8 @@ export type MessageAction =
   | { action: 'UPDATE_CONFIG'; config: TimerConfig };
 
 export default defineBackground(() => {
+  let recoveryScheduled = false;
+
   const ALARM_TIMER = 'tomate-timer';
   const ALARM_BADGE_REFRESH = 'badge-refresh';
   const BADGE_RED = '#DC2626';
@@ -206,10 +208,14 @@ export default defineBackground(() => {
   };
 
   browser.runtime.onInstalled.addListener(async () => {
+    if (recoveryScheduled) return;
+    recoveryScheduled = true;
     await recoverFromMissedAlarm();
   });
 
   browser.runtime.onStartup.addListener(async () => {
+    if (recoveryScheduled) return;
+    recoveryScheduled = true;
     await recoverFromMissedAlarm();
   });
 


### PR DESCRIPTION
## Summary

- Adds a module-scoped `recoveryScheduled` flag inside `defineBackground()` in `entrypoints/background.ts`
- Both `browser.runtime.onInstalled` and `browser.runtime.onStartup` listeners now check the flag before calling `recoverFromMissedAlarm()`; the second one to fire returns early
- Prevents the alarm being rescheduled twice and a spurious session being recorded when Chrome starts after an update (both events firing in the same service-worker lifecycle)

## Test plan

- [ ] `bun run build` succeeds with no errors
- [ ] `bun test` passes (32/32)
- [ ] Manual: install an update in Chrome while a session was running — verify only one recovery session is recorded and the alarm is not doubled

Closes #8