### PR TITLE
fix: guard notifications.create() against API unavailability on Linux/Chromium

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -231,12 +231,14 @@ export default defineBackground(() => {
 
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: '🍅 Tomate Complete!',
-        message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-      });
+      if (typeof browser.notifications !== 'undefined') {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: '🍅 Tomate Complete!',
+          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+        });
+      }
       if (config.openBreakTab !== false) {
         try {
           await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
@@ -247,12 +249,14 @@ export default defineBackground(() => {
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-        message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-      });
+      if (typeof browser.notifications !== 'undefined') {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+        });
+      }
     }
 
     if (isActivePhase(completed.phase) && completed.endTime !== null) {


### PR DESCRIPTION
## Summary

- Wraps both `browser.notifications.create()` calls in `entrypoints/background.ts` with a `typeof browser.notifications !== 'undefined'` guard
- Prevents a `TypeError` thrown on Linux/Chromium builds where `browser.notifications` may be `undefined` even when the `notifications` permission is declared in the manifest
- Both notification sites are guarded: the work-session completion notification and the break-over notification

## Test plan

- [x] `bun run build` passes with no errors
- [x] `bun test` — all 32 tests pass
- [ ] Manual: verify notifications still fire on Chrome/Firefox where the API is available
- [ ] Manual: verify no crash occurs on a Linux/Chromium build where `browser.notifications` is undefined

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)