### PR TITLE
fix: UI/UX issues #149–#158 (settings feedback, a11y, error handling, perf)

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -3,13 +3,18 @@ import type { TimerPhase } from '@/lib/types';
 
 type ControlsProps = {
   phase: TimerPhase;
+  loading?: boolean;
   onStart: () => void;
   onAbandon: () => void;
   onAcceptLongBreak: () => void;
   onSkipLongBreak: () => void;
 };
 
+const disabledClass = 'disabled:opacity-60 disabled:cursor-not-allowed';
+
 export default function Controls(props: ControlsProps) {
+  const busy = () => props.loading ?? false;
+
   return (
     <div class="mt-5 flex gap-3 justify-center">
       <Switch>
@@ -17,43 +22,53 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
-            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
+            disabled={busy()}
+            aria-busy={busy()}
+            class={`px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors ${disabledClass}`}
           >
-            Start
+            {busy() ? 'Starting…' : 'Start'}
           </button>
         </Match>
         <Match when={props.phase === 'WORKING'}>
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={busy()}
+            aria-busy={busy()}
+            class={`px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors ${disabledClass}`}
           >
-            Abandon
+            {busy() ? 'Updating…' : 'Abandon'}
           </button>
         </Match>
         <Match when={props.phase === 'SHORT_BREAK' || props.phase === 'LONG_BREAK'}>
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={busy()}
+            aria-busy={busy()}
+            class={`px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors ${disabledClass}`}
           >
-            Skip Break
+            {busy() ? 'Updating…' : 'Skip Break'}
           </button>
         </Match>
         <Match when={props.phase === 'BREAK_SUGGESTION'}>
           <button
             type="button"
             onClick={props.onAcceptLongBreak}
-            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
+            disabled={busy()}
+            aria-busy={busy()}
+            class={`px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors ${disabledClass}`}
           >
-            Long Break
+            {busy() ? 'Updating…' : 'Long Break'}
           </button>
           <button
             type="button"
             onClick={props.onSkipLongBreak}
-            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={busy()}
+            aria-busy={busy()}
+            class={`px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors ${disabledClass}`}
           >
-            Skip
+            {busy() ? 'Updating…' : 'Skip'}
           </button>
         </Match>
       </Switch>

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -196,6 +196,8 @@ export default function Heatmap(props: HeatmapProps) {
                         "background-color": getIntensityColor(cell.count),
                       }}
                       title={tooltipText(cell)}
+                      aria-label={tooltipText(cell)}
+                      tabIndex={-1}
                     />
                   ) : (
                     <div
@@ -203,6 +205,7 @@ export default function Heatmap(props: HeatmapProps) {
                         width: `${cellSize()}px`,
                         height: `${cellSize()}px`,
                       }}
+                      aria-hidden="true"
                     />
                   )
                 }

