### PR TITLE
test: add integration tests for background message handlers and badge updates

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -270,4 +270,283 @@ describe('background service worker', () => {
       }),
     );
   });
+
+  // ─── Badge integration tests ────────────────────────────────────────────────
+
+  it('badge-refresh alarm shows remaining minutes in red during WORKING', async () => {
+    // endTime 5 minutes from now → Math.ceil(300_000 / 60_000) = 5
+    const now = 1_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: now,
+        endTime: now + 5 * 60_000,
+        duration: 5 * 60_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: now + 60_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: '5' });
+    expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#DC2626' });
+  });
+
+  it('badge-refresh alarm shows "BRK" in green during SHORT_BREAK', async () => {
+    const now = 1_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    await setTimerState(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: now,
+        endTime: now + DEFAULT_CONFIG.shortBreakDuration,
+        duration: DEFAULT_CONFIG.shortBreakDuration,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: now + 60_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: 'BRK' });
+    expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#16A34A' });
+  });
+
+  it('badge-refresh alarm shows "BRK" in green during LONG_BREAK', async () => {
+    const now = 1_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    await setTimerState(
+      createState({
+        phase: 'LONG_BREAK',
+        startTime: now,
+        endTime: now + DEFAULT_CONFIG.longBreakDuration,
+        duration: DEFAULT_CONFIG.longBreakDuration,
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: now + 60_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: 'BRK' });
+    expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#16A34A' });
+  });
+
+  it('badge shows count-with-checkmark in gold during BREAK_SUGGESTION', async () => {
+    await setTimerState(
+      createState({
+        phase: 'BREAK_SUGGESTION',
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+    );
+    await initBackground();
+
+    // Trigger badge refresh via the badge-refresh alarm
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 60_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: '4✓' });
+    expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#CA8A04' });
+  });
+
+  it('badge shows empty text during IDLE with no completed sessions today', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    // IDLE state with no sessions in storage → getTodayCount returns 0
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 60_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
+  });
+
+  it('ABANDON_TIMER clears the badge after returning to IDLE', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 2_000,
+        duration: 1_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
+
+    // After abandoning, phase is IDLE and there are no sessions → badge text ''
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: '' });
+  });
+
+  // ─── ACCEPT_LONG_BREAK / SKIP_LONG_BREAK ────────────────────────────────────
+
+  it('ACCEPT_LONG_BREAK transitions from BREAK_SUGGESTION to LONG_BREAK and schedules alarm', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    await setTimerState(
+      createState({
+        phase: 'BREAK_SUGGESTION',
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+    );
+    await initBackground();
+
+    const response = await fakeBrowser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
+
+    expect(response).toEqual(
+      createState({
+        phase: 'LONG_BREAK',
+        startTime: 10_000,
+        endTime: 10_000 + DEFAULT_CONFIG.longBreakDuration,
+        duration: DEFAULT_CONFIG.longBreakDuration,
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+    );
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
+      expect.objectContaining({
+        scheduledTime: 10_000 + DEFAULT_CONFIG.longBreakDuration,
+      }),
+    );
+    await expect(fakeBrowser.alarms.get('badge-refresh')).resolves.toEqual(
+      expect.objectContaining({ periodInMinutes: 1 }),
+    );
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: 'BRK' });
+  });
+
+  it('SKIP_LONG_BREAK returns to IDLE and resets cycle position', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    await setTimerState(
+      createState({
+        phase: 'BREAK_SUGGESTION',
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+    );
+    await initBackground();
+
+    const response = await fakeBrowser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
+
+    expect(response).toEqual(
+      createState({
+        phase: 'IDLE',
+        sessionCount: 4,
+        cyclePosition: 0,
+        completedToday: 4,
+      }),
+    );
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toBeUndefined();
+    await expect(fakeBrowser.alarms.get('badge-refresh')).resolves.toBeUndefined();
+  });
+
+  // ─── Long break alarm completion ────────────────────────────────────────────
+
+  it('completes a long break alarm, returns to idle with cycle reset, and notifies', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(9_000);
+    await setTimerState(
+      createState({
+        phase: 'LONG_BREAK',
+        startTime: 6_000,
+        endTime: 8_000,
+        duration: 2_000,
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 8_000 });
+
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'IDLE',
+        sessionCount: 4,
+        cyclePosition: 0,
+        completedToday: 4,
+      }),
+    );
+    await expect(fakeBrowser.alarms.get('badge-refresh')).resolves.toBeUndefined();
+
+    const notifications = await fakeBrowser.notifications.getAll();
+    expect(Object.values(notifications)).toContainEqual(
+      expect.objectContaining({
+        title: "Long Break's Over",
+        message: "Refreshed? Let's go!",
+      }),
+    );
+  });
+
+  // ─── 4th-session WORKING alarm → BREAK_SUGGESTION ───────────────────────────
+
+  it('completing 4th session (cyclePosition 3) transitions to BREAK_SUGGESTION instead of SHORT_BREAK', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+        sessionCount: 3,
+        cyclePosition: 3,
+        completedToday: 3,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'BREAK_SUGGESTION',
+        startTime: null,
+        endTime: null,
+        duration: null,
+        sessionCount: 4,
+        cyclePosition: 3,
+        completedToday: 4,
+      }),
+    );
+    // BREAK_SUGGESTION has no active alarm
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toBeUndefined();
+    // badge shows count with checkmark
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: '4✓' });
+  });
+
+  // ─── ABANDON during SHORT_BREAK ─────────────────────────────────────────────
+
+  it('ABANDON_TIMER during SHORT_BREAK returns to IDLE and clears alarms', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    await setTimerState(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: 1_000,
+        endTime: 2_000,
+        duration: 1_000,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+    await initBackground();
+    await fakeBrowser.alarms.create('tomate-timer', { when: 2_000 });
+    await fakeBrowser.alarms.create('badge-refresh', { periodInMinutes: 1 });
+
+    const response = await fakeBrowser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
+
+    expect(response).toEqual(
+      createState({
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toBeUndefined();
+    await expect(fakeBrowser.alarms.get('badge-refresh')).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds 11 new integration tests to `entrypoints/__tests__/background.test.ts` covering previously untested paths in the message handler and badge pipeline
- Badge phase coverage: WORKING (minutes remaining, red), SHORT_BREAK/LONG_BREAK (BRK, green), BREAK_SUGGESTION (N✓, gold), IDLE with no sessions (empty text)
- New message handler coverage: ACCEPT_LONG_BREAK (→ LONG_BREAK, alarm + badge), SKIP_LONG_BREAK (→ IDLE, cycle reset)
- Alarm completion: long break alarm → IDLE with cycle reset and "Long Break's Over" notification
- Edge cases: ABANDON_TIMER during SHORT_BREAK clears alarms; 4th-session WORKING alarm yields BREAK_SUGGESTION not SHORT_BREAK; ABANDON_TIMER badge cleared to ''

## Test plan

- [x] `bun test` — all 43 tests pass (18 in background.test.ts, 25 across other files)
- [x] No existing tests duplicated — verified against prior coverage before adding

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)