### PR TITLE
fix: handle stats errors, filter storage listener, guard options save (#47, #48, #51)

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -12,6 +12,7 @@ export default function App() {
   const [longBreak, setLongBreak] = createSignal(30);
   const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [saved, setSaved] = createSignal(false);
+  const [saveError, setSaveError] = createSignal('');
 
   onMount(async () => {
     const config = await getConfig();
@@ -22,16 +23,22 @@ export default function App() {
   });
 
   const handleSave = async () => {
+    setSaveError('');
     const config: TimerConfig = {
       workDuration: work() * MS_PER_MINUTE,
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,
       longBreakDuration: longBreak() * MS_PER_MINUTE,
       openBreakTab: openBreakTab(),
     };
-    await setConfig(config);
-    await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    try {
+      await setConfig(config);
+      await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      console.error('[tomate] settings save failed:', err);
+      setSaveError('Save failed. Please try again.');
+    }
   };
 
   const handleReset = () => {
@@ -113,6 +120,9 @@ export default function App() {
 
           <Show when={saved()}>
             <span class="text-sm text-green-600">Settings saved ✓</span>
+          </Show>
+          <Show when={saveError()}>
+            <span class="text-sm text-red-600">{saveError()}</span>
           </Show>
         </div>
       </div>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -44,8 +44,11 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const onStorageChanged = (changes: Record<string, unknown>) => {
+      if ('sessions' in changes) refreshStats();
+    };
+    browser.storage.onChanged.addListener(onStorageChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onStorageChanged));
   });
 
   createEffect(() => {

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -50,34 +50,44 @@ export default function App() {
   const [sessions] = createResource(() => getSessionHistory());
   const [todayCount] = createResource(() => getTodayCount());
 
-  const total = () => computeTotalCount(sessions() ?? []);
-  const week = () => computeWeekCount(sessions() ?? []);
-  const bestDay = () => computeBestDay(sessions() ?? []);
-  const streak = () => computeStreak(sessions() ?? []);
+  const hasError = () => !!(sessions.error || yearData.error || todayCount.error);
+  const sessionList = () => sessions() ?? [];
+
+  const total = () => computeTotalCount(sessionList());
+  const week = () => computeWeekCount(sessionList());
+  const bestDay = () => computeBestDay(sessionList());
+  const streak = () => computeStreak(sessionList());
 
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <div class="flex items-center justify-between mb-6">
           <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
-          <Show when={(sessions() ?? []).length > 0}>
+          <Show when={sessionList().length > 0 && !hasError()}>
             <button
               class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
-              onClick={() => exportCSV(sessions() ?? [])}
+              onClick={() => exportCSV(sessionList())}
             >
               Export CSV
             </button>
           </Show>
         </div>
 
-        <Show when={(sessions() ?? []).length === 0}>
+        <Show when={hasError()}>
+          <div class="text-center py-8 text-red-500">
+            <p class="text-lg font-medium">Failed to load stats</p>
+            <p class="text-sm mt-1">Please close and reopen this page. If the problem persists, check your browser storage.</p>
+          </div>
+        </Show>
+
+        <Show when={!hasError() && sessionList().length === 0}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>
             <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
           </div>
         </Show>
 
-        <Show when={(sessions() ?? []).length > 0}>
+        <Show when={!hasError() && sessionList().length > 0}>
           <div class="grid grid-cols-5 gap-3 mb-6">
             <StatCard label="Total tomates" value={total()} />
             <StatCard label="Today" value={todayCount() ?? 0} />


### PR DESCRIPTION
## Summary

- **#47** — `stats/App.tsx` now checks `resource.error` explicitly. When any of the three async loads fail, the page renders a descriptive error message instead of silently showing zeros (which was possible because `?? fallback` only catches `null`/`undefined`, not error states).
- **#48** — Popup's `browser.storage.onChanged` listener is now filtered: `refreshStats()` only fires when `'sessions'` is in the changed keys, preventing unnecessary `getTodayCount()` + `getHeatmapData()` calls on every config, label, or state update.
- **#51** — Options `handleSave` is wrapped in `try/catch`. The success message (`Settings saved ✓`) only appears after both `setConfig` and `sendMessage` resolve. On failure, a red error message is shown to the user and the error is logged to the console.

## Test plan

- [x] `bun run build` — passes cleanly
- [x] `bun test` — all 32 tests pass
- [ ] Manually test stats page with storage mocked to throw → should see error message, not zeros
- [ ] Verify popup storage listener: changing config in options should NOT trigger a stats refresh in the popup (check devtools network/console)
- [ ] Test options save with storage full or background script unavailable → should show red error instead of false success

Closes #47
Closes #48
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)