### PR TITLE
perf: skip getConfig() for GET_STATE, ABANDON, and SKIP_LONG_BREAK handlers

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -140,40 +140,16 @@ export default defineBackground(() => {
   };
 
   const handleMessage = async (message: MessageAction) => {
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+    const state = await getTimerState();
 
     switch (message.action) {
-      case 'START_TIMER': {
-        const nextState = startTimer(state, config);
-        await setTimerState(nextState);
-
-        if (nextState.endTime !== null) {
-          await scheduleTimerAlarm(nextState.endTime);
-          await startBadgeRefresh();
-        }
-
-        await refreshBadge();
-        return nextState;
+      case 'GET_STATE': {
+        return state;
       }
       case 'ABANDON_TIMER': {
         const nextState = abandonTimer(state);
         await setTimerState(nextState);
         await clearActiveAlarms();
-        await refreshBadge();
-        return nextState;
-      }
-      case 'GET_STATE': {
-        return state;
-      }
-      case 'ACCEPT_LONG_BREAK': {
-        const nextState = acceptLongBreak(state, config);
-        await setTimerState(nextState);
-
-        if (nextState.endTime !== null) {
-          await scheduleTimerAlarm(nextState.endTime);
-          await startBadgeRefresh();
-        }
-
         await refreshBadge();
         return nextState;
       }
@@ -184,23 +160,52 @@ export default defineBackground(() => {
         await refreshBadge();
         return nextState;
       }
-      case 'UPDATE_CONFIG': {
-        await setConfig(message.config);
-        const nextState = adjustDuration(state, message.config);
-        await setTimerState(nextState);
-
-        if (isActivePhase(nextState.phase) && nextState.endTime !== null) {
-          await scheduleTimerAlarm(nextState.endTime);
-          await startBadgeRefresh();
-        } else {
-          await clearActiveAlarms();
-        }
-
-        await refreshBadge();
-        return nextState;
-      }
       default: {
-        return state;
+        const config = await getConfig();
+        switch (message.action) {
+          case 'START_TIMER': {
+            const nextState = startTimer(state, config);
+            await setTimerState(nextState);
+
+            if (nextState.endTime !== null) {
+              await scheduleTimerAlarm(nextState.endTime);
+              await startBadgeRefresh();
+            }
+
+            await refreshBadge();
+            return nextState;
+          }
+          case 'ACCEPT_LONG_BREAK': {
+            const nextState = acceptLongBreak(state, config);
+            await setTimerState(nextState);
+
+            if (nextState.endTime !== null) {
+              await scheduleTimerAlarm(nextState.endTime);
+              await startBadgeRefresh();
+            }
+
+            await refreshBadge();
+            return nextState;
+          }
+          case 'UPDATE_CONFIG': {
+            await setConfig(message.config);
+            const nextState = adjustDuration(state, message.config);
+            await setTimerState(nextState);
+
+            if (isActivePhase(nextState.phase) && nextState.endTime !== null) {
+              await scheduleTimerAlarm(nextState.endTime);
+              await startBadgeRefresh();
+            } else {
+              await clearActiveAlarms();
+            }
+
+            await refreshBadge();
+            return nextState;
+          }
+          default: {
+            return state;
+          }
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary

- `handleMessage` previously called `getConfig()` eagerly for all 6 action types via `Promise.all([getTimerState(), getConfig()])`, even for actions that never use config
- Refactored to load only `getTimerState()` upfront, then lazily load `getConfig()` only in the `default` branch covering `START_TIMER`, `ACCEPT_LONG_BREAK`, and `UPDATE_CONFIG`
- `GET_STATE`, `ABANDON_TIMER`, and `SKIP_LONG_BREAK` now avoid the unnecessary storage read entirely

## Test plan

- [x] `bun run build` passes with no errors
- [x] `bun test` — all 32 tests pass

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)