### PR TITLE
fix: add onCleanup for labelTimeout to prevent stale closure on unmount

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -95,6 +95,7 @@ export default function App() {
   };
 
   let labelTimeout: ReturnType<typeof setTimeout>;
+  onCleanup(() => clearTimeout(labelTimeout));
   const handleLabelChange = (value: string) => {
     setLabel(value);
     clearTimeout(labelTimeout);


### PR DESCRIPTION
## Summary

- `labelTimeout` in `App.tsx` was declared without a cleanup handler, meaning if the popup closed while the 300 ms debounce was still pending, the `setTimeout` callback could fire and call `setCurrentLabel` on a disposed SolidJS component.
- Added `onCleanup(() => clearTimeout(labelTimeout))` immediately after the `let labelTimeout` declaration so SolidJS cancels the timer when the component unmounts.

## Test plan

- [x] `bun run build` passes with no errors
- [x] `bun test` passes (32/32)
- [x] Manually verify: typing in the task label and quickly closing the popup no longer triggers a stale-closure warning

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)