### PR TITLE
test: add endTime invariant assertions to adjustDuration edge cases

### DIFF
--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -209,6 +209,76 @@ describe('timer state machine', () => {
     });
   });
 
+  it('endTime invariant: equals now when new duration matches elapsed exactly', () => {
+    // elapsed = 5_000ms, newDuration = 5_000ms → startTime + newDuration === now
+    const now = 10_000;
+    const state = createState({
+      phase: 'WORKING',
+      startTime: 5_000,
+      endTime: 15_000,
+      duration: 10_000,
+    });
+    const config = createConfig({ workDuration: 5_000 });
+    const result = adjustDuration(state, config, now);
+
+    expect(result.endTime).toBe(now);
+    expect(result.endTime).toBeGreaterThanOrEqual(now);
+  });
+
+  it('endTime invariant: clamped to now when new duration is shorter than elapsed', () => {
+    // elapsed = 5_000ms, newDuration = 1ms → endTime must not go into the past
+    const now = 10_000;
+    const state = createState({
+      phase: 'WORKING',
+      startTime: 5_000,
+      endTime: 15_000,
+      duration: 10_000,
+    });
+    const config = createConfig({ workDuration: 1 });
+    const result = adjustDuration(state, config, now);
+
+    expect(result.endTime).toBe(now);
+    expect(result.endTime).toBeGreaterThanOrEqual(now);
+  });
+
+  it('endTime invariant: never in the past regardless of new duration', () => {
+    // Covers any new duration ≤ elapsed: endTime >= now must always hold
+    const now = 20_000;
+    const state = createState({
+      phase: 'WORKING',
+      startTime: 1_000,
+      endTime: 21_000,
+      duration: 20_000,
+    });
+
+    for (const workDuration of [1, 500, 18_999, 19_000]) {
+      const config = createConfig({ workDuration });
+      const result = adjustDuration(state, config, now);
+      expect(result.endTime).toBeGreaterThanOrEqual(now);
+    }
+  });
+
+  it('adjusts SHORT_BREAK using shortBreakDuration and never sets endTime in the past', () => {
+    // 3_000ms elapsed on a break whose new shortBreakDuration is 2_000ms
+    // → startTime(1_000) + 2_000 = 3_000 === now, so endTime must clamp to now
+    const now = 4_000;
+    const state = createState({
+      phase: 'SHORT_BREAK',
+      startTime: 1_000,
+      endTime: 6_000,
+      duration: 5_000,
+      sessionCount: 1,
+      completedToday: 1,
+    });
+    const config = createConfig({ shortBreakDuration: 2_000 });
+    const result = adjustDuration(state, config, now);
+
+    expect(result.duration).toBe(2_000);
+    expect(result.endTime).toBeGreaterThanOrEqual(now);
+    // startTime(1_000) + 2_000 = 3_000 < now(4_000), so it must clamp to now
+    expect(result.endTime).toBe(now);
+  });
+
   it('recovers a missed alarm for a completed work session', () => {
     const config = createConfig({ shortBreakDuration: 500 });
     const state = createState({


### PR DESCRIPTION
## Summary

- Adds four new tests for `adjustDuration()` covering the invariant that `endTime` must never precede `now`
- Tests cover: exact-match clamping (elapsed === newDuration), minimum-duration clamping (1ms), a parametric loop over multiple sub-elapsed durations, and `SHORT_BREAK` phase using `shortBreakDuration`

## Test plan

- [x] `bun test lib/__tests__/timer.test.ts` — 18/18 pass (was 14)
- [x] `bun run build` — clean build, no errors

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)