### PR TITLE
perf: wrap stats derived values in createMemo and fix Heatmap reactive deps

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -133,10 +133,11 @@ export default function Heatmap(props: HeatmapProps) {
       <div class="flex" style={{ "padding-left": `${labelWidth}px` }}>
         <For each={monthLabels()}>
           {(ml, i) => {
+            const labelsSnapshot = monthLabels();
+            const colCount = columns().length;
             const nextCol = () => {
-              const labels = monthLabels();
               const idx = i();
-              return idx < labels.length - 1 ? labels[idx + 1].column : columns().length;
+              return idx < labelsSnapshot.length - 1 ? labelsSnapshot[idx + 1].column : colCount;
             };
             const width = () => (nextCol() - ml.column) * (cellSize() + gap);
             return (

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For, Show } from 'solid-js';
+import { createMemo, createResource, For, Show } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -50,10 +50,10 @@ export default function App() {
   const [sessions] = createResource(() => getSessionHistory());
   const [todayCount] = createResource(() => getTodayCount());
 
-  const total = () => computeTotalCount(sessions() ?? []);
-  const week = () => computeWeekCount(sessions() ?? []);
-  const bestDay = () => computeBestDay(sessions() ?? []);
-  const streak = () => computeStreak(sessions() ?? []);
+  const total = createMemo(() => computeTotalCount(sessions() ?? []));
+  const week = createMemo(() => computeWeekCount(sessions() ?? []));
+  const bestDay = createMemo(() => computeBestDay(sessions() ?? []));
+  const streak = createMemo(() => computeStreak(sessions() ?? []));
 
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">


### PR DESCRIPTION
## Summary

- **#260**: Converted `total`, `week`, `bestDay`, and `streak` in `entrypoints/stats/App.tsx` from plain arrow functions to `createMemo`. Previously, `computeBestDay` (and the others) reran on every reactive read access; now each memo caches its result and only recomputes when `sessions()` changes.
- **#264**: Inside `Heatmap.tsx`'s `For` callback for `monthLabels`, the inner `nextCol` function was re-subscribing to `monthLabels()` and `columns()` as reactive dependencies on every invocation (N redundant subscriptions per label). Fixed by capturing `labelsSnapshot` and `colCount` once at the top of the `For` callback body, outside any reactive closure.

## Test plan

- [x] `bun run build` — passes cleanly
- [x] `bun test` — 32/32 tests pass

Closes #260
Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)