--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -1,17 +1,50 @@
+import { createSignal } from 'solid-js';
+
+const MAX_LENGTH = 50;
+
 type TaskLabelProps = {
   value: string;
   onChange: (value: string) => void;
 };
 
 export default function TaskLabel(props: TaskLabelProps) {
+  const [focused, setFocused] = createSignal(false);
+  const remaining = () => MAX_LENGTH - props.value.length;
+
   return (
-    <input
-      type="text"
-      value={props.value}
-      onInput={(e) => props.onChange(e.currentTarget.value)}
-      placeholder="What are you working on?"
-      maxLength={50}
-      class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
-    />
+    <div class="w-full mt-4">
+      <label
+        for="task-label-input"
+        class="block text-xs font-medium text-gray-500 mb-1"
+      >
+        Task label{' '}
+        <span class="font-normal text-gray-400">(optional, max {MAX_LENGTH} chars)</span>
+      </label>
+      <div class="relative">
+        <input
+          id="task-label-input"
+          type="text"
+          value={props.value}
+          onInput={(e) => props.onChange(e.currentTarget.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          placeholder="What are you working on?"
+          maxLength={MAX_LENGTH}
+          aria-describedby="task-label-counter"
+          class="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
+        />
+        {(focused() || props.value.length > 0) && (
+          <span
+            id="task-label-counter"
+            aria-live="polite"
+            class={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] pointer-events-none ${
+              remaining() <= 10 ? 'text-red-400' : 'text-gray-400'
+            }`}
+          >
+            {remaining()}/{MAX_LENGTH}
+          </span>
+        )}
+      </div>
+    </div>
   );
 }

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -231,28 +231,42 @@ export default defineBackground(() => {
 
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: '🍅 Tomate Complete!',
-        message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-      });
+      try {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: '🍅 Tomate Complete!',
+          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+        });
+      } catch (err) {
+        console.error('[tomate] failed to show work-complete notification:', err);
+      }
       if (config.openBreakTab !== false) {
         try {
           await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
         } catch {
-          // tab creation can fail if no browser window is open
+          // tabs.create() can fail when no browser window is open (e.g. all windows
+          // were closed before the alarm fired). Fall back to creating a new window.
+          try {
+            await browser.windows.create({ url: browser.runtime.getURL('/stats.html') });
+          } catch (err) {
+            console.error('[tomate] failed to open stats tab or window:', err);
+          }
         }
       }
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      await browser.notifications.create({
-        type: 'basic',
-        iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-        title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-        message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-      });
+      try {
+        await browser.notifications.create({
+          type: 'basic',
+          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+        });
+      } catch (err) {
+        console.error('[tomate] failed to show break-complete notification:', err);
+      }
     }
 
     if (isActivePhase(completed.phase) && completed.endTime !== null) {

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -12,6 +12,7 @@ export default function App() {
   const [longBreak, setLongBreak] = createSignal(30);
   const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [saved, setSaved] = createSignal(false);
+  const [isSaving, setIsSaving] = createSignal(false);
 
   onMount(async () => {
     const config = await getConfig();
@@ -22,16 +23,22 @@ export default function App() {
   });
 
   const handleSave = async () => {
-    const config: TimerConfig = {
-      workDuration: work() * MS_PER_MINUTE,
-      shortBreakDuration: shortBreak() * MS_PER_MINUTE,
-      longBreakDuration: longBreak() * MS_PER_MINUTE,
-      openBreakTab: openBreakTab(),
-    };
-    await setConfig(config);
-    await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    if (isSaving()) return;
+    setIsSaving(true);
+    try {
+      const config: TimerConfig = {
+        workDuration: work() * MS_PER_MINUTE,
+        shortBreakDuration: shortBreak() * MS_PER_MINUTE,
+        longBreakDuration: longBreak() * MS_PER_MINUTE,
+        openBreakTab: openBreakTab(),
+      };
+      await setConfig(config);
+      await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleReset = () => {
@@ -45,6 +52,11 @@ export default function App() {
     <div class="min-h-screen bg-red-50 flex items-start justify-center pt-16">
       <div class="w-full max-w-[400px] bg-white rounded-lg shadow-sm p-6">
         <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
+
+        <div class="mb-4 flex items-start gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-700">
+          <span class="mt-0.5 shrink-0">ℹ️</span>
+          <span>Changes to durations apply to new sessions, not the currently active timer.</span>
+        </div>
 
         <div class="space-y-4">
           <label class="block">
@@ -98,9 +110,11 @@ export default function App() {
           <button
             type="button"
             onClick={handleSave}
-            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            disabled={isSaving()}
+            aria-label="Save settings. Duration changes apply to the next session."
+            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            Save
+            {isSaving() ? 'Saving…' : 'Save'}
           </button>
 
           <button
@@ -112,7 +126,7 @@ export default function App() {
           </button>
 
           <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
+            <span class="text-sm text-green-600">Settings saved. Duration changes apply to the next session.</span>
           </Show>
         </div>
       </div>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, Switch, Match, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
@@ -19,12 +19,29 @@ import TaskLabel from '@/components/TaskLabel';
 import TodayCount from '@/components/TodayCount';
 import Heatmap from '@/components/Heatmap';
 
+const SEND_TIMEOUT_MS = 5_000;
+
+function sendMessageWithTimeout<T>(message: unknown): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('sendMessage timed out')),
+      SEND_TIMEOUT_MS,
+    );
+    browser.runtime.sendMessage(message).then(
+      (res) => { clearTimeout(timer); resolve(res as T); },
+      (err) => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
+
 export default function App() {
   const [state, setState] = createSignal<TimerState>(INITIAL_STATE);
   const [remaining, setRemaining] = createSignal(0);
   const [label, setLabel] = createSignal('');
   const [todayCount, setTodayCount] = createSignal(0);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [bgError, setBgError] = createSignal(false);
+  const [controlsLoading, setControlsLoading] = createSignal(false);
 
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
@@ -32,8 +49,16 @@ export default function App() {
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    let currentState: TimerState;
+    try {
+      currentState = await sendMessageWithTimeout<TimerState>({ action: 'GET_STATE' });
+      setBgError(false);
+    } catch (err) {
+      console.error('[tomate] popup could not reach background service worker:', err);
+      setBgError(true);
+      currentState = INITIAL_STATE;
+    }
+    setState(currentState);
 
     const pending = await getPendingCelebration();
     if (pending) {
@@ -44,8 +69,15 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const statsListener = (changes: Record<string, unknown>) => {
+      // Only refresh when session data changes, not on every storage write
+      // (e.g. timerState, currentLabel, pendingCelebration all write frequently)
+      if ('sessions' in changes) {
+        refreshStats();
+      }
+    };
+    browser.storage.onChanged.addListener(statsListener);
+    onCleanup(() => browser.storage.onChanged.removeListener(statsListener));
   });
 
   createEffect(() => {
@@ -74,24 +106,34 @@ export default function App() {
     return 1 - remaining() / s.duration;
   };
 
-  const startTimer = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'START_TIMER' });
-    setState(newState as TimerState);
+  const sendAction = async (action: string) => {
+    if (controlsLoading()) return;
+    setControlsLoading(true);
+    try {
+      const newState = await sendMessageWithTimeout<TimerState>({ action });
+      setState(newState);
+      setBgError(false);
+    } catch (err) {
+      console.error(`[tomate] action ${action} failed:`, err);
+      setBgError(true);
+    } finally {
+      setControlsLoading(false);
+    }
   };
 
-  const abandonTimer = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
-    setState(newState as TimerState);
-  };
+  const startTimer = () => sendAction('START_TIMER');
+  const abandonTimer = () => sendAction('ABANDON_TIMER');
+  const acceptLongBreak = () => sendAction('ACCEPT_LONG_BREAK');
+  const skipLongBreak = () => sendAction('SKIP_LONG_BREAK');
 
-  const acceptLongBreak = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
-    setState(newState as TimerState);
-  };
-
-  const skipLongBreak = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
-    setState(newState as TimerState);
+  const reconnect = async () => {
+    setBgError(false);
+    try {
+      const currentState = await sendMessageWithTimeout<TimerState>({ action: 'GET_STATE' });
+      setState(currentState);
+    } catch {
+      setBgError(true);
+    }
   };
 
   let labelTimeout: ReturnType<typeof setTimeout>;
@@ -109,11 +151,25 @@ export default function App() {
           type="button"
           onClick={() => browser.runtime.openOptionsPage()}
           class="text-gray-400 hover:text-gray-600 text-lg"
-          aria-label="Settings"
+          aria-label="Open settings"
+          tabIndex={0}
         >
           ⚙️
         </button>
       </div>
+
+      <Show when={bgError()}>
+        <div class="w-full mb-2 flex items-center justify-between gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-1.5 text-xs text-amber-700">
+          <span>Timer unavailable. Try reloading.</span>
+          <button
+            type="button"
+            onClick={reconnect}
+            class="underline font-medium hover:text-amber-900"
+          >
+            Reconnect
+          </button>
+        </div>
+      </Show>
 
       <TimerRing progress={progress()} phase={state().phase} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
@@ -132,6 +188,7 @@ export default function App() {
 
       <Controls
         phase={state().phase}
+        loading={controlsLoading()}
         onStart={startTimer}
         onAbandon={abandonTimer}
         onAcceptLongBreak={acceptLongBreak}
@@ -148,6 +205,7 @@ export default function App() {
         type="button"
         onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        tabIndex={0}
       >
         View all stats →
       </button>

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -46,21 +46,44 @@ function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
 }
 
 export default function App() {
-  const [yearData] = createResource(() => getHeatmapData(365));
-  const [sessions] = createResource(() => getSessionHistory());
-  const [todayCount] = createResource(() => getTodayCount());
+  const [yearData, { refetch: refetchYearData }] = createResource(() =>
+    getHeatmapData(365).catch((err) => {
+      console.error('[tomate] failed to load heatmap data:', err);
+      throw err;
+    }),
+  );
+  const [sessions, { refetch: refetchSessions }] = createResource(() =>
+    getSessionHistory().catch((err) => {
+      console.error('[tomate] failed to load session history:', err);
+      throw err;
+    }),
+  );
+  const [todayCount, { refetch: refetchTodayCount }] = createResource(() =>
+    getTodayCount().catch((err) => {
+      console.error('[tomate] failed to load today count:', err);
+      throw err;
+    }),
+  );
+
+  const retryAll = () => {
+    refetchYearData();
+    refetchSessions();
+    refetchTodayCount();
+  };
 
   const total = () => computeTotalCount(sessions() ?? []);
   const week = () => computeWeekCount(sessions() ?? []);
   const bestDay = () => computeBestDay(sessions() ?? []);
   const streak = () => computeStreak(sessions() ?? []);
 
+  const anyError = () => yearData.error || sessions.error || todayCount.error;
+
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <div class="flex items-center justify-between mb-6">
           <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
-          <Show when={(sessions() ?? []).length > 0}>
+          <Show when={(sessions() ?? []).length > 0 && !anyError()}>
             <button
               class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
               onClick={() => exportCSV(sessions() ?? [])}
@@ -70,14 +93,27 @@ export default function App() {
           </Show>
         </div>
 
-        <Show when={(sessions() ?? []).length === 0}>
+        <Show when={anyError()}>
+          <div class="text-center py-8">
+            <p class="text-lg text-red-600 font-medium">Failed to load stats.</p>
+            <p class="text-sm mt-1 text-gray-500">Please try refreshing.</p>
+            <button
+              class="mt-4 text-sm px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors"
+              onClick={retryAll}
+            >
+              Retry
+            </button>
+          </div>
+        </Show>
+
+        <Show when={!anyError() && (sessions() ?? []).length === 0}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>
             <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
           </div>
         </Show>
 
-        <Show when={(sessions() ?? []).length > 0}>
+        <Show when={!anyError() && (sessions() ?? []).length > 0}>
           <div class="grid grid-cols-5 gap-3 mb-6">
             <StatCard label="Total tomates" value={total()} />
             <StatCard label="Today" value={todayCount() ?? 0} />


### PR DESCRIPTION
## Summary

- **#149** — Options page now shows an info callout ("Duration changes apply to new sessions, not the active timer"), the Save button is debounced with an `isSaving` guard to prevent double-submit, and the success toast text is more precise.
- **#150** — Popup tab order clarified: settings/stats buttons have explicit `tabIndex=0`; heatmap cells get `tabIndex=-1` (non-interactive) and `aria-hidden="true"` / `aria-label` as appropriate.
- **#151** — Stats page `createResource` calls now wrap in `.catch()` with `console.error` logging; a user-visible error banner with a **Retry** button is shown on failure.
- **#152** — Both `browser.notifications.create()` calls in `background.ts` are wrapped in `try/catch` with `console.error` so a notification failure never silently swallows an error or kills timer processing.
- **#154** — `TaskLabel` now has a visible `<label>` element with `htmlFor`, and a remaining-character counter (`38/50`) that appears when the input is focused or non-empty.
- **#155** — `tabs.create()` failure in `background.ts` now falls back to `windows.create()` (handles the "no window open" edge case), with a final `console.error` if that also fails.
- **#156** — Popup `storage.onChanged` listener is scoped to the `sessions` key only; `refreshStats()` no longer fires on every `timerState`/`currentLabel`/`pendingCelebration` write.
- **#157** — `sendMessage` in the popup is wrapped in a 5-second `sendMessageWithTimeout`; on timeout/failure the popup shows an amber "Timer unavailable" banner with a **Reconnect** button.
- **#158** — `Controls` accepts a `loading` prop; buttons are `disabled` and show "Updating…" / "Starting…" text while a `sendAction` is in-flight, preventing double-submission.

## Test plan
- [x] `bun run build` — clean build, no TS errors
- [x] `bun test` — 32/32 pass

Closes #149
Closes #150
Closes #151
Closes #152
Closes #154
Closes #155
Closes #156
Closes #157
Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)