### PR TITLE
fix: log sendAction errors and manage focus on phase transitions

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -15,6 +15,7 @@ export default function Controls(props: ControlsProps) {
       <Switch>
         <Match when={props.phase === 'IDLE'}>
           <button
+            id="start-btn"
             type="button"
             onClick={props.onStart}
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
@@ -24,6 +25,7 @@ export default function Controls(props: ControlsProps) {
         </Match>
         <Match when={props.phase === 'WORKING'}>
           <button
+            id="abandon-btn"
             type="button"
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
@@ -33,6 +35,7 @@ export default function Controls(props: ControlsProps) {
         </Match>
         <Match when={props.phase === 'SHORT_BREAK' || props.phase === 'LONG_BREAK'}>
           <button
+            id="skip-break-btn"
             type="button"
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
@@ -42,6 +45,7 @@ export default function Controls(props: ControlsProps) {
         </Match>
         <Match when={props.phase === 'BREAK_SUGGESTION'}>
           <button
+            id="accept-break-btn"
             type="button"
             onClick={props.onAcceptLongBreak}
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -19,12 +19,22 @@ import TaskLabel from '@/components/TaskLabel';
 import TodayCount from '@/components/TodayCount';
 import Heatmap from '@/components/Heatmap';
 
+/** Map each phase to the id of the primary action button for that phase. */
+const PHASE_PRIMARY_BTN: Record<string, string> = {
+  IDLE: 'start-btn',
+  WORKING: 'abandon-btn',
+  SHORT_BREAK: 'skip-break-btn',
+  LONG_BREAK: 'skip-break-btn',
+  BREAK_SUGGESTION: 'accept-break-btn',
+};
+
 export default function App() {
   const [state, setState] = createSignal<TimerState>(INITIAL_STATE);
   const [remaining, setRemaining] = createSignal(0);
   const [label, setLabel] = createSignal('');
   const [todayCount, setTodayCount] = createSignal(0);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [actionError, setActionError] = createSignal<string | null>(null);
 
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
@@ -60,6 +70,18 @@ export default function App() {
     }
   });
 
+  // Issue #49 — move focus to the primary action button on phase transitions
+  createEffect(() => {
+    const phase = state().phase;
+    const btnId = PHASE_PRIMARY_BTN[phase];
+    if (!btnId) return;
+    // Use queueMicrotask so SolidJS has finished rendering the new DOM before we focus
+    queueMicrotask(() => {
+      const btn = document.getElementById(btnId) as HTMLElement | null;
+      btn?.focus();
+    });
+  });
+
   const formatTime = () => {
     const ms = remaining();
     const totalSeconds = Math.ceil(ms / 1000);
@@ -74,25 +96,25 @@ export default function App() {
     return 1 - remaining() / s.duration;
   };
 
-  const startTimer = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'START_TIMER' });
-    setState(newState as TimerState);
+  /** Send an action to the background service worker and update state.
+   *  Errors are logged and surfaced briefly to the user (#16). */
+  const sendAction = async (action: string) => {
+    setActionError(null);
+    try {
+      const newState = await browser.runtime.sendMessage({ action });
+      setState(newState as TimerState);
+    } catch (err) {
+      console.warn(`[Tomate] sendAction(${action}) failed:`, err);
+      setActionError('Could not reach background. Please try again.');
+      // Auto-clear the error after 3 s so it doesn't linger
+      setTimeout(() => setActionError(null), 3000);
+    }
   };
 
-  const abandonTimer = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
-    setState(newState as TimerState);
-  };
-
-  const acceptLongBreak = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
-    setState(newState as TimerState);
-  };
-
-  const skipLongBreak = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
-    setState(newState as TimerState);
-  };
+  const startTimer = () => sendAction('START_TIMER');
+  const abandonTimer = () => sendAction('ABANDON_TIMER');
+  const acceptLongBreak = () => sendAction('ACCEPT_LONG_BREAK');
+  const skipLongBreak = () => sendAction('SKIP_LONG_BREAK');
 
   let labelTimeout: ReturnType<typeof setTimeout>;
   const handleLabelChange = (value: string) => {
@@ -129,6 +151,10 @@ export default function App() {
       </div>
 
       <TaskLabel value={label()} onChange={handleLabelChange} />
+
+      {actionError() && (
+        <p role="alert" class="text-xs text-red-500 mt-1">{actionError()}</p>
+      )}
 
       <Controls
         phase={state().phase}


### PR DESCRIPTION
## Summary

- **#16 — Silent error swallowing in popup sendAction**: All four action functions (`startTimer`, `abandonTimer`, `acceptLongBreak`, `skipLongBreak`) are consolidated into a single `sendAction()` helper that wraps `browser.runtime.sendMessage` in a try/catch. On failure it calls `console.warn` with the full error and surfaces a brief inline `<p role="alert">` message that auto-clears after 3 s.
- **#49 — a11y: no focus management after timer phase transitions**: A new `createEffect` watches `state().phase` and uses `queueMicrotask` (to let SolidJS finish rendering) to call `.focus()` on the primary action button for each phase. Stable `id` attributes (`start-btn`, `abandon-btn`, `skip-break-btn`, `accept-break-btn`) were added to the four button variants in `Controls.tsx`. A `PHASE_PRIMARY_BTN` map in App.tsx routes each phase to its button id.

## Test plan

- [ ] Build passes (`bun run build`) — confirmed
- [ ] All 32 unit tests pass (`bun test`) — confirmed
- [ ] Load the extension in Chrome; confirm that each time the phase changes the correct button receives keyboard focus
- [ ] Disconnect the background service worker (e.g. by disabling the extension in Manage Extensions mid-session) and click Start — confirm `console.warn` fires and the inline error message appears, then disappears after ~3 s

Closes #16
Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)