### PR TITLE
fix: return true from async onMessage handler and scope storage listeners

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -213,7 +213,19 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    const promise = handleMessage(message as MessageAction).catch((err: unknown) => {
+      console.error('[tomate] onMessage handler error:', err);
+      return null;
+    });
+
+    // Pipe the resolved value into sendResponse for hosts that require
+    // the return-true + sendResponse protocol (MV2-style runtimes).
+    // Returning the Promise itself supports Chrome MV3 and test fakes that
+    // await the listener's return value directly.
+    promise.then(sendResponse);
+    return promise as unknown as true;
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -44,8 +44,13 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const onSessionsChanged = (changes: Record<string, unknown>) => {
+      if ('sessions' in changes) {
+        void refreshStats();
+      }
+    };
+    browser.storage.onChanged.addListener(onSessionsChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onSessionsChanged));
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary

- **#7 — Unhandled promise rejection in onMessage listener**: The `browser.runtime.onMessage` callback now wraps `handleMessage` in a caught Promise. Any rejection is logged to the console instead of propagating as an unhandled rejection. The resolved value is piped via `sendResponse` for MV2-style runtimes, while the Promise is also returned to support Chrome MV3 and the `@webext-core/fake-browser` test fake that awaits the listener's return value.
- **#48 — Storage change listener fires for all keys unnecessarily**: The `storage.onChanged` listener in `popup/App.tsx` now guards on `'sessions' in changes` before calling `refreshStats()`, preventing unnecessary re-renders triggered by `timerState`, `config`, `currentLabel`, and `pendingCelebration` writes.

## Test plan

- [x] `bun run build` — clean build, no errors
- [x] `bun test` — all 32 tests pass
- [ ] Manual: start a timer in the popup and verify the badge and state update correctly
- [ ] Manual: verify no "Uncaught promise rejection" errors appear in the background service worker console
- [ ] Manual: verify popup stats only refresh after a work session completes (not on every storage write)

Closes #7
Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)