### PR TITLE
fix: validate UPDATE_CONFIG payload, guard stale alarms, log audio errors (#42, #45, #46)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -32,6 +32,22 @@ export type MessageAction =
   | { action: 'SKIP_LONG_BREAK' }
   | { action: 'UPDATE_CONFIG'; config: TimerConfig };
 
+const MAX_DURATION_MS = 120 * 60_000; // 120 minutes
+
+function isValidConfig(config: unknown): config is TimerConfig {
+  if (!config || typeof config !== 'object') return false;
+  const c = config as Record<string, unknown>;
+  // Accept any positive finite duration up to 120 min; UI enforces 1-min floor separately
+  const isValidDuration = (v: unknown) =>
+    typeof v === 'number' && isFinite(v) && v > 0 && v <= MAX_DURATION_MS;
+  return (
+    isValidDuration(c.workDuration) &&
+    isValidDuration(c.shortBreakDuration) &&
+    isValidDuration(c.longBreakDuration) &&
+    typeof c.openBreakTab === 'boolean'
+  );
+}
+
 export default defineBackground(() => {
   const ALARM_TIMER = 'tomate-timer';
   const ALARM_BADGE_REFRESH = 'badge-refresh';
@@ -185,6 +201,10 @@ export default defineBackground(() => {
         return nextState;
       }
       case 'UPDATE_CONFIG': {
+        if (!isValidConfig(message.config)) {
+          console.warn('[tomate] UPDATE_CONFIG rejected: invalid config payload', message.config);
+          return state;
+        }
         await setConfig(message.config);
         const nextState = adjustDuration(state, message.config);
         await setTimerState(nextState);
@@ -226,6 +246,13 @@ export default defineBackground(() => {
     }
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+
+    if (!isActivePhase(state.phase)) {
+      console.warn('[tomate] alarm fired in non-active phase', state.phase, '— skipping');
+      await clearActiveAlarms();
+      return;
+    }
+
     const completed = completeTimer(state, config);
     await setTimerState(completed);
 

--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -25,7 +25,7 @@ const CONFETTI_CONFIGS: Record<string, confetti.Options> = {
 export const playCelebration = (type: 'work' | 'milestone' | 'break'): void => {
   confetti(CONFETTI_CONFIGS[type]);
 
-  try {
-    new Audio(browser.runtime.getURL('/sounds/completion.mp3' as '/popup.html')).play();
-  } catch {}
+  new Audio(browser.runtime.getURL('/sounds/completion.mp3' as '/popup.html')).play().catch((err) => {
+    console.warn('[tomate] celebration audio playback failed:', err);
+  });
 };


### PR DESCRIPTION
## Summary

- **#42** — `UPDATE_CONFIG` message handler now validates the config payload via `isValidConfig()` before writing to storage. Rejects non-objects, NaN/Infinity/negative/out-of-bounds durations, and wrong types; logs a warning and returns current state unchanged.
- **#45** — Alarm handler now guards against stale alarms firing in non-active phases (`IDLE`, `BREAK_SUGGESTION`). Early-returns with a `console.warn` and clears the stale alarm instead of silently falling through `completeTimer`.
- **#46** — Replaced the empty `try/catch` in `playCelebration()` with `.catch(console.warn)`, making missing sound files and autoplay-policy blocks visible to developers via the browser console.

## Test plan

- [x] `bun run build` — passes cleanly
- [x] `bun test` — all 32 tests pass (including existing `UPDATE_CONFIG` test using sub-minute durations)
- [ ] Manually test: send a malformed `UPDATE_CONFIG` from devtools → should see console.warn and no state change
- [ ] Manually test: trigger an alarm while in IDLE state → should see console.warn and no phase change
- [ ] Manually test: complete a session → audio error (if any) should appear in popup devtools console

Closes #42
Closes #45
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)