### PR TITLE
fix: store and clear saved-banner timeout to prevent stacking and leak

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, onCleanup, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
@@ -12,6 +12,9 @@ export default function App() {
   const [longBreak, setLongBreak] = createSignal(30);
   const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [saved, setSaved] = createSignal(false);
+  let savedTimer: ReturnType<typeof setTimeout> | undefined;
+
+  onCleanup(() => clearTimeout(savedTimer));
 
   onMount(async () => {
     const config = await getConfig();
@@ -31,7 +34,8 @@ export default function App() {
     await setConfig(config);
     await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
     setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    clearTimeout(savedTimer);
+    savedTimer = setTimeout(() => setSaved(false), 2000);
   };
 
   const handleReset = () => {


### PR DESCRIPTION
## Summary
- Import `onCleanup` from `solid-js` and add a component-level `savedTimer` variable to track the active timeout ID
- In `handleSave`, call `clearTimeout(savedTimer)` before scheduling a new one so rapid saves cancel any pending reset instead of stacking multiple timers (fixes #261)
- Register `onCleanup(() => clearTimeout(savedTimer))` so the timeout is cancelled if the options page unmounts within the 2-second window, preventing a state update on a disposed component (fixes #262)

## Test plan
- [ ] Build passes (`bun run build`)
- [ ] All 32 tests pass (`bun test`)
- [ ] Manual: open options page, click Save rapidly several times — banner shows steadily for 2s after the last click, no flicker
- [ ] Manual: click Save then immediately close the tab — no errors in console about updating disposed signals

Closes #261
Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)