### PR TITLE
fix: eliminate stale closure in popup tick/countdown interval

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -51,7 +51,10 @@ export default function App() {
   createEffect(() => {
     const s = state();
     if (isActivePhase(s.phase) && s.endTime) {
-      const tick = () => setRemaining(Math.max(0, s.endTime! - Date.now()));
+      const tick = () => {
+        const current = state();
+        setRemaining(Math.max(0, (current.endTime ?? 0) - Date.now()));
+      };
       tick();
       const id = setInterval(tick, 1000);
       onCleanup(() => clearInterval(id));


### PR DESCRIPTION
## Summary

- In `entrypoints/popup/App.tsx`, the `tick` function inside `createEffect` closed over the captured snapshot `s = state()` from when the effect first ran, so `s.endTime` was frozen at that moment
- If the timer was restarted or `state()` updated (e.g. a new `endTime`) while the interval was still running, the countdown continued using the stale `endTime`, causing incorrect remaining-time calculations
- The fix makes `tick` call `state()` on every invocation, reading the live reactive signal value each time

## Test plan

- [x] `bun run build` passes with no errors
- [x] `bun test` — all 32 tests pass
- [ ] Manual: start a timer, abandon and restart it — countdown should immediately reflect the new end time without drift

Closes #11

Generated with [Claude Code](https://claude.ai/claude-code)