### PR TITLE
fix: a11y and storage issues (#229, #230, #234, #236, #238, #239)

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -189,6 +189,8 @@ export default function Heatmap(props: HeatmapProps) {
                 {(cell) =>
                   cell ? (
                     <div
+                      role="gridcell"
+                      tabindex={0}
                       class="rounded-sm"
                       style={{
                         width: `${cellSize()}px`,
@@ -196,6 +198,7 @@ export default function Heatmap(props: HeatmapProps) {
                         "background-color": getIntensityColor(cell.count),
                       }}
                       title={tooltipText(cell)}
+                      aria-label={tooltipText(cell)}
                     />
                   ) : (
                     <div

--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -270,4 +270,21 @@ describe('background service worker', () => {
       }),
     );
   });
+
+  it('ignores messages with missing action field (issue #238)', async () => {
+    await initBackground();
+
+    const response = await fakeBrowser.runtime.sendMessage({ notAnAction: 'foo' });
+
+    // Should return undefined (no response) rather than stale state
+    expect(response).toBeUndefined();
+  });
+
+  it('ignores messages with misspelled action (issue #238)', async () => {
+    await initBackground();
+
+    const response = await fakeBrowser.runtime.sendMessage({ action: 'STRRT_TIMER' });
+
+    expect(response).toBeUndefined();
+  });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -139,7 +139,24 @@ export default defineBackground(() => {
     await refreshBadge();
   };
 
+  const VALID_ACTIONS = new Set([
+    'START_TIMER',
+    'ABANDON_TIMER',
+    'GET_STATE',
+    'ACCEPT_LONG_BREAK',
+    'SKIP_LONG_BREAK',
+    'UPDATE_CONFIG',
+  ]);
+
   const handleMessage = async (message: MessageAction) => {
+    if (
+      typeof message !== 'object' ||
+      message === null ||
+      !VALID_ACTIONS.has((message as { action?: unknown }).action as string)
+    ) {
+      return;
+    }
+
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
 
     switch (message.action) {
@@ -213,7 +230,15 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  browser.runtime.onMessage.addListener((message, sender) => {
+    // Reject messages from other extensions; allow messages from our own
+    // extension pages (sender.id === our id) and from within the service
+    // worker itself (sender.id may be absent in some environments).
+    if (sender.id !== undefined && sender.id !== browser.runtime.id) {
+      return;
+    }
+    return handleMessage(message as MessageAction);
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -148,6 +148,7 @@ export default function App() {
         type="button"
         onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        aria-label="View all stats"
       >
         View all stats →
       </button>

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -105,6 +105,8 @@ export default function App() {
                     class="w-3 h-3 rounded-sm"
                     style={{ "background-color": item.color }}
                     title={item.label}
+                    role="img"
+                    aria-label={`${item.label} tomate${item.label === '1' ? '' : 's'}`}
                   />
                 )}
               </For>

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -149,4 +149,45 @@ describe('storage helpers', () => {
     await setPendingCelebration(false);
     await expect(getPendingCelebration()).resolves.toBe(false);
   });
+
+  it('returns DEFAULT_CONFIG when storage is empty', async () => {
+    await expect(getConfig()).resolves.toEqual(DEFAULT_CONFIG);
+  });
+
+  it('coerces string duration values to numbers in stored config (issue #239)', async () => {
+    // Simulate a config where durations were stored as strings
+    await fakeBrowser.storage.local.set({
+      config: {
+        workDuration: '1500000',
+        shortBreakDuration: '300000',
+        longBreakDuration: '1800000',
+        openBreakTab: true,
+      },
+    });
+
+    const config = await getConfig();
+
+    expect(config.workDuration).toBe(1_500_000);
+    expect(config.shortBreakDuration).toBe(300_000);
+    expect(config.longBreakDuration).toBe(1_800_000);
+    expect(typeof config.workDuration).toBe('number');
+  });
+
+  it('falls back to DEFAULT_CONFIG values for non-positive or non-numeric durations', async () => {
+    await fakeBrowser.storage.local.set({
+      config: {
+        workDuration: -100,
+        shortBreakDuration: 'not-a-number',
+        longBreakDuration: 0,
+        openBreakTab: false,
+      },
+    });
+
+    const config = await getConfig();
+
+    expect(config.workDuration).toBe(DEFAULT_CONFIG.workDuration);
+    expect(config.shortBreakDuration).toBe(DEFAULT_CONFIG.shortBreakDuration);
+    expect(config.longBreakDuration).toBe(DEFAULT_CONFIG.longBreakDuration);
+    expect(config.openBreakTab).toBe(false);
+  });
 });

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -45,8 +45,24 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
   await browser.storage.local.set({ [KEYS.TIMER_STATE]: state });
 };
 
+const toPositiveNumber = (value: unknown, fallback: number): number => {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+const validateConfig = (raw: unknown): TimerConfig => {
+  if (raw === null || typeof raw !== 'object') return DEFAULT_CONFIG;
+  const r = raw as Record<string, unknown>;
+  return {
+    workDuration: toPositiveNumber(r.workDuration, DEFAULT_CONFIG.workDuration),
+    shortBreakDuration: toPositiveNumber(r.shortBreakDuration, DEFAULT_CONFIG.shortBreakDuration),
+    longBreakDuration: toPositiveNumber(r.longBreakDuration, DEFAULT_CONFIG.longBreakDuration),
+    openBreakTab: typeof r.openBreakTab === 'boolean' ? r.openBreakTab : DEFAULT_CONFIG.openBreakTab,
+  };
+};
+
 export const getConfig = async (): Promise<TimerConfig> =>
-  (await getStoredValue<TimerConfig>(KEYS.CONFIG)) ?? DEFAULT_CONFIG;
+  validateConfig(await getStoredValue<unknown>(KEYS.CONFIG));
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });


### PR DESCRIPTION
## Summary

- **#229** `Heatmap.tsx`: day cells were non-focusable divs — added `role="gridcell"`, `tabindex={0}`, and `aria-label` so keyboard users and screen readers can reach count data
- **#230** `stats/App.tsx`: intensity legend swatches had only a `title` attribute — added `role="img"` and `aria-label` with human-readable count range text
- **#234** `popup/App.tsx`: "View all stats →" button included the arrow glyph in its accessible name — added `aria-label="View all stats"` for a clean screen-reader label
- **#236** `background.ts`: `onMessage` listener now checks `sender.id` and silently ignores messages from any other extension ID
- **#238** `background.ts`: `handleMessage` now validates the `action` field at runtime before entering the switch, returning `undefined` for unknown/missing actions instead of stale state
- **#239** `storage.ts`: `getConfig` now runs stored values through `validateConfig`, coercing string durations to numbers and falling back to `DEFAULT_CONFIG` for any non-positive/non-numeric value, preventing `Date.now() + string` concatenation bugs

## Test plan

- [ ] `bun run build` — clean build, no type errors
- [ ] `bun test` — all 37 tests pass (5 new tests added for #238/#239)
- [ ] Manually open popup, verify keyboard focus lands on each heatmap cell
- [ ] Verify screen reader announces legend swatches correctly (e.g. "0 tomates", "1 tomate")
- [ ] Verify "View all stats" button reads cleanly without the arrow glyph
- [ ] Corrupt workDuration in `chrome.storage.local` to a string — confirm timer still starts correctly

Closes #229
Closes #230
Closes #234
Closes #236
Closes #238
Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)