### PR TITLE
fix: clear existing badge refresh alarm before creating new one

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -85,6 +85,7 @@ export default defineBackground(() => {
   };
 
   const startBadgeRefresh = async (): Promise<void> => {
+    await browser.alarms.clear(ALARM_BADGE_REFRESH);
     await browser.alarms.create(ALARM_BADGE_REFRESH, { periodInMinutes: 1 });
   };
 


### PR DESCRIPTION
## Summary

- Adds `await browser.alarms.clear(ALARM_BADGE_REFRESH)` as the first line of `startBadgeRefresh()` in `entrypoints/background.ts`
- Prevents duplicate periodic alarms from being registered when multiple code paths (START_TIMER, ACCEPT_LONG_BREAK, UPDATE_CONFIG, alarm handler, and `recoverFromMissedAlarm`) all call `startBadgeRefresh()`
- Chrome silently replaces alarms today, but the explicit clear makes the intent unambiguous and removes the fragile implicit dependency on browser behavior

Closes #97

## Test plan

- [x] `bun run build` passes with no errors
- [x] `bun test` — all 32 tests pass
- [ ] Manual: open extension, start a timer, stop and restart — confirm no duplicate `badge-refresh` alarms appear in `chrome://extensions` → Service Worker → Alarms

🤖 Generated with [Claude Code](https://claude.com/claude-code)