### PR TITLE
fix: write timer state and completed session atomically in one storage call

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -20,6 +20,7 @@ import {
   setConfig,
   setPendingCelebration,
   setTimerState,
+  setTimerStateAndSession,
   toDateKey,
 } from '@/lib/storage';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
@@ -92,16 +93,16 @@ export default defineBackground(() => {
     await Promise.all([browser.alarms.clear(ALARM_TIMER), browser.alarms.clear(ALARM_BADGE_REFRESH)]);
   };
 
-  const persistCompletedSession = async (
+  const buildCompletedSession = async (
     state: Awaited<ReturnType<typeof getTimerState>>,
     endTime: number,
-  ): Promise<void> => {
+  ): Promise<CompletedSession | null> => {
     if (state.startTime === null || state.duration === null) {
-      return;
+      return null;
     }
 
     const label = await getCurrentLabel();
-    const session: CompletedSession = {
+    return {
       id: crypto.randomUUID(),
       label,
       startTime: state.startTime,
@@ -109,6 +110,16 @@ export default defineBackground(() => {
       date: toDateKey(state.startTime),
       duration: state.duration,
     };
+  };
+
+  const persistCompletedSession = async (
+    state: Awaited<ReturnType<typeof getTimerState>>,
+    endTime: number,
+  ): Promise<void> => {
+    const session = await buildCompletedSession(state, endTime);
+    if (session === null) {
+      return;
+    }
 
     await addCompletedSession(session);
     await setPendingCelebration(true);
@@ -227,16 +238,26 @@ export default defineBackground(() => {
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
     const completed = completeTimer(state, config);
-    await setTimerState(completed);
 
     if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
+      const now = Date.now();
+      const session = await buildCompletedSession(state, now);
+      if (session !== null) {
+        // Atomic write: timer state and completed session in one storage call,
+        // preventing inconsistency if the service worker dies between the two writes.
+        await setTimerStateAndSession(completed, session);
+        await setPendingCelebration(true);
+      } else {
+        await setTimerState(completed);
+      }
       await browser.notifications.create({
         type: 'basic',
         iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
         title: '🍅 Tomate Complete!',
         message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
       });
+    } else {
+      await setTimerState(completed);
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -57,6 +57,22 @@ export const addCompletedSession = async (session: CompletedSession): Promise<vo
   await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
 };
 
+/**
+ * Atomically writes the new timer state and appends a completed session in a
+ * single `chrome.storage.local.set()` call, preventing inconsistency if the
+ * service worker is killed between the two writes.
+ */
+export const setTimerStateAndSession = async (
+  state: TimerState,
+  session: CompletedSession,
+): Promise<void> => {
+  const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
+  await browser.storage.local.set({
+    [KEYS.TIMER_STATE]: state,
+    [KEYS.SESSIONS]: [...sessions, session],
+  });
+};
+
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
 


### PR DESCRIPTION
## Summary

- Adds `setTimerStateAndSession(state, session)` to `lib/storage.ts`, which writes `timerState` and `sessions` in a single `chrome.storage.local.set()` call
- Extracts `buildCompletedSession` helper in `background.ts` so the `onAlarm` WORKING-completion path can build the session object and pass it to the atomic writer
- Replaces the two sequential writes (`setTimerState` then `addCompletedSession`) in the alarm handler with the single atomic call, eliminating the crash-window inconsistency described in #43
- All other code paths (break completions, missed-alarm recovery, message handlers) are unchanged

## Test plan

- [x] `bun run build` — clean build, no type errors
- [x] `bun test` — 32/32 tests pass
- [ ] Manual smoke test: start a work session, let the alarm fire, verify the badge updates and the session appears in Stats
- [ ] Simulate service worker kill mid-completion (DevTools → Service Workers → Stop) and confirm state + session are consistent on next load

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)