### PR TITLE
fix: use getTodayCount for BREAK_SUGGESTION badge to prevent midnight drift

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -59,7 +59,7 @@ export default defineBackground(() => {
         break;
       }
       case 'BREAK_SUGGESTION': {
-        text = `${state.completedToday}✓`;
+        text = `${todayCount}✓`;
         color = BADGE_GOLD;
         break;
       }


### PR DESCRIPTION
## Summary

- In `refreshBadge`, the `BREAK_SUGGESTION` case was displaying `state.completedToday` which is stored in the timer state and can be stale after midnight
- Changed to use `todayCount` (already fetched fresh via `getTodayCount()` in the same `Promise.all`) — consistent with how the `IDLE` case handles the count
- One-line change: `${state.completedToday}✓` → `${todayCount}✓`

## Test plan

- [x] `bun run build` passes
- [x] `bun test` passes (32/32)
- [ ] Manually verify: let a pomodoro complete near midnight, check that the badge count shown in BREAK_SUGGESTION state reflects today's sessions rather than a stale counter from yesterday

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)