### PR TITLE
perf: batch independent popup onMount storage reads with Promise.all

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -27,21 +27,26 @@ export default function App() {
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
 
   const refreshStats = async () => {
-    setTodayCount(await getTodayCount());
-    setHeatmapData(await getHeatmapData(120));
+    const [count, heatmap] = await Promise.all([getTodayCount(), getHeatmapData(120)]);
+    setTodayCount(count);
+    setHeatmapData(heatmap);
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
+    const [currentState, pending, currentLabel] = await Promise.all([
+      browser.runtime.sendMessage({ action: 'GET_STATE' }),
+      getPendingCelebration(),
+      getCurrentLabel(),
+    ]);
+
     setState(currentState as TimerState);
 
-    const pending = await getPendingCelebration();
     if (pending) {
       playCelebration('work');
       await setPendingCelebration(false);
     }
 
-    setLabel(await getCurrentLabel());
+    setLabel(currentLabel);
     await refreshStats();
 
     browser.storage.onChanged.addListener(refreshStats);


### PR DESCRIPTION
## Summary

- Replaced sequential `await` chains in `onMount` with a single `Promise.all` batching three independent reads: `GET_STATE` message to background, `getPendingCelebration()`, and `getCurrentLabel()`
- Also parallelized the two sequential reads inside `refreshStats`: `getTodayCount()` and `getHeatmapData(120)` now run concurrently
- The only sequential dependency preserved is `setPendingCelebration(false)`, which correctly remains after reading the pending value

## Test plan

- [x] `bun run build` passes
- [x] `bun test` — all 32 tests pass
- [x] Logic correctness: `setState`, `setLabel`, and celebration handling all receive the same values as before

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)