### PR TITLE
feat: add keyboard shortcuts (Space/Escape/S) for timer control

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -94,6 +94,38 @@ export default function App() {
     setState(newState as TimerState);
   };
 
+  onMount(() => {
+    const handleKeydown = (e: KeyboardEvent) => {
+      // Don't fire when focus is inside a text input (e.g. TaskLabel)
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+
+      const phase = state().phase;
+
+      if (e.code === 'Space') {
+        e.preventDefault();
+        if (phase === 'IDLE') {
+          startTimer();
+        } else if (phase === 'BREAK_SUGGESTION') {
+          acceptLongBreak();
+        }
+      } else if (e.code === 'Escape') {
+        if (phase === 'WORKING') {
+          abandonTimer();
+        }
+      } else if (e.key === 's' || e.key === 'S') {
+        if (phase === 'BREAK_SUGGESTION' || phase === 'SHORT_BREAK') {
+          skipLongBreak();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeydown);
+    onCleanup(() => document.removeEventListener('keydown', handleKeydown));
+  });
+
   let labelTimeout: ReturnType<typeof setTimeout>;
   const handleLabelChange = (value: string) => {
     setLabel(value);


### PR DESCRIPTION
## Summary

- `Space` starts the timer when IDLE, or accepts the long break when in `BREAK_SUGGESTION` phase
- `Escape` abandons the running timer when in `WORKING` phase
- `S`/`s` skips the break when in `BREAK_SUGGESTION` or `SHORT_BREAK` phase
- Input-guard prevents shortcuts from firing while the TaskLabel text field has focus

## Implementation

Added a second `onMount` block in `entrypoints/popup/App.tsx` that registers a `keydown` listener on `document`. The handler reads the current phase from the SolidJS signal, applies the guard against text inputs, and delegates to the existing `startTimer`, `abandonTimer`, `acceptLongBreak`, and `skipLongBreak` async functions. Cleanup is handled via `onCleanup`.

## Test plan

- [ ] Build passes (`bun run build`)
- [ ] All 32 existing tests pass (`bun test`)
- [ ] With popup open and IDLE: pressing Space starts the timer
- [ ] With popup open and WORKING: pressing Escape resets to IDLE
- [ ] With popup open and BREAK_SUGGESTION: pressing Space accepts long break, pressing S skips it
- [ ] With popup open and SHORT_BREAK: pressing S skips to next work session
- [ ] With focus inside the TaskLabel input, none of the shortcuts fire

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)