### PR TITLE
perf: pass local state to refreshBadge to skip redundant storage read

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -22,7 +22,7 @@ import {
   setTimerState,
   toDateKey,
 } from '@/lib/storage';
-import type { CompletedSession, TimerConfig } from '@/lib/types';
+import type { CompletedSession, TimerConfig, TimerState } from '@/lib/types';
 
 export type MessageAction =
   | { action: 'START_TIMER' }
@@ -40,8 +40,11 @@ export default defineBackground(() => {
   const BADGE_GOLD = '#CA8A04';
   const badgeApi = browser.action;
 
-  const refreshBadge = async (): Promise<void> => {
-    const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
+  const refreshBadge = async (prefetchedState?: TimerState, prefetchedCount?: number): Promise<void> => {
+    const [state, todayCount] = await Promise.all([
+      prefetchedState !== undefined ? Promise.resolve(prefetchedState) : getTimerState(),
+      prefetchedCount !== undefined ? Promise.resolve(prefetchedCount) : getTodayCount(),
+    ]);
 
     let text = '';
     let color = BADGE_RED;
@@ -262,6 +265,6 @@ export default defineBackground(() => {
       await clearActiveAlarms();
     }
 
-    await refreshBadge();
+    await refreshBadge(completed, completed.completedToday);
   });
 });


### PR DESCRIPTION
## Summary

- `refreshBadge()` now accepts optional `prefetchedState?: TimerState` and `prefetchedCount?: number` parameters
- When pre-fetched values are provided, `Promise.resolve()` is used instead of calling `getTimerState()` / `getTodayCount()` — eliminating 2 storage reads after the write in the `onAlarm` handler
- The `onAlarm` handler passes `completed` and `completed.completedToday` directly to `refreshBadge`, avoiding the redundant read that was happening right after `setTimerState(completed)` wrote the same data
- All other call-sites (message handler, recovery, badge-refresh alarm) continue to call `refreshBadge()` with no args so their behavior is unchanged

## Test plan

- [x] `bun run build` — passes, 74.83 kB bundle unchanged
- [x] `bun test` — all 32 tests pass across 4 files

Closes #176