### PR TITLE
fix: guard persistCompletedSession behind successful setTimerState write

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -227,8 +227,15 @@ export default defineBackground(() => {
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
     const completed = completeTimer(state, config);
-    await setTimerState(completed);
 
+    try {
+      await setTimerState(completed);
+    } catch (err) {
+      console.error('[onAlarm] setTimerState failed — aborting to avoid inconsistent state', err);
+      return;
+    }
+
+    // Only persist session and send notifications after state write succeeded
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
       await browser.notifications.create({


### PR DESCRIPTION
## Summary

- Wraps `setTimerState(completed)` in a try-catch inside the `onAlarm` handler in `entrypoints/background.ts`
- If `setTimerState` throws, the handler now returns early, preventing `persistCompletedSession` and notifications from running against stale/unwritten state
- Adds a `console.error` log so failures are visible in the background service worker console

## Test plan

- [x] `bun run build` passes
- [x] `bun test` passes (32/32)
- [ ] Manually trigger an alarm while mocking `setTimerState` to throw — confirm no session is persisted and no notification is fired

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)