### PR TITLE
fix: correct type annotation for storage change listener callback

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,5 +1,6 @@
 import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
 import { browser } from 'wxt/browser';
+import type { Browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
 import { playCelebration } from '@/lib/celebration';
@@ -31,6 +32,10 @@ export default function App() {
     setHeatmapData(await getHeatmapData(120));
   };
 
+  const onStorageChanged = (_changes: Record<string, Browser.storage.StorageChange>) => {
+    void refreshStats();
+  };
+
   onMount(async () => {
     const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
     setState(currentState as TimerState);
@@ -44,8 +49,8 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    browser.storage.onChanged.addListener(onStorageChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onStorageChanged));
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary

- Introduces a dedicated `onStorageChanged` callback with the correct `Record<string, Browser.storage.StorageChange>` type annotation for the `changes` parameter
- Replaces the previously untyped `refreshStats` async function that was passed directly to `browser.storage.onChanged.addListener` (TypeScript accepted it since the function took no params, but the intent was not expressed in the types)
- Uses `Browser.storage.StorageChange` from `wxt/browser` — the project's browser abstraction layer — rather than the raw `chrome.storage.StorageChange` or an inline object type

## Test plan

- [x] `bun run build` passes with no errors
- [x] `npx tsc --noEmit` produces no new type errors
- [ ] Manual smoke test: open popup, complete a session, verify stats refresh

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)