### PR TITLE
fix: prevent duplicate sessions from rapid double alarm fires

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -240,6 +240,26 @@ describe('background service worker', () => {
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
   });
 
+  it('deduplicates rapid double alarm fires and creates only one session', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+      }),
+    );
+    await initBackground();
+
+    // Simulate Chrome firing the same alarm twice in rapid succession (same scheduledTime bucket)
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+
+    const sessions = await getSessionHistory();
+    expect(sessions).toHaveLength(1);
+  });
+
   it('updates config during an active timer and recreates the timer alarm', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000);
     const updatedConfig = createConfig({ workDuration: 20_000, shortBreakDuration: 1_000 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -215,6 +215,8 @@ export default defineBackground(() => {
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
 
+  const recentlyHandledAlarms = new Set<string>();
+
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {
       await refreshBadge();
@@ -224,6 +226,13 @@ export default defineBackground(() => {
     if (alarm.name !== ALARM_TIMER) {
       return;
     }
+
+    const dedupeKey = `${alarm.name}:${Math.floor(alarm.scheduledTime / 5000)}`;
+    if (recentlyHandledAlarms.has(dedupeKey)) {
+      return;
+    }
+    recentlyHandledAlarms.add(dedupeKey);
+    setTimeout(() => recentlyHandledAlarms.delete(dedupeKey), 10_000);
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
     const completed = completeTimer(state, config);


### PR DESCRIPTION
## Summary

- Chrome's alarm API can occasionally fire the same alarm twice in rapid succession, causing `persistCompletedSession` to run twice and creating two `CompletedSession` records for a single work period.
- Added a `recentlyHandledAlarms: Set<string>` inside the `onAlarm` listener. Before processing a `tomate-timer` alarm, a deduplication key is derived as `${alarm.name}:${Math.floor(alarm.scheduledTime / 5000)}`. If the key is already in the set the handler returns immediately; otherwise it is added, the alarm is processed, and the key is removed after 10 seconds.
- Added a regression test that triggers the same alarm twice and asserts only one session is persisted.

## Test plan

- [x] `bun run build` — passes, no type errors
- [x] `bun test` — all 33 tests pass including the new deduplication test
- [ ] Manual: start a Pomodoro in Chrome, verify one session is saved per work period

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)