### PR TITLE
fix: add null fallback for bestDay date to prevent undefined render

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -85,7 +85,7 @@ export default function App() {
             <StatCard
               label="Best day"
               value={bestDay()?.count ?? '—'}
-              sublabel={bestDay()?.date}
+              sublabel={bestDay()?.date ?? '—'}
             />
             <StatCard
               label="Current streak"


### PR DESCRIPTION
## Summary

- `bestDay()?.date` in `entrypoints/stats/App.tsx` lacked a `?? '—'` fallback, causing `undefined` to render in the Best Day stat card's sublabel when no sessions exist
- Added `?? '—'` to match the existing guard already present on `bestDay()?.count`

## Test plan

- [ ] Build passes (`bun run build`)
- [ ] All 32 tests pass (`bun test`)
- [ ] Visit the stats page with zero sessions — Best Day sublabel shows `—` instead of blank/undefined

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)