### PR TITLE
fix: display error banner when stats createResource fails

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -70,6 +70,12 @@ export default function App() {
           </Show>
         </div>
 
+        <Show when={sessions.error || yearData.error}>
+          <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm mb-4" role="alert">
+            Failed to load session data. Try reloading the page.
+          </div>
+        </Show>
+
         <Show when={(sessions() ?? []).length === 0}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>


### PR DESCRIPTION
## Summary

- Adds a visible error banner in the Stats page when `sessions` or `yearData` `createResource` calls fail
- Previously, errors were silently discarded and users would see empty/missing data with no indication of a problem
- The banner renders above the stats cards using SolidJS `resource.error` reactive property

## Test plan

- [ ] Verify `bun run build` passes (confirmed locally)
- [ ] Verify `bun test` passes — 32 tests, 0 failures (confirmed locally)
- [ ] Manually test by mocking a storage failure: error banner appears above stats content
- [ ] Confirm no banner appears during normal operation

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)