### PR TITLE
fix: log warning when persistCompletedSession skips due to null startTime

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -95,9 +95,13 @@ export default defineBackground(() => {
   const persistCompletedSession = async (
     state: Awaited<ReturnType<typeof getTimerState>>,
     endTime: number,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     if (state.startTime === null || state.duration === null) {
-      return;
+      console.warn('[tomate] persistCompletedSession: skipping — state.startTime is null', {
+        phase: state.phase,
+        sessionCount: state.sessionCount,
+      });
+      return false;
     }
 
     const label = await getCurrentLabel();
@@ -112,6 +116,7 @@ export default defineBackground(() => {
 
     await addCompletedSession(session);
     await setPendingCelebration(true);
+    return true;
   };
 
   const recoverFromMissedAlarm = async (): Promise<void> => {
@@ -126,6 +131,7 @@ export default defineBackground(() => {
     await setTimerState(recovered);
 
     if (state.phase === 'WORKING') {
+      // Returns false (and logs a warning) when state.startTime is null — session is skipped.
       await persistCompletedSession(state, Date.now());
     }
 
@@ -230,6 +236,7 @@ export default defineBackground(() => {
     await setTimerState(completed);
 
     if (state.phase === 'WORKING') {
+      // Returns false (and logs a warning) when state.startTime is null — session is skipped.
       await persistCompletedSession(state, Date.now());
       await browser.notifications.create({
         type: 'basic',


### PR DESCRIPTION
## Summary

- Added `console.warn` in `persistCompletedSession` when `state.startTime` is null, including `phase` and `sessionCount` in the log payload so callers can diagnose the dropped session
- Changed return type from `Promise<void>` to `Promise<boolean>` — returns `false` when skipped, `true` when the session was successfully persisted
- Added inline comments at both call sites (alarm handler and `recoverFromMissedAlarm`) noting that a `false` return means the session was silently dropped

## Test plan

- [x] `bun run build` passes (702 ms, no type errors)
- [x] `bun test` passes (32/32 tests, 0 failures)
- [ ] Manually trigger a session-complete flow with a null `startTime` in dev and confirm the warning appears in the background service worker console

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)