### PR TITLE
fix: guard browser.tabs availability and log tabs.create errors

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -237,11 +237,11 @@ export default defineBackground(() => {
         title: '🍅 Tomate Complete!',
         message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
       });
-      if (config.openBreakTab !== false) {
+      if (typeof browser.tabs !== 'undefined' && config.openBreakTab !== false) {
         try {
           await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
-        } catch {
-          // tab creation can fail if no browser window is open
+        } catch (err) {
+          console.warn('[tomate] browser.tabs.create() failed (no open window?):', err);
         }
       }
     }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -45,8 +45,10 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<Partial<TimerConfig>>(KEYS.CONFIG);
+  return { ...DEFAULT_CONFIG, ...stored };
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });


### PR DESCRIPTION
## Summary

- Added `typeof browser.tabs !== 'undefined'` guard before the `browser.tabs.create()` call in `entrypoints/background.ts`, protecting against environments where `browser.tabs` is not available (e.g. headless mode, no open Chrome window)
- Changed the silent catch block to log a `console.warn` with the error, so failures are observable in extension service-worker logs
- Updated `getConfig()` in `lib/storage.ts` to merge stored config with `DEFAULT_CONFIG` using spread (`{ ...DEFAULT_CONFIG, ...stored }`), so any field missing from stored config (e.g. `openBreakTab` for users who installed before this field existed) correctly falls back to the default value

## Test plan

- [x] `bun run build` passes
- [x] `bun test` passes (32/32)
- [ ] Manual: disable/close all Chrome windows, trigger a work-session completion via alarm — extension should not crash; `console.warn` should appear in service-worker logs

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)