### PR TITLE
fix: disable save button during async save to prevent concurrent setConfig calls

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -12,6 +12,7 @@ export default function App() {
   const [longBreak, setLongBreak] = createSignal(30);
   const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [saved, setSaved] = createSignal(false);
+  const [isSaving, setIsSaving] = createSignal(false);
 
   onMount(async () => {
     const config = await getConfig();
@@ -22,16 +23,22 @@ export default function App() {
   });
 
   const handleSave = async () => {
-    const config: TimerConfig = {
-      workDuration: work() * MS_PER_MINUTE,
-      shortBreakDuration: shortBreak() * MS_PER_MINUTE,
-      longBreakDuration: longBreak() * MS_PER_MINUTE,
-      openBreakTab: openBreakTab(),
-    };
-    await setConfig(config);
-    await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    if (isSaving()) return;
+    setIsSaving(true);
+    try {
+      const config: TimerConfig = {
+        workDuration: work() * MS_PER_MINUTE,
+        shortBreakDuration: shortBreak() * MS_PER_MINUTE,
+        longBreakDuration: longBreak() * MS_PER_MINUTE,
+        openBreakTab: openBreakTab(),
+      };
+      await setConfig(config);
+      await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleReset = () => {
@@ -98,9 +105,10 @@ export default function App() {
           <button
             type="button"
             onClick={handleSave}
-            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            disabled={isSaving()}
+            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Save
+            {isSaving() ? 'Saving...' : 'Save'}
           </button>
 
           <button


### PR DESCRIPTION
## Summary

- Adds `isSaving` signal to track in-flight save state
- Guards `handleSave` with an early-return if already saving, and wraps the async body in `try/finally` to always clear the flag
- Sets `disabled={isSaving()}` on the Save button and adds Tailwind `disabled:opacity-50 disabled:cursor-not-allowed` classes for visual feedback
- Changes button label to "Saving..." while the save is in progress

## Test plan

- [ ] Click Save rapidly — only one `setConfig()` call fires per save cycle
- [ ] Button becomes visually dimmed and shows "Saving..." text during the async operation
- [ ] Button re-enables and reverts to "Save" after the operation completes (or throws)
- [ ] `bun run build` passes
- [ ] `bun test` passes (32/32)

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)