### PR TITLE
fix(a11y): add ARIA progressbar to TimerRing and contextual labels to Controls (#52, #53)

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -17,6 +17,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
+            aria-label="Start a focus session"
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
           >
             Start
@@ -26,6 +27,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
+            aria-label="Abandon the current focus session"
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Abandon
@@ -35,6 +37,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
+            aria-label="Skip the current break and return to idle"
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Skip Break
@@ -44,6 +47,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAcceptLongBreak}
+            aria-label="Start a long break (you've earned it!)"
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
           >
             Long Break
@@ -51,6 +55,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onSkipLongBreak}
+            aria-label="Skip the long break and return to idle"
             class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
             Skip

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -3,6 +3,8 @@ import type { TimerPhase } from '@/lib/types';
 type TimerRingProps = {
   progress: number;
   phase: TimerPhase;
+  /** Formatted time string, e.g. "24:30", used for accessible announcements */
+  timeLabel?: string;
 };
 
 const PHASE_COLORS: Record<TimerPhase, string> = {
@@ -13,6 +15,14 @@ const PHASE_COLORS: Record<TimerPhase, string> = {
   BREAK_SUGGESTION: '#CA8A04',
 };
 
+const PHASE_LABELS: Record<TimerPhase, string> = {
+  IDLE: 'Idle',
+  WORKING: 'Working',
+  SHORT_BREAK: 'Short break',
+  LONG_BREAK: 'Long break',
+  BREAK_SUGGESTION: 'Long break suggested',
+};
+
 const SIZE = 160;
 const STROKE = 8;
 const RADIUS = (SIZE - STROKE) / 2;
@@ -21,10 +31,25 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 export default function TimerRing(props: TimerRingProps) {
   const offset = () => CIRCUMFERENCE * (1 - props.progress);
   const color = () => PHASE_COLORS[props.phase];
+  const progressPct = () => Math.round(props.progress * 100);
+  const ariaLabel = () =>
+    props.timeLabel
+      ? `${PHASE_LABELS[props.phase]} — ${props.timeLabel} remaining`
+      : PHASE_LABELS[props.phase];
 
   return (
-    <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      <title>Timer progress</title>
+    <svg
+      width={SIZE}
+      height={SIZE}
+      class="timer-ring"
+      viewBox={`0 0 ${SIZE} ${SIZE}`}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={progressPct()}
+      aria-label={ariaLabel()}
+    >
+      <title>{ariaLabel()}</title>
       <circle
         cx={SIZE / 2}
         cy={SIZE / 2}

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -115,7 +115,7 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
+      <TimerRing progress={progress()} phase={state().phase} timeLabel={formatTime()} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
       <div class="text-sm text-gray-500 mt-1">


### PR DESCRIPTION
## Summary

- **#52** — `TimerRing` SVG now has `role="progressbar"` with `aria-valuemin={0}`, `aria-valuemax={100}`, `aria-valuenow` (updated every second as the timer ticks), and a dynamic `aria-label` + `<title>` that combines the current phase and time remaining (e.g. _"Working — 24:30 remaining"_). A new optional `timeLabel` prop is threaded from `popup/App.tsx`.
- **#53** — All control buttons in `Controls.tsx` now have descriptive `aria-label` attributes with context:
  - **Start** → `"Start a focus session"`
  - **Abandon** → `"Abandon the current focus session"`
  - **Skip Break** → `"Skip the current break and return to idle"`
  - **Long Break** → `"Start a long break (you've earned it!)"`
  - **Skip** (at break suggestion) → `"Skip the long break and return to idle"`

## Test plan

- [x] `bun run build` — passes cleanly
- [x] `bun test` — all 32 tests pass
- [ ] Test with VoiceOver/NVDA: timer ring should announce phase + remaining time; buttons should read contextual labels
- [ ] Verify `aria-valuenow` updates each second while timer is running

Closes #52
Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)