### PR TITLE
fix: apply blocking rules on startup if phase is WORKING

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/timer';
 import {
   addCompletedSession,
+  getBlockedSites,
   getConfig,
   getCurrentLabel,
   getTimerState,
@@ -22,6 +23,7 @@ import {
   setTimerState,
   toDateKey,
 } from '@/lib/storage';
+import { applyBlockingRules, clearBlockingRules } from '@/lib/blocking';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
 
 export type MessageAction =
@@ -205,12 +207,27 @@ export default defineBackground(() => {
     }
   };
 
+  const applyBlockingOnStartup = async (): Promise<void> => {
+    const [startupState, startupSites] = await Promise.all([getTimerState(), getBlockedSites()]);
+    try {
+      if (startupState.phase === 'WORKING' && startupSites.length > 0) {
+        await applyBlockingRules(startupSites);
+      } else {
+        await clearBlockingRules();
+      }
+    } catch {
+      // blocking rules are best-effort; don't crash the handler
+    }
+  };
+
   browser.runtime.onInstalled.addListener(async () => {
     await recoverFromMissedAlarm();
+    await applyBlockingOnStartup();
   });
 
   browser.runtime.onStartup.addListener(async () => {
     await recoverFromMissedAlarm();
+    await applyBlockingOnStartup();
   });
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));

--- a/lib/blocking.ts
+++ b/lib/blocking.ts
@@ -1,0 +1,39 @@
+import { browser } from 'wxt/browser';
+
+// Rule IDs are allocated from this base to avoid conflicts with any static rules.
+const DYNAMIC_RULE_ID_BASE = 1000;
+
+/**
+ * Replaces all dynamic DNR blocking rules with new ones derived from the
+ * supplied list of hostname/URL patterns.
+ */
+export const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+  const removeRuleIds = existingRules.map((r) => r.id);
+
+  const addRules = sites.map((site, index) => ({
+    id: DYNAMIC_RULE_ID_BASE + index,
+    priority: 1,
+    action: { type: 'block' as const },
+    condition: {
+      urlFilter: site,
+      resourceTypes: ['main_frame' as const],
+    },
+  }));
+
+  await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules });
+};
+
+/**
+ * Removes all dynamic DNR blocking rules.
+ */
+export const clearBlockingRules = async (): Promise<void> => {
+  const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+  const removeRuleIds = existingRules.map((r) => r.id);
+
+  if (removeRuleIds.length === 0) {
+    return;
+  }
+
+  await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules: [] });
+};

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -14,6 +14,7 @@ const KEYS = {
   SESSIONS: 'sessions',
   PENDING_CELEBRATION: 'pendingCelebration',
   CURRENT_LABEL: 'currentLabel',
+  BLOCKED_SITES: 'blockedSites',
 } as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -102,4 +103,11 @@ export const getCurrentLabel = async (): Promise<string> =>
 
 export const setCurrentLabel = async (label: string): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CURRENT_LABEL]: label.slice(0, MAX_LABEL_LENGTH) });
+};
+
+export const getBlockedSites = async (): Promise<string[]> =>
+  (await getStoredValue<string[]>(KEYS.BLOCKED_SITES)) ?? [];
+
+export const setBlockedSites = async (sites: string[]): Promise<void> => {
+  await browser.storage.local.set({ [KEYS.BLOCKED_SITES]: sites });
 };

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Tomate',
     description: 'A Pomodoro timer that helps you focus — one tomate at a time.',
-    permissions: ['alarms', 'notifications', 'storage', 'tabs'],
+    permissions: ['alarms', 'declarativeNetRequest', 'notifications', 'storage', 'tabs'],
     action: {
       default_icon: {
         '16': '/icons/icon-16.png',


### PR DESCRIPTION
## Summary

- `storage.onChanged` only fires when values change, so a persisted `phase=WORKING` on restart left blocking rules absent
- Adds `applyBlockingOnStartup()` helper called from both `onInstalled` and `onStartup` listeners
- New `lib/blocking.ts` with `applyBlockingRules` / `clearBlockingRules` using the DNR dynamic-rules API
- New `getBlockedSites` / `setBlockedSites` added to `lib/storage.ts`
- `declarativeNetRequest` permission added to manifest
- Try/catch wraps the blocking calls so a DNR failure cannot crash the startup handler

## Test plan

- [ ] Build passes (`bun run build`)
- [ ] All 32 tests pass (`bun test`)
- [ ] Load unpacked extension with a saved `blockedSites` list and `phase=WORKING` in storage — verify blocked sites are unreachable immediately after browser restart without interacting with the extension
- [ ] Load with `phase=IDLE` or empty `blockedSites` — verify no DNR rules are added and previously blocked sites are reachable

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)