### PR TITLE
fix: derive live completedToday from storage sessions to handle midnight reset

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -240,6 +240,59 @@ describe('background service worker', () => {
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
   });
 
+  it('attributes a cross-midnight session to the completion date, not the start date', async () => {
+    // Session started at 23:58 on 2026-03-19, completed at 00:03 on 2026-03-20
+    const startTime = new Date(2026, 2, 19, 23, 58, 0).getTime();
+    const endTime = new Date(2026, 2, 20, 0, 3, 0).getTime();
+    vi.spyOn(Date, 'now').mockReturnValue(endTime);
+
+    await setCurrentLabel('Late night session');
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime,
+        endTime: startTime + DEFAULT_CONFIG.workDuration,
+        duration: DEFAULT_CONFIG.workDuration,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({
+      name: 'tomate-timer',
+      scheduledTime: startTime + DEFAULT_CONFIG.workDuration,
+    });
+
+    const sessions = await getSessionHistory();
+    expect(sessions).toHaveLength(1);
+    // The session must be filed under the completion date (2026-03-20), not start date (2026-03-19)
+    expect(sessions[0].date).toBe('2026-03-20');
+    expect(sessions[0].startTime).toBe(startTime);
+    expect(sessions[0].endTime).toBe(endTime);
+  });
+
+  it('shows storage-derived today count in BREAK_SUGGESTION badge after midnight', async () => {
+    // Simulate: state has completedToday=5 from yesterday, but storage has 0 sessions today
+    // (the counter was never reset). refreshBadge should show 0, not 5.
+    const now = new Date(2026, 2, 20, 0, 5, 0).getTime();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    await setTimerState(
+      createState({
+        phase: 'BREAK_SUGGESTION',
+        completedToday: 5, // stale — from yesterday
+        sessionCount: 5,
+      }),
+    );
+    // No sessions stored for today (2026-03-20) — all were from yesterday
+    await initBackground();
+
+    // Trigger badge refresh
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: now });
+
+    // Badge should reflect 0 sessions today, not the stale completedToday=5
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: '0✓' });
+  });
+
   it('updates config during an active timer and recreates the timer alarm', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000);
     const updatedConfig = createConfig({ workDuration: 20_000, shortBreakDuration: 1_000 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -59,7 +59,7 @@ export default defineBackground(() => {
         break;
       }
       case 'BREAK_SUGGESTION': {
-        text = `${state.completedToday}✓`;
+        text = `${todayCount}✓`;
         color = BADGE_GOLD;
         break;
       }
@@ -106,7 +106,7 @@ export default defineBackground(() => {
       label,
       startTime: state.startTime,
       endTime,
-      date: toDateKey(state.startTime),
+      date: toDateKey(endTime),
       duration: state.duration,
     };
 


### PR DESCRIPTION
## Summary

- **#127 (wrong-day attribution):** `persistCompletedSession` was using `toDateKey(state.startTime)` as the session `date`. A session started at 23:58 and completed at 00:03 was filed under the previous day. Changed to `toDateKey(endTime)` so the session is always attributed to the day it completed.

- **#6 (counter never resets):** The `BREAK_SUGGESTION` badge was rendering `${state.completedToday}✓`, a counter that only incremented and never reset at midnight. `refreshBadge` already fetches `todayCount` from `getTodayCount()` (which filters storage sessions by today's date key); changed the badge to use `todayCount` instead of the stale in-memory field.

## Test plan

- [x] `bun run build` — compiles cleanly
- [x] `bun test` — all 34 tests pass (2 new regression tests added)
- [x] New test: cross-midnight session gets `date = '2026-03-20'` when `endTime` is 2026-03-20, even though `startTime` is 2026-03-19
- [x] New test: `BREAK_SUGGESTION` badge shows `0✓` when `completedToday=5` is stale but no storage sessions exist for today

Closes #6
Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)