### PR TITLE
fix: only apply website blocking rules during WORKING phase

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -8,6 +8,7 @@ import {
   getPendingCelebration,
   getSessionHistory,
   getTimerState,
+  setBlockedSites,
   setCurrentLabel,
   setTimerState,
 } from '@/lib/storage';
@@ -37,14 +38,24 @@ const initBackground = async (): Promise<void> => {
   await background.default.main?.();
 };
 
+const mockDnr = {
+  getDynamicRules: vi.fn().mockResolvedValue([]),
+  updateDynamicRules: vi.fn().mockResolvedValue(undefined),
+};
+
 describe('background service worker', () => {
   beforeEach(async () => {
     vi.restoreAllMocks();
+    vi.clearAllMocks();
     fakeBrowser.reset();
     await fakeBrowser.storage.local.clear();
 
     fakeBrowser.action.setBadgeText = vi.fn().mockResolvedValue(undefined);
     fakeBrowser.action.setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+
+    mockDnr.getDynamicRules.mockResolvedValue([]);
+    mockDnr.updateDynamicRules.mockResolvedValue(undefined);
+    (fakeBrowser as typeof fakeBrowser & { declarativeNetRequest: typeof mockDnr }).declarativeNetRequest = mockDnr;
   });
 
   it('starts a timer, persists working state, and creates the timer alarm', async () => {
@@ -269,5 +280,100 @@ describe('background service worker', () => {
         scheduledTime: 25_000,
       }),
     );
+  });
+
+  describe('website blocking', () => {
+    it('applies blocking rules when blockedSites changes during WORKING phase', async () => {
+      await setTimerState(
+        createState({
+          phase: 'WORKING',
+          startTime: 1_000,
+          endTime: 2_000,
+          duration: 1_000,
+        }),
+      );
+      await initBackground();
+
+      await fakeBrowser.storage.onChanged.trigger(
+        { blockedSites: { newValue: ['reddit.com', 'twitter.com'] } },
+        'local',
+      );
+
+      expect(mockDnr.updateDynamicRules).toHaveBeenCalledWith(
+        expect.objectContaining({
+          addRules: expect.arrayContaining([
+            expect.objectContaining({ condition: expect.objectContaining({ urlFilter: 'reddit.com' }) }),
+            expect.objectContaining({ condition: expect.objectContaining({ urlFilter: 'twitter.com' }) }),
+          ]),
+        }),
+      );
+    });
+
+    it('clears blocking rules when blockedSites changes during a non-WORKING phase', async () => {
+      await setTimerState(createState({ phase: 'SHORT_BREAK', startTime: 1_000, endTime: 2_000, duration: 1_000 }));
+      mockDnr.getDynamicRules.mockResolvedValue([{ id: 1000 }]);
+      await initBackground();
+
+      await fakeBrowser.storage.onChanged.trigger(
+        { blockedSites: { newValue: ['reddit.com'] } },
+        'local',
+      );
+
+      expect(mockDnr.updateDynamicRules).toHaveBeenCalledWith({ removeRuleIds: [1000], addRules: [] });
+    });
+
+    it('applies blocking rules when phase transitions to WORKING', async () => {
+      await setBlockedSites(['reddit.com']);
+      await setTimerState(createState({ phase: 'IDLE' }));
+      await initBackground();
+
+      await fakeBrowser.storage.onChanged.trigger(
+        {
+          timerState: {
+            oldValue: createState({ phase: 'IDLE' }),
+            newValue: createState({ phase: 'WORKING', startTime: 1_000, endTime: 2_000, duration: 1_000 }),
+          },
+        },
+        'local',
+      );
+
+      expect(mockDnr.updateDynamicRules).toHaveBeenCalledWith(
+        expect.objectContaining({
+          addRules: expect.arrayContaining([
+            expect.objectContaining({ condition: expect.objectContaining({ urlFilter: 'reddit.com' }) }),
+          ]),
+        }),
+      );
+    });
+
+    it('clears blocking rules when phase transitions away from WORKING', async () => {
+      await setBlockedSites(['reddit.com']);
+      await setTimerState(createState({ phase: 'SHORT_BREAK', startTime: 1_000, endTime: 2_000, duration: 1_000 }));
+      mockDnr.getDynamicRules.mockResolvedValue([{ id: 1000 }]);
+      await initBackground();
+
+      await fakeBrowser.storage.onChanged.trigger(
+        {
+          timerState: {
+            oldValue: createState({ phase: 'WORKING', startTime: 1_000, endTime: 2_000, duration: 1_000 }),
+            newValue: createState({ phase: 'SHORT_BREAK', startTime: 2_000, endTime: 3_000, duration: 1_000 }),
+          },
+        },
+        'local',
+      );
+
+      expect(mockDnr.updateDynamicRules).toHaveBeenCalledWith({ removeRuleIds: [1000], addRules: [] });
+    });
+
+    it('ignores storage changes for unrelated keys', async () => {
+      await initBackground();
+
+      await fakeBrowser.storage.onChanged.trigger(
+        { config: { newValue: DEFAULT_CONFIG } },
+        'local',
+      );
+
+      expect(mockDnr.updateDynamicRules).not.toHaveBeenCalled();
+    });
   });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/timer';
 import {
   addCompletedSession,
+  getBlockedSites,
   getConfig,
   getCurrentLabel,
   getTimerState,
@@ -90,6 +91,40 @@ export default defineBackground(() => {
 
   const clearActiveAlarms = async (): Promise<void> => {
     await Promise.all([browser.alarms.clear(ALARM_TIMER), browser.alarms.clear(ALARM_BADGE_REFRESH)]);
+  };
+
+  const BLOCKING_RULE_ID_BASE = 1000;
+
+  const applyBlockingRules = async (sites: string[]): Promise<void> => {
+    const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+    const removeRuleIds = existingRules.map((r) => r.id);
+
+    const addRules = sites
+      .filter((site) => site.trim().length > 0)
+      .map((site, index) => ({
+        id: BLOCKING_RULE_ID_BASE + index,
+        priority: 1,
+        action: { type: 'block' as const },
+        condition: {
+          urlFilter: site.trim(),
+          resourceTypes: [
+            'main_frame' as const,
+            'sub_frame' as const,
+            'xmlhttprequest' as const,
+          ],
+        },
+      }));
+
+    await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules });
+  };
+
+  const clearBlockingRules = async (): Promise<void> => {
+    const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+    const removeRuleIds = existingRules.map((r) => r.id);
+
+    if (removeRuleIds.length > 0) {
+      await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules: [] });
+    }
   };
 
   const persistCompletedSession = async (
@@ -214,6 +249,30 @@ export default defineBackground(() => {
   });
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+
+  browser.storage.onChanged.addListener(async (changes) => {
+    const blockedSitesChanged = 'blockedSites' in changes;
+    const timerStateChanged = 'timerState' in changes;
+
+    if (!blockedSitesChanged && !timerStateChanged) {
+      return;
+    }
+
+    // Use the new timerState from the change event when available to avoid a
+    // race condition where storage.local hasn't flushed the new value yet.
+    const phase = timerStateChanged
+      ? ((changes['timerState']?.newValue as { phase?: string } | undefined)?.phase ?? 'IDLE')
+      : (await getTimerState()).phase;
+
+    if (phase === 'WORKING') {
+      const sites = blockedSitesChanged
+        ? ((changes['blockedSites']?.newValue as string[] | undefined) ?? [])
+        : await getBlockedSites();
+      await applyBlockingRules(sites);
+    } else {
+      await clearBlockingRules();
+    }
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -14,6 +14,7 @@ const KEYS = {
   SESSIONS: 'sessions',
   PENDING_CELEBRATION: 'pendingCelebration',
   CURRENT_LABEL: 'currentLabel',
+  BLOCKED_SITES: 'blockedSites',
 } as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -102,4 +103,11 @@ export const getCurrentLabel = async (): Promise<string> =>
 
 export const setCurrentLabel = async (label: string): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CURRENT_LABEL]: label.slice(0, MAX_LABEL_LENGTH) });
