### PR TITLE
security: sanitize CSV label field to prevent spreadsheet formula injection

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -29,10 +29,15 @@ function StatCard(props: StatCardProps) {
   );
 }
 
+const sanitizeCSVCell = (val: string): string => {
+  const s = String(val);
+  return /^[=+@\-]/.test(s) ? `\t${s}` : s;
+};
+
 function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
   const header = 'startTime,endTime,duration,label';
   const rows = sessions.map((s) => {
-    const label = `"${s.label.replace(/"/g, '""')}"`;
+    const label = `"${sanitizeCSVCell(s.label).replace(/"/g, '""')}"`;
     return `${s.startTime},${s.endTime},${s.duration},${label}`;
   });
   const csv = [header, ...rows].join('\n');


### PR DESCRIPTION
## Summary

- Adds `sanitizeCSVCell` helper that prepends a tab character to any cell value starting with `=`, `+`, `@`, or `-` (the four spreadsheet formula trigger characters)
- Applies the sanitizer to the `label` field in `exportCSV`, which is the only user-controlled string field written to CSV output
- Approach is RFC 4180 compatible — the tab prefix is inside the quoted field and does not break CSV parsers, while preventing Excel/Sheets/LibreOffice from executing the value as a formula

## Test plan

- [ ] `bun run build` passes (verified)
- [ ] `bun test` passes — 32/32 (verified)
- [ ] Manual: export a session whose label starts with `=SUM(1+1)` and confirm the downloaded CSV contains `"\t=SUM(1+1)"` rather than `"=SUM(1+1)"`
- [ ] Manual: export a session whose label starts with a normal character and confirm it is unchanged in the CSV

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)