### PR TITLE
fix: reschedule active timer after extension update

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -184,6 +184,38 @@ describe('background service worker', () => {
     );
   });
 
+  it('reschedules an active timer alarm after extension update (endTime in the future)', async () => {
+    const futureEndTime = 20_000;
+    vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 5_000,
+        endTime: futureEndTime,
+        duration: 15_000,
+      }),
+    );
+    await initBackground();
+
+    // Simulate extension update: alarms were cleared by Chrome, onInstalled fires
+    await fakeBrowser.alarms.clearAll();
+    await fakeBrowser.runtime.onInstalled.trigger({ reason: 'update', temporary: false } as never);
+
+    // Timer state should be unchanged (session not yet complete)
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'WORKING',
+        startTime: 5_000,
+        endTime: futureEndTime,
+        duration: 15_000,
+      }),
+    );
+    // Alarm must be rescheduled to the original endTime
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
+      expect.objectContaining({ scheduledTime: futureEndTime }),
+    );
+  });
+
   it('recovers a missed working alarm on startup and records the completed session', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000);
     await setCurrentLabel('Recovered work');

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -119,6 +119,12 @@ export default defineBackground(() => {
     const recovered = recoverMissedAlarm(state, config);
 
     if (!recovered) {
+      // Timer hasn't expired yet — if it's still active, reschedule the alarm
+      // (alarms are cleared when the extension updates or the service worker restarts)
+      if (isActivePhase(state.phase) && state.endTime !== null) {
+        await scheduleTimerAlarm(state.endTime);
+        await startBadgeRefresh();
+      }
       await refreshBadge();
       return;
     }

--- a/tests/reschedule-on-update.test.ts
+++ b/tests/reschedule-on-update.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { recoverMissedAlarm, isActivePhase } from '../lib/timer';
+import { DEFAULT_CONFIG } from '../lib/types';
+
+const NOW = 1_000_000_000_000; // fixed reference timestamp (ms)
+const FIVE_MINUTES = 5 * 60 * 1_000;
+const WORK_DURATION = DEFAULT_CONFIG.workDuration; // 25 min
+
+describe('recoverMissedAlarm — timer still active (endTime in the future)', () => {
+  it('returns null when WORKING timer has not yet expired', () => {
+    // Scenario: extension updates while user has 5 min left on a work session.
+    // recoverMissedAlarm must return null so the background can reschedule
+    // the existing alarm rather than treating it as a missed/expired one.
+    const state = {
+      phase: 'WORKING' as const,
+      startTime: NOW - WORK_DURATION + FIVE_MINUTES,
+      endTime: NOW + FIVE_MINUTES,
+      duration: WORK_DURATION,
+      sessionCount: 0,
+      cyclePosition: 0,
+      completedToday: 0,
+    };
+
+    const result = recoverMissedAlarm(state, DEFAULT_CONFIG, NOW);
+
+    expect(result).toBeNull();
+  });
+
+  it('isActivePhase is true for WORKING so background can reschedule', () => {
+    expect(isActivePhase('WORKING')).toBe(true);
+  });
+
+  it('isActivePhase is true for SHORT_BREAK so background can reschedule', () => {
+    expect(isActivePhase('SHORT_BREAK')).toBe(true);
+  });
+
+  it('isActivePhase is true for LONG_BREAK so background can reschedule', () => {
+    expect(isActivePhase('LONG_BREAK')).toBe(true);
+  });
+
+  it('isActivePhase is false for IDLE and BREAK_SUGGESTION — no alarm needed', () => {
+    expect(isActivePhase('IDLE')).toBe(false);
+    expect(isActivePhase('BREAK_SUGGESTION')).toBe(false);
+  });
+});
+
+describe('recoverMissedAlarm — timer already expired', () => {
+  it('returns a new state when WORKING timer expired before now', () => {
+    // Simulates a missed alarm: extension was dormant longer than the session.
+    const state = {
+      phase: 'WORKING' as const,
+      startTime: NOW - WORK_DURATION - 1,
+      endTime: NOW - 1, // expired 1 ms ago
+      duration: WORK_DURATION,
+      sessionCount: 0,
+      cyclePosition: 0,
+      completedToday: 0,
+    };
+
+    const result = recoverMissedAlarm(state, DEFAULT_CONFIG, NOW);
+
+    expect(result).not.toBeNull();
+    // After a WORKING session completes (cyclePosition < 3) → SHORT_BREAK
+    expect(result!.phase).toBe('SHORT_BREAK');
+    expect(result!.completedToday).toBe(1);
+  });
+
+  it('returns null for IDLE state (nothing to recover)', () => {
+    const state = {
+      phase: 'IDLE' as const,
+      startTime: null,
+      endTime: null,
+      duration: null,
+      sessionCount: 0,
+      cyclePosition: 0,
+      completedToday: 0,
+    };
+
+    const result = recoverMissedAlarm(state, DEFAULT_CONFIG, NOW);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('reschedule-on-update invariant', () => {
+  it('a WORKING state with future endTime should trigger alarm rescheduling in background', () => {
+    // This test documents the contract relied on by recoverFromMissedAlarm in background.ts:
+    // when recoverMissedAlarm returns null AND isActivePhase is true AND endTime > now,
+    // the background MUST reschedule the alarm to endTime.
+    const futureEndTime = NOW + FIVE_MINUTES;
+    const state = {
+      phase: 'WORKING' as const,
+      startTime: NOW - WORK_DURATION + FIVE_MINUTES,
+      endTime: futureEndTime,
+      duration: WORK_DURATION,
+      sessionCount: 0,
+      cyclePosition: 0,
+      completedToday: 0,
+    };
+
+    // recoverMissedAlarm returns null (timer still running)
+    expect(recoverMissedAlarm(state, DEFAULT_CONFIG, NOW)).toBeNull();
+
+    // background should detect active phase + future endTime and reschedule
+    const shouldReschedule = isActivePhase(state.phase) && state.endTime !== null && state.endTime > NOW;
+    expect(shouldReschedule).toBe(true);
+
+    // The endTime the alarm should be rescheduled to
+    expect(state.endTime).toBe(futureEndTime);
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `recoverFromMissedAlarm()` in background.ts bailed out early when `recoverMissedAlarm()` (lib/timer.ts) returned `null`. That function returns `null` when `endTime >= now` — i.e. the timer is *still running*. The early return skipped alarm rescheduling, so an active timer silently stopped on every extension update.
- **Fix**: In the `!recovered` branch, check whether the stored state is an active phase with a future `endTime`. If so, reschedule the alarm to `state.endTime` and restart the badge-refresh alarm before returning.
- **Tests**: Added `tests/reschedule-on-update.test.ts` (pure unit tests against `recoverMissedAlarm` + `isActivePhase`) and an integration test in `entrypoints/__tests__/background.test.ts` that simulates an extension update triggering `onInstalled` while a WORKING timer has time remaining.

## Test plan

- [ ] `bun run build` passes
- [ ] `bun run test` — 4 test files pass (33 pre-existing + 8 new unit tests); `entrypoints/__tests__/background.test.ts` has 8 failures that are all pre-existing (vitest/esbuild dynamic-import loader issue unrelated to this change)
- [ ] Manual: start a 25-min timer, reload the extension from `chrome://extensions`, confirm the badge still counts down and the alarm fires at the correct time

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)