### PR TITLE
fix: log unknown message actions and validate config field types from storage

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -200,6 +200,7 @@ export default defineBackground(() => {
         return nextState;
       }
       default: {
+        console.warn('[tomate] Unknown action:', (message as any).action);
         return state;
       }
     }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -45,8 +45,16 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
-export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+export const getConfig = async (): Promise<TimerConfig> => {
+  const stored = await getStoredValue<Partial<TimerConfig>>(KEYS.CONFIG);
+  if (stored) {
+    if (typeof stored.workDuration !== 'number') delete stored.workDuration;
+    if (typeof stored.shortBreakDuration !== 'number') delete stored.shortBreakDuration;
+    if (typeof stored.longBreakDuration !== 'number') delete stored.longBreakDuration;
+    if (typeof stored.openBreakTab !== 'boolean') delete stored.openBreakTab;
+  }
+  return { ...DEFAULT_CONFIG, ...stored };
+};
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });


### PR DESCRIPTION
## Summary

- **#238**: Changed the `default` case in `handleMessage` (background.ts) from a silent `return state` to a `console.warn` that logs the unknown action before returning state. This makes missing/misspelled actions visible in the service-worker console instead of silently returning stale state.
- **#239**: Rewrote `getConfig` (storage.ts) to merge the stored partial config with `DEFAULT_CONFIG` after stripping any fields whose runtime type doesn't match the expected type (`number` for durations, `boolean` for `openBreakTab`). This prevents a corrupted string value for a duration field from causing `Date.now() + string` concatenation that produces a bogus alarm timestamp.

## Test plan

- [x] `bun run build` passes (837 ms clean build)
- [x] `bun test` — 32/32 tests pass across 4 files
- [ ] Manual smoke: open extension popup, verify timer starts/stops/completes normally
- [ ] Manual regression: set a string value in storage for `workDuration`, reload extension, confirm timer still uses the DEFAULT 25-minute duration

Closes #238
Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)