+};
+
+export const getBlockedSites = async (): Promise<string[]> =>
+  (await getStoredValue<string[]>(KEYS.BLOCKED_SITES)) ?? [];
+
+export const setBlockedSites = async (sites: string[]): Promise<void> => {
+  await browser.storage.local.set({ [KEYS.BLOCKED_SITES]: sites });
 };

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Tomate',
     description: 'A Pomodoro timer that helps you focus — one tomate at a time.',
-    permissions: ['alarms', 'notifications', 'storage', 'tabs'],
+    permissions: ['alarms', 'declarativeNetRequest', 'declarativeNetRequestWithHostAccess', 'notifications', 'storage', 'tabs'],
     action: {
       default_icon: {
         '16': '/icons/icon-16.png',


### PR DESCRIPTION
## Summary

- `applyBlockingRules` and `clearBlockingRules` helpers added to `background.ts` using `browser.declarativeNetRequest.updateDynamicRules`
- A `browser.storage.onChanged` listener now fires on both `blockedSites` and `timerState` changes; it applies rules only when the current phase is `WORKING`, and clears all rules otherwise
- Phase transitions are handled inline using `changes.timerState.newValue` to avoid a read-after-write race condition
- `declarativeNetRequest` and `declarativeNetRequestWithHostAccess` permissions added to `wxt.config.ts`
- `getBlockedSites` / `setBlockedSites` storage helpers added to `lib/storage.ts`
- 5 new tests cover: apply on `blockedSites` change during WORKING, clear during SHORT_BREAK, apply on phase → WORKING, clear on phase → SHORT_BREAK, ignore unrelated keys

## Test plan

- [x] `bun run build` passes
- [x] `bun test` passes (37 tests, 0 failures)
- [ ] Manual: start a WORKING session → blocked sites are inaccessible; start a break → sites accessible again
- [ ] Manual: update blocked sites list while in WORKING → rules immediately refreshed

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)