### PR TITLE
fix: serialize onAlarm and handleMessage with async queue to prevent race conditions

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -205,6 +205,15 @@ export default defineBackground(() => {
     }
   };
 
+  // Async mutex: ensures onAlarm and handleMessage never interleave.
+  // Each operation is appended to the tail of the promise chain so that
+  // concurrent browser callbacks are serialized rather than overlapping.
+  let pendingOp: Promise<void> = Promise.resolve();
+  const withLock = (fn: () => Promise<void>): Promise<void> => {
+    pendingOp = pendingOp.then(fn).catch(() => {});
+    return pendingOp;
+  };
+
   browser.runtime.onInstalled.addListener(async () => {
     await recoverFromMissedAlarm();
   });
@@ -213,11 +222,21 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  // Returning the Promise keeps the message channel open in MV3 (Chrome 99+)
+  // and allows the fake browser test harness to await the full response.
+  browser.runtime.onMessage.addListener((message) => {
+    let resolve: (value: unknown) => void;
+    const result = new Promise((r) => { resolve = r; });
+    withLock(async () => {
+      const response = await handleMessage(message as MessageAction);
+      resolve!(response);
+    });
+    return result;
+  });
 
-  browser.alarms.onAlarm.addListener(async (alarm) => {
+  browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {
-      await refreshBadge();
+      void refreshBadge();
       return;
     }
 
@@ -225,43 +244,45 @@ export default defineBackground(() => {
       return;
     }
 
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
-    const completed = completeTimer(state, config);
-    await setTimerState(completed);
+    return withLock(async () => {
+      const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+      const completed = completeTimer(state, config);
+      await setTimerState(completed);
 
-    if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: '🍅 Tomate Complete!',
-        message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-      });
-      if (config.openBreakTab !== false) {
-        try {
-          await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
-        } catch {
-          // tab creation can fail if no browser window is open
+      if (state.phase === 'WORKING') {
+        await persistCompletedSession(state, Date.now());
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: '🍅 Tomate Complete!',
+          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+        });
+        if (config.openBreakTab !== false) {
+          try {
+            await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
+          } catch {
+            // tab creation can fail if no browser window is open
+          }
         }
       }
-    }
 
-    if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-        message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-      });
-    }
+      if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+        });
+      }
 
-    if (isActivePhase(completed.phase) && completed.endTime !== null) {
-      await scheduleTimerAlarm(completed.endTime);
-      await startBadgeRefresh();
-    } else {
-      await clearActiveAlarms();
-    }
+      if (isActivePhase(completed.phase) && completed.endTime !== null) {
+        await scheduleTimerAlarm(completed.endTime);
+        await startBadgeRefresh();
+      } else {
+        await clearActiveAlarms();
+      }
 
-    await refreshBadge();
+      await refreshBadge();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a module-scoped `pendingOp` promise chain and a `withLock` helper inside `defineBackground`
- Wraps the `onMessage` listener body in `withLock` so concurrent message callbacks are serialized through a single queue
- Wraps the `onAlarm` timer-handling path in `withLock` so a concurrent alarm firing during `reschedulePendingTimer` cannot interleave with an in-flight message handler
- The returned Promise from both listeners lets MV3 keep the message channel open (Chrome 99+) and lets the fake-browser test harness await full completion

## Why this approach

The previous `onMessage` listener returned the `handleMessage` Promise directly, but the `onAlarm` handler was fully unguarded — a concurrent alarm during `onInstalled`/`onStartup` recovery could read stale state and write a duplicate session. Using a single shared queue (`pendingOp`) means the two handlers are mutually exclusive without needing a time-window deduplication `Set`.

## Test plan

- [x] `bun run build` passes cleanly
- [x] `bun test` — all 32 tests pass (0 failures)
- [ ] Load extension, start a timer near expiry, trigger a simulated update (reload background); confirm only one session is recorded
- [ ] Normal timer completion continues to work (session saved, notification shown, badge updated)

Closes #1
Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)