### PR TITLE
fix: handle QuotaExceededError in addCompletedSession with prune-and-retry

### DIFF
--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -4,6 +4,7 @@ import { fakeBrowser } from 'wxt/testing';
 vi.mock('wxt/browser', () => ({ browser: fakeBrowser }));
 
 import {
+  MAX_SESSIONS,
   addCompletedSession,
   getConfig,
   getCurrentLabel,
@@ -148,5 +149,76 @@ describe('storage helpers', () => {
 
     await setPendingCelebration(false);
     await expect(getPendingCelebration()).resolves.toBe(false);
+  });
+
+  it('caps sessions at MAX_SESSIONS to prevent quota issues', async () => {
+    const baseTime = new Date(2026, 0, 1, 9, 0, 0).getTime();
+
+    // Pre-seed storage with MAX_SESSIONS sessions
+    const initial = Array.from({ length: MAX_SESSIONS }, (_, i) =>
+      createSession(baseTime + i * 1_000, { id: `seed-${i}` }),
+    );
+    await fakeBrowser.storage.local.set({ sessions: initial });
+
+    // Add one more — should evict the oldest
+    const extra = createSession(baseTime + MAX_SESSIONS * 1_000, { id: 'extra' });
+    await addCompletedSession(extra);
+
+    const stored = await getSessionHistory();
+    expect(stored.length).toBe(MAX_SESSIONS);
+    expect(stored[0].id).toBe('seed-1');
+    expect(stored[stored.length - 1].id).toBe('extra');
+  });
+
+  it('prunes oldest sessions and retries when QuotaExceededError is thrown', async () => {
+    // PRUNE_COUNT = Math.max(100, ceil(MAX_SESSIONS * 0.1)) = 200.
+    // Seed with PRUNE_COUNT + 50 so that after pruning the newest sessions remain.
+    const PRUNE_COUNT = Math.max(100, Math.ceil(MAX_SESSIONS * 0.1));
+    const seedCount = PRUNE_COUNT + 50;
+    const baseTime = new Date(2026, 0, 2, 9, 0, 0).getTime();
+    const sessions = Array.from({ length: seedCount }, (_, i) =>
+      createSession(baseTime + i * 1_000, { id: `s-${i}` }),
+    );
+    await fakeBrowser.storage.local.set({ sessions });
+
+    // Intercept the first write with a QuotaExceededError, then restore so
+    // the retry write goes through to the real fakeBrowser storage.
+    let firstCall = true;
+    const spy = vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items: Record<string, unknown>) => {
+      if ('sessions' in items && firstCall) {
+        firstCall = false;
+        spy.mockRestore(); // let retry use the real set
+        const err = new Error('QuotaExceededError');
+        err.name = 'QuotaExceededError';
+        throw err;
+      }
+      throw new Error('unexpected spy call');
+    });
+
+    const newSession = createSession(baseTime + seedCount * 1_000, { id: 'new' });
+    await addCompletedSession(newSession);
+
+    const stored = await getSessionHistory();
+    expect(stored.length).toBeGreaterThan(0);
+    expect(stored[stored.length - 1].id).toBe('new');
+  });
+
+  it('logs console.error and does not throw if retry also fails', async () => {
+    const quotaError = new Error('QuotaExceededError');
+    quotaError.name = 'QuotaExceededError';
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValue(quotaError);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const session = createSession(Date.now());
+    await expect(addCompletedSession(session)).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('re-throws non-quota errors from storage.set', async () => {
+    const storageError = new Error('Internal storage error');
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValue(storageError);
+
+    const session = createSession(Date.now());
+    await expect(addCompletedSession(session)).rejects.toThrow('Internal storage error');
   });
 });

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -18,6 +18,8 @@ const KEYS = {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
+export const MAX_SESSIONS = 2000;
+const PRUNE_COUNT = Math.max(100, Math.ceil(MAX_SESSIONS * 0.1));
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -52,9 +54,31 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
 };
 
+const isQuotaExceededError = (err: unknown): boolean => {
+  if (!(err instanceof Error)) return false;
+  return err.message.toLowerCase().includes('quota') || err.name === 'QuotaExceededError';
+};
+
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+
+  // Always cap at MAX_SESSIONS before writing to prevent quota issues
+  const capped = sessions.length >= MAX_SESSIONS ? sessions.slice(sessions.length - MAX_SESSIONS + 1) : sessions;
+  const updated = [...capped, session];
+
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: updated });
+  } catch (err) {
+    if (!isQuotaExceededError(err)) throw err;
+
+    // Prune oldest sessions and retry
+    const pruned = updated.slice(PRUNE_COUNT);
+    try {
+      await browser.storage.local.set({ [KEYS.SESSIONS]: pruned });
+    } catch (retryErr) {
+      console.error('[tomate] addCompletedSession: storage quota exceeded even after pruning', retryErr);
+    }
+  }
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
## Summary

- Added `MAX_SESSIONS = 2000` constant and always cap the sessions array at that limit before writing, preventing quota from being hit in the first place
- Wrapped `browser.storage.local.set()` in `addCompletedSession` in try/catch to detect `QuotaExceededError`
- On quota error: prune the oldest `PRUNE_COUNT` sessions (10% of MAX_SESSIONS, minimum 100) and retry the write
- If the retry also fails, log via `console.error` rather than silently dropping the session or crashing

## Test plan

- [ ] `bun run build` passes (verified)
- [ ] `bun test` passes — 36 tests across 4 files (verified)
- [ ] New tests cover: MAX_SESSIONS cap enforcement, prune-and-retry on QuotaExceededError, console.error on double-failure, re-throw of non-quota errors

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)