### PR TITLE
fix: dark mode for options/stats/popup, confetti bounds, phase transitions (#206, #208, #210, #214, #216)

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -11,7 +11,7 @@ type ControlsProps = {
 
 export default function Controls(props: ControlsProps) {
   return (
-    <div class="mt-5 flex gap-3 justify-center">
+    <div class="mt-5 flex gap-3 justify-center transition-opacity duration-200">
       <Switch>
         <Match when={props.phase === 'IDLE'}>
           <button

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -44,7 +44,8 @@ export default function TimerRing(props: TimerRingProps) {
         stroke-dasharray={String(CIRCUMFERENCE)}
         stroke-dashoffset={offset()}
         transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
-        class="transition-[stroke-dashoffset] duration-500 ease-linear"
+        class="transition-[stroke-dashoffset,stroke] duration-500 ease-linear"
+        style={{ "transition-property": "stroke-dashoffset, stroke", "transition-duration": "500ms, 400ms", "transition-timing-function": "linear, ease-in-out" }}
       />
     </svg>
   );

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -42,44 +42,44 @@ export default function App() {
   };
 
   return (
-    <div class="min-h-screen bg-red-50 flex items-start justify-center pt-16">
-      <div class="w-full max-w-[400px] bg-white rounded-lg shadow-sm p-6">
-        <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 flex items-start justify-center pt-16">
+      <div class="w-full max-w-[400px] bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400 mb-6">Tomate Settings</h1>
 
         <div class="space-y-4">
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Work Duration (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Work Duration (minutes)</span>
             <input
               type="number"
               min={1}
               max={120}
               value={work()}
               onInput={(e) => setWork(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 dark:focus:border-red-400 focus:outline-none focus:ring-1 focus:ring-red-500 dark:focus:ring-red-400"
             />
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Short Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Short Break (minutes)</span>
             <input
               type="number"
               min={1}
               max={30}
               value={shortBreak()}
               onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 dark:focus:border-red-400 focus:outline-none focus:ring-1 focus:ring-red-500 dark:focus:ring-red-400"
             />
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Long Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Long Break (minutes)</span>
             <input
               type="number"
               min={5}
               max={60}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 dark:focus:border-red-400 focus:outline-none focus:ring-1 focus:ring-red-500 dark:focus:ring-red-400"
             />
           </label>
 
@@ -88,9 +88,9 @@ export default function App() {
               type="checkbox"
               checked={openBreakTab()}
               onChange={(e) => setOpenBreakTab(e.currentTarget.checked)}
-              class="w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-red-600 dark:text-red-400 focus:ring-red-500 dark:focus:ring-red-400"
             />
-            <span class="text-sm font-medium text-gray-700">Open stats tab when session completes</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Open stats tab when session completes</span>
           </label>
         </div>
 
@@ -98,7 +98,7 @@ export default function App() {
           <button
             type="button"
             onClick={handleSave}
-            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            class="bg-red-600 dark:bg-red-700 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 dark:hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 dark:focus:ring-red-400 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
           >
             Save
           </button>
@@ -106,13 +106,13 @@ export default function App() {
           <button
             type="button"
             onClick={handleReset}
-            class="text-sm text-gray-500 hover:text-gray-700 underline"
+            class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline"
           >
             Reset to defaults
           </button>
 
           <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
+            <span class="text-sm text-green-600 dark:text-green-400">Settings saved ✓</span>
           </Show>
         </div>
       </div>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -102,13 +102,13 @@ export default function App() {
   };
 
   return (
-    <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
+    <div class="w-[360px] min-h-[400px] bg-red-50 dark:bg-gray-900 p-4 flex flex-col items-center">
       <div class="w-full flex justify-between items-center mb-4">
-        <h1 class="text-xl font-bold text-red-600">Tomate</h1>
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400">Tomate</h1>
         <button
           type="button"
           onClick={() => browser.runtime.openOptionsPage()}
-          class="text-gray-400 hover:text-gray-600 text-lg"
+          class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-lg"
           aria-label="Settings"
         >
           ⚙️
@@ -116,9 +116,9 @@ export default function App() {
       </div>
 
       <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+      <div class="text-4xl font-mono font-bold text-gray-800 dark:text-gray-100 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
+      <div class="text-sm text-gray-500 dark:text-gray-400 mt-1 transition-colors duration-300">
         <Switch>
           <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
           <Match when={state().phase === 'WORKING'}>Working</Match>
@@ -147,7 +147,7 @@ export default function App() {
       <button
         type="button"
         onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
-        class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        class="mt-2 text-xs text-red-400 dark:text-red-500 hover:text-red-600 dark:hover:text-red-300 underline"
       >
         View all stats →
       </button>

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -21,10 +21,10 @@ type StatCardProps = {
 
 function StatCard(props: StatCardProps) {
   return (
-    <div class="bg-white rounded-xl p-4 shadow-sm border border-red-100 flex flex-col items-center gap-1">
-      <span class="text-2xl font-bold text-red-600">{props.value}</span>
-      <span class="text-xs text-gray-500 font-medium">{props.label}</span>
-      {props.sublabel && <span class="text-[10px] text-gray-400">{props.sublabel}</span>}
+    <div class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-red-100 dark:border-gray-700 flex flex-col items-center gap-1">
+      <span class="text-2xl font-bold text-red-600 dark:text-red-400">{props.value}</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400 font-medium">{props.label}</span>
+      {props.sublabel && <span class="text-[10px] text-gray-400 dark:text-gray-500">{props.sublabel}</span>}
     </div>
   );
 }
@@ -56,13 +56,13 @@ export default function App() {
   const streak = () => computeStreak(sessions() ?? []);
 
   return (
-    <div class="min-h-screen bg-red-50 py-10 px-4">
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
+          <h1 class="text-2xl font-bold text-red-600 dark:text-red-400">Tomate Stats</h1>
           <Show when={(sessions() ?? []).length > 0}>
             <button
-              class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
+              class="text-sm px-3 py-1.5 rounded-lg border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors"
               onClick={() => exportCSV(sessions() ?? [])}
             >
               Export CSV
@@ -93,11 +93,11 @@ export default function App() {
             />
           </div>
 
-          <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-            <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
+          <div class="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-red-100 dark:border-gray-700">
+            <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">365-day activity</h2>
             <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
 
-            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
+            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400 dark:text-gray-500">
               <span>Less</span>
               <For each={INTENSITY_LEGEND}>
                 {(item) => (

--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -4,20 +4,20 @@ import { browser } from 'wxt/browser';
 const CONFETTI_CONFIGS: Record<string, confetti.Options> = {
   work: {
     particleCount: 150,
-    spread: 80,
-    origin: { y: 0.6 },
+    spread: 40,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#DC2626', '#16A34A', '#FBBF24'],
   },
   milestone: {
     particleCount: 300,
-    spread: 100,
-    origin: { y: 0.6 },
+    spread: 50,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#DC2626', '#16A34A', '#FBBF24', '#7C3AED', '#2563EB'],
   },
   break: {
     particleCount: 50,
-    spread: 60,
-    origin: { y: 0.6 },
+    spread: 35,
+    origin: { x: 0.5, y: 0.5 },
     colors: ['#60A5FA', '#34D399', '#A78BFA'],
   },
 };


### PR DESCRIPTION
## Summary

- **#206** — Options page: added `dark:` variants to all 8+ color classes (bg, card, heading, form labels, input borders, focus rings, helper text, saved confirmation)
- **#208** — Stats page: added `dark:` variants to `StatCard` component and page layout (bg, borders, headings, sub-labels, export button, heatmap section)
- **#210** — Popup `App.tsx`: added `dark:` variants to root container, title, settings icon, timer display, phase label, and "View all stats" link
- **#214** — `lib/celebration.ts`: fixed confetti overflow by centering `origin` at `{x: 0.5, y: 0.5}` and tightening `spread` (80→40 work, 100→50 milestone, 60→35 break) to keep particles within the popup's 360×400px bounds
- **#216** — `components/TimerRing.tsx`: added `stroke` CSS transition (400ms ease-in-out) via inline style on the progress circle; `components/Controls.tsx`: added `transition-opacity duration-200` to the button wrapper for smoother phase switches

## Test plan

- [x] `bun run build` — passes (920ms, all chunks generated)
- [x] `bun test` — 32/32 pass, 0 fail
- [ ] Manual: toggle OS dark mode and verify options, stats, and popup pages adapt correctly
- [ ] Manual: complete a session and verify confetti stays within popup bounds
- [ ] Manual: start/abandon a timer and verify the ring stroke color transitions smoothly

Closes #206
Closes #208
Closes #210
Closes #214
Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)