### PR TITLE
fix: sync state from background when countdown reaches zero

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -51,7 +51,16 @@ export default function App() {
   createEffect(() => {
     const s = state();
     if (isActivePhase(s.phase) && s.endTime) {
-      const tick = () => setRemaining(Math.max(0, s.endTime! - Date.now()));
+      let synced = false;
+      const tick = async () => {
+        const r = Math.max(0, s.endTime! - Date.now());
+        setRemaining(r);
+        if (r === 0 && !synced) {
+          synced = true;
+          const fresh = await browser.runtime.sendMessage({ action: 'GET_STATE' });
+          setState(fresh as TimerState);
+        }
+      };
       tick();
       const id = setInterval(tick, 1000);
       onCleanup(() => clearInterval(id));


### PR DESCRIPTION
## Summary

- When the popup countdown interval ticks to 00:00, the UI previously had no mechanism to detect that the background had advanced to the next phase.
- Added async awareness to the `setInterval` tick callback: when `remaining` reaches `0`, a `GET_STATE` message is sent to the background service worker and the result is used to update the `state` signal, causing the UI to transition to the correct new phase.
- A `synced` boolean guard flag (scoped to each effect invocation, cleaned up automatically when the effect re-runs) prevents duplicate requests on subsequent ticks after zero is reached.

## Test plan

- [ ] Verify `bun run build` passes (no TS/Vite errors)
- [ ] Verify `bun test` passes (32/32)
- [ ] Manual: open popup while a timer is running, wait for it to expire — confirm the display transitions from 00:00 to the next phase (BREAK_SUGGESTION or IDLE) without requiring a popup re-open

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)