### PR TITLE
fix: merge stored config with DEFAULT_CONFIG to ensure new fields get defaults

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -45,8 +45,11 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<Partial<TimerConfig>>(KEYS.CONFIG);
+  if (!stored) return DEFAULT_CONFIG;
+  return { ...DEFAULT_CONFIG, ...stored };
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });


### PR DESCRIPTION
## Summary

- `getConfig()` previously returned the raw stored object verbatim, so any new fields added to `TimerConfig` after a user's first install would come back as `undefined`
- Fix spreads `DEFAULT_CONFIG` under the stored value, guaranteeing every key in `DEFAULT_CONFIG` has a fallback for existing installs
- Forward-compatible: any future field added to `DEFAULT_CONFIG` will automatically be backfilled — no manual migration needed

## Test plan

- [x] `bun run build` passes (851 ms, no errors)
- [x] `bun test` passes (32/32 tests)
- [x] Existing stored configs missing `openBreakTab` will now correctly default to `true` instead of `undefined`

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)