### PR TITLE
test: add coverage for openBreakTab tabs.create path in onAlarm

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -8,6 +8,7 @@ import {
   getPendingCelebration,
   getSessionHistory,
   getTimerState,
+  setConfig,
   setCurrentLabel,
   setTimerState,
 } from '@/lib/storage';
@@ -225,6 +226,47 @@ describe('background service worker', () => {
         scheduledTime: 10_000 + DEFAULT_CONFIG.shortBreakDuration,
       }),
     );
+  });
+
+  it('opens stats tab when WORKING session completes and openBreakTab is true', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    const createTabSpy = vi.spyOn(fakeBrowser.tabs, 'create').mockResolvedValue({} as never);
+    await setConfig(createConfig({ openBreakTab: true }));
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+
+    expect(createTabSpy).toHaveBeenCalledOnce();
+    expect(createTabSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ url: expect.stringContaining('stats.html') }),
+    );
+  });
+
+  it('does not open tab when openBreakTab is false', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    const createTabSpy = vi.spyOn(fakeBrowser.tabs, 'create').mockResolvedValue({} as never);
+    await setConfig(createConfig({ openBreakTab: false }));
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+
+    expect(createTabSpy).not.toHaveBeenCalled();
   });
 
   it('returns the current timer state for GET_STATE', async () => {


### PR DESCRIPTION
## Summary
- Adds two new tests to `entrypoints/__tests__/background.test.ts` covering the `browser.tabs.create` code path that fires when a WORKING alarm completes
- Test 1: asserts `tabs.create` is called with the stats.html URL when `openBreakTab: true`
- Test 2: asserts `tabs.create` is NOT called when `openBreakTab: false`

## Test plan
- [x] `bun test` passes all 34 tests (9 in background.test.ts, up from 7)
- [x] `bun run build` succeeds

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)