### PR TITLE
fix(196-202): background service & storage issues

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -1,4 +1,4 @@
-import { For, createMemo } from 'solid-js';
+import { For, createMemo, Show } from 'solid-js';
 
 type HeatmapProps = {
   data: Record<string, number>;
@@ -65,6 +65,7 @@ const generateHeatmapGrid = (
 };
 
 type MonthLabel = { label: string; column: number };
+type YearLabel = { year: number; column: number };
 
 export default function Heatmap(props: HeatmapProps) {
   const cellSize = () => props.cellSize ?? 12;
@@ -119,6 +120,28 @@ export default function Heatmap(props: HeatmapProps) {
     return labels;
   });
 
+  const yearLabels = createMemo((): YearLabel[] => {
+    const cols = columns();
+    const labels: YearLabel[] = [];
+    let lastYear = -1;
+
+    for (let c = 0; c < cols.length; c++) {
+      const firstCell = cols[c].find((cell) => cell !== null);
+      if (firstCell) {
+        const year = Number.parseInt(firstCell.date.split('-')[0], 10);
+        if (year !== lastYear) {
+          labels.push({ year, column: c });
+          lastYear = year;
+        }
+      }
+    }
+
+    // Only show year labels if the grid spans more than one year
+    return labels.length > 1 ? labels : [];
+  });
+
+  const multiYear = () => yearLabels().length > 1;
+
   const tooltipText = (cell: HeatmapCell) => {
     const count = cell.count;
     const label = count === 0 ? 'No tomates' : `${count} tomate${count !== 1 ? 's' : ''}`;
@@ -129,6 +152,30 @@ export default function Heatmap(props: HeatmapProps) {
 
   return (
     <div class="w-full overflow-x-auto">
+      {/* Year labels — only rendered when heatmap spans multiple calendar years */}
+      <Show when={multiYear()}>
+        <div class="flex mb-0.5" style={{ "padding-left": `${labelWidth}px` }}>
+          <For each={yearLabels()}>
+            {(yl, i) => {
+              const nextCol = () => {
+                const labels = yearLabels();
+                const idx = i();
+                return idx < labels.length - 1 ? labels[idx + 1].column : columns().length;
+              };
+              const width = () => (nextCol() - yl.column) * (cellSize() + gap);
+              return (
+                <span
+                  class="text-[9px] font-semibold text-red-400 inline-block overflow-hidden"
+                  style={{ width: `${width()}px`, "min-width": `${width()}px` }}
+                >
+                  {yl.year}
+                </span>
+              );
+            }}
+          </For>
+        </div>
+      </Show>
+
       {/* Month labels */}
       <div class="flex" style={{ "padding-left": `${labelWidth}px` }}>
         <For each={monthLabels()}>

--- a/components/TodayCount.tsx
+++ b/components/TodayCount.tsx
@@ -1,11 +1,39 @@
+import { Show } from 'solid-js';
+
 type TodayCountProps = {
   count: number;
+  goal?: number;
 };
 
 export default function TodayCount(props: TodayCountProps) {
+  const hasGoal = () => (props.goal ?? 0) > 0;
+  const pct = () => {
+    const g = props.goal ?? 0;
+    if (g <= 0) return 0;
+    return Math.min(100, Math.round((props.count / g) * 100));
+  };
+  const goalReached = () => hasGoal() && props.count >= (props.goal ?? 0);
+
   return (
-    <div class="mt-4 text-sm text-gray-500">
-      🍅 {props.count} tomate{props.count !== 1 ? 's' : ''} today
+    <div class="mt-4 w-full">
+      <div class="text-sm text-gray-500 text-center">
+        🍅 {props.count} tomate{props.count !== 1 ? 's' : ''} today
+        <Show when={hasGoal()}>
+          <span class="ml-1 text-gray-400">/ {props.goal} goal</span>
+        </Show>
+      </div>
+      <Show when={hasGoal()}>
+        <div class="mt-1 w-full bg-gray-200 rounded-full h-1.5 overflow-hidden">
+          <div
+            class={`h-1.5 rounded-full transition-all duration-300 ${goalReached() ? 'bg-green-500' : 'bg-red-400'}`}
+            style={{ width: `${pct()}%` }}
+            role="progressbar"
+            aria-valuenow={props.count}
+            aria-valuemax={props.goal}
+            aria-label="Daily goal progress"
+          />
+        </div>
+      </Show>
     </div>
   );
 }

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -11,6 +11,7 @@ export default function App() {
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
   const [openBreakTab, setOpenBreakTab] = createSignal(true);
+  const [dailyGoal, setDailyGoal] = createSignal(DEFAULT_CONFIG.dailyGoal);
   const [saved, setSaved] = createSignal(false);
 
   onMount(async () => {
@@ -19,6 +20,7 @@ export default function App() {
     setShortBreak(Math.round(config.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
     setOpenBreakTab(config.openBreakTab !== false);
+    setDailyGoal(config.dailyGoal ?? DEFAULT_CONFIG.dailyGoal);
   });
 
   const handleSave = async () => {
@@ -27,6 +29,7 @@ export default function App() {
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,
       longBreakDuration: longBreak() * MS_PER_MINUTE,
       openBreakTab: openBreakTab(),
+      dailyGoal: dailyGoal(),
     };
     await setConfig(config);
     await browser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config });
@@ -39,6 +42,7 @@ export default function App() {
     setShortBreak(Math.round(DEFAULT_CONFIG.shortBreakDuration / MS_PER_MINUTE));
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
     setOpenBreakTab(DEFAULT_CONFIG.openBreakTab);
+    setDailyGoal(DEFAULT_CONFIG.dailyGoal);
   };
 
   return (
@@ -81,6 +85,19 @@ export default function App() {
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+          </label>
+
+          <label class="block">
+            <span class="text-sm font-medium text-gray-700">Daily Goal (tomates)</span>
+            <input
+              type="number"
+              min={0}
+              max={50}
+              value={dailyGoal()}
+              onInput={(e) => setDailyGoal(Number(e.currentTarget.value))}
+              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+            />
+            <span class="text-xs text-gray-400 mt-0.5 block">Set to 0 to disable the goal progress bar.</span>
           </label>
 
           <label class="flex items-center gap-3 cursor-pointer">

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,9 +1,10 @@
-import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, Switch, Match, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
 import { playCelebration } from '@/lib/celebration';
 import {
+  getConfig,
   getPendingCelebration,
   setPendingCelebration,
   getCurrentLabel,
@@ -19,27 +20,65 @@ import TaskLabel from '@/components/TaskLabel';
 import TodayCount from '@/components/TodayCount';
 import Heatmap from '@/components/Heatmap';
 
+const GET_STATE_TIMEOUT_MS = 5000;
+
+const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
+  Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), ms),
+    ),
+  ]);
+
 export default function App() {
   const [state, setState] = createSignal<TimerState>(INITIAL_STATE);
   const [remaining, setRemaining] = createSignal(0);
   const [label, setLabel] = createSignal('');
   const [todayCount, setTodayCount] = createSignal(0);
+  const [dailyGoal, setDailyGoal] = createSignal(0);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [connectionError, setConnectionError] = createSignal(false);
+  const [goalToast, setGoalToast] = createSignal(false);
+  const [goalToastDismissed, setGoalToastDismissed] = createSignal(false);
+
+  const dismissGoalToast = () => {
+    setGoalToast(false);
+    setGoalToastDismissed(true);
+  };
 
   const refreshStats = async () => {
-    setTodayCount(await getTodayCount());
+    const prev = todayCount();
+    const next = await getTodayCount();
+    setTodayCount(next);
     setHeatmapData(await getHeatmapData(120));
+
+    const goal = dailyGoal();
+    if (goal > 0 && prev < goal && next >= goal && !goalToastDismissed()) {
+      setGoalToast(true);
+      setTimeout(dismissGoalToast, 5000);
+    }
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    try {
+      const currentState = await withTimeout(
+        browser.runtime.sendMessage({ action: 'GET_STATE' }),
+        GET_STATE_TIMEOUT_MS,
+      );
+      setState(currentState as TimerState);
+    } catch {
+      setConnectionError(true);
+      return;
+    }
 
     const pending = await getPendingCelebration();
     if (pending) {
       playCelebration('work');
       await setPendingCelebration(false);
     }
+
+    const config = await getConfig();
+    setDailyGoal(config.dailyGoal ?? 0);
 
     setLabel(await getCurrentLabel());
     await refreshStats();
@@ -115,42 +154,69 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+      <Show when={connectionError()}>
+        <div class="w-full bg-red-100 border border-red-300 rounded-lg p-4 text-center text-sm text-red-700 mt-4">
+          <p class="font-semibold">Could not connect to timer</p>
+          <p class="text-xs mt-1 text-red-500">The background service is not responding.</p>
+        </div>
+      </Show>
 
-      <div class="text-sm text-gray-500 mt-1">
-        <Switch>
-          <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
-          <Match when={state().phase === 'WORKING'}>Working</Match>
-          <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
-          <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
-          <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
-        </Switch>
-      </div>
+      <Show when={!connectionError()}>
+        <Show when={goalToast()}>
+          <div
+            class="w-full bg-green-100 border border-green-300 rounded-lg px-3 py-2 mb-3 flex items-center justify-between text-sm text-green-800"
+            role="status"
+            aria-live="polite"
+          >
+            <span>You've reached today's goal! 🎉</span>
+            <button
+              type="button"
+              onClick={dismissGoalToast}
+              class="ml-2 text-green-600 hover:text-green-800 font-bold leading-none"
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+        </Show>
 
-      <TaskLabel value={label()} onChange={handleLabelChange} />
+        <TimerRing progress={progress()} phase={state().phase} />
+        <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
-      <Controls
-        phase={state().phase}
-        onStart={startTimer}
-        onAbandon={abandonTimer}
-        onAcceptLongBreak={acceptLongBreak}
-        onSkipLongBreak={skipLongBreak}
-      />
+        <div class="text-sm text-gray-500 mt-1">
+          <Switch>
+            <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
+            <Match when={state().phase === 'WORKING'}>Working</Match>
+            <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
+            <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
+            <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
+          </Switch>
+        </div>
 
-      <TodayCount count={todayCount()} />
+        <TaskLabel value={label()} onChange={handleLabelChange} />
 
-      <div class="mt-2 w-full">
-        <Heatmap days={120} data={heatmapData()} />
-      </div>
+        <Controls
+          phase={state().phase}
+          onStart={startTimer}
+          onAbandon={abandonTimer}
+          onAcceptLongBreak={acceptLongBreak}
+          onSkipLongBreak={skipLongBreak}
+        />
 
-      <button
-        type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
-        class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
-      >
-        View all stats →
-      </button>
+        <TodayCount count={todayCount()} goal={dailyGoal()} />
+
+        <div class="mt-2 w-full">
+          <Heatmap days={120} data={heatmapData()} />
+        </div>
+
+        <button
+          type="button"
+          onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+          class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        >
+          View all stats →
+        </button>
+      </Show>
     </div>
   );
 }

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,6 +1,6 @@
-import { createResource, For, Show } from 'solid-js';
+import { createResource, createSignal, createMemo, For, Show } from 'solid-js';
 
-import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
+import { getSessionHistory } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
 
 import Heatmap from '@/components/Heatmap';
@@ -45,57 +45,273 @@ function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
   URL.revokeObjectURL(url);
 }
 
-export default function App() {
-  const [yearData] = createResource(() => getHeatmapData(365));
-  const [sessions] = createResource(() => getSessionHistory());
-  const [todayCount] = createResource(() => getTodayCount());
+const CURRENT_YEAR = new Date().getFullYear();
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
 
-  const total = () => computeTotalCount(sessions() ?? []);
-  const week = () => computeWeekCount(sessions() ?? []);
-  const bestDay = () => computeBestDay(sessions() ?? []);
-  const streak = () => computeStreak(sessions() ?? []);
+type FilterMode = 'all' | 'year' | 'month';
+
+export default function App() {
+  const [sessions] = createResource(() => getSessionHistory());
+
+  // Filter state
+  const [filterMode, setFilterMode] = createSignal<FilterMode>('all');
+  const [filterYear, setFilterYear] = createSignal(CURRENT_YEAR);
+  const [filterMonth, setFilterMonth] = createSignal(new Date().getMonth()); // 0-indexed
+
+  // Derive the earliest year with data
+  const earliestYear = createMemo(() => {
+    const all = sessions() ?? [];
+    if (all.length === 0) return CURRENT_YEAR;
+    const minDate = all[0].date; // sessions are stored oldest-first
+    return Number.parseInt(minDate.split('-')[0], 10);
+  });
+
+  const availableYears = createMemo(() => {
+    const years: number[] = [];
+    for (let y = CURRENT_YEAR; y >= earliestYear(); y--) {
+      years.push(y);
+    }
+    return years;
+  });
+
+  // Filtered sessions based on current filter mode
+  const filteredSessions = createMemo(() => {
+    const all = sessions() ?? [];
+    if (filterMode() === 'all') return all;
+
+    const year = filterYear();
+    const month = filterMonth();
+
+    if (filterMode() === 'year') {
+      return all.filter((s) => s.date.startsWith(`${year}-`));
+    }
+
+    // month filter
+    const monthStr = String(month + 1).padStart(2, '0');
+    return all.filter((s) => s.date.startsWith(`${year}-${monthStr}-`));
+  });
+
+  // Build heatmap data from filtered sessions
+  const heatmapData = createMemo(() => {
+    const map: Record<string, number> = {};
+    for (const s of filteredSessions()) {
+      map[s.date] = (map[s.date] ?? 0) + 1;
+    }
+    return map;
+  });
+
+  // Heatmap days: year = 365, month = days in month, all = 365
+  const heatmapDays = createMemo(() => {
+    if (filterMode() === 'month') {
+      return new Date(filterYear(), filterMonth() + 1, 0).getDate();
+    }
+    return 365;
+  });
+
+  // Stats
+  const total = () => computeTotalCount(filteredSessions());
+  const week = () => (filterMode() === 'all' ? computeWeekCount(filteredSessions()) : null);
+  const bestDay = () => computeBestDay(filteredSessions());
+  const streak = () => (filterMode() === 'all' ? computeStreak(filteredSessions()) : null);
+  const todayCount = createMemo(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    return filteredSessions().filter((s) => s.date === today).length;
+  });
+
+  // Navigation helpers
+  const filterLabel = () => {
+    if (filterMode() === 'all') return 'All time';
+    if (filterMode() === 'year') return String(filterYear());
+    return `${MONTH_NAMES[filterMonth()]} ${filterYear()}`;
+  };
+
+  const canGoBack = () => {
+    if (filterMode() === 'year') return filterYear() > earliestYear();
+    if (filterMode() === 'month') {
+      return filterYear() > earliestYear() || filterMonth() > 0;
+    }
+    return false;
+  };
+
+  const canGoForward = () => {
+    if (filterMode() === 'year') return filterYear() < CURRENT_YEAR;
+    if (filterMode() === 'month') {
+      return filterYear() < CURRENT_YEAR || filterMonth() < new Date().getMonth();
+    }
+    return false;
+  };
+
+  const goBack = () => {
+    if (filterMode() === 'year') {
+      setFilterYear((y) => y - 1);
+    } else if (filterMode() === 'month') {
+      if (filterMonth() === 0) {
+        setFilterYear((y) => y - 1);
+        setFilterMonth(11);
+      } else {
+        setFilterMonth((m) => m - 1);
+      }
+    }
+  };
+
+  const goForward = () => {
+    if (filterMode() === 'year') {
+      setFilterYear((y) => y + 1);
+    } else if (filterMode() === 'month') {
+      if (filterMonth() === 11) {
+        setFilterYear((y) => y + 1);
+        setFilterMonth(0);
+      } else {
+        setFilterMonth((m) => m + 1);
+      }
+    }
+  };
+
+  const setModeAll = () => setFilterMode('all');
+  const setModeYear = () => { setFilterMode('year'); setFilterYear(CURRENT_YEAR); };
+  const setModeMonth = () => { setFilterMode('month'); setFilterYear(CURRENT_YEAR); setFilterMonth(new Date().getMonth()); };
+
+  const hasData = () => (sessions() ?? []).length > 0;
 
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <div class="flex items-center justify-between mb-6">
           <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
-          <Show when={(sessions() ?? []).length > 0}>
+          <Show when={hasData()}>
             <button
               class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
-              onClick={() => exportCSV(sessions() ?? [])}
+              onClick={() => exportCSV(filteredSessions())}
             >
               Export CSV
             </button>
           </Show>
         </div>
 
-        <Show when={(sessions() ?? []).length === 0}>
+        {/* Filter controls */}
+        <Show when={hasData()}>
+          <div class="flex flex-wrap items-center gap-2 mb-4">
+            {/* Quick filter buttons */}
+            <div class="flex rounded-lg overflow-hidden border border-red-200 text-sm">
+              <button
+                type="button"
+                class={`px-3 py-1.5 transition-colors ${filterMode() === 'all' ? 'bg-red-600 text-white' : 'bg-white text-red-600 hover:bg-red-50'}`}
+                onClick={setModeAll}
+              >
+                All time
+              </button>
+              <button
+                type="button"
+                class={`px-3 py-1.5 border-l border-red-200 transition-colors ${filterMode() === 'year' ? 'bg-red-600 text-white' : 'bg-white text-red-600 hover:bg-red-50'}`}
+                onClick={setModeYear}
+              >
+                Year
+              </button>
+              <button
+                type="button"
+                class={`px-3 py-1.5 border-l border-red-200 transition-colors ${filterMode() === 'month' ? 'bg-red-600 text-white' : 'bg-white text-red-600 hover:bg-red-50'}`}
+                onClick={setModeMonth}
+              >
+                Month
+              </button>
+            </div>
+
+            {/* Navigation arrows + label */}
+            <Show when={filterMode() !== 'all'}>
+              <div class="flex items-center gap-1 ml-2">
+                <button
+                  type="button"
+                  onClick={goBack}
+                  disabled={!canGoBack()}
+                  class="px-2 py-1 rounded text-red-600 hover:bg-red-100 disabled:opacity-30 disabled:cursor-not-allowed text-sm font-bold"
+                  aria-label="Previous period"
+                >
+                  ‹
+                </button>
+                <span class="text-sm font-medium text-gray-700 min-w-[120px] text-center">{filterLabel()}</span>
+                <button
+                  type="button"
+                  onClick={goForward}
+                  disabled={!canGoForward()}
+                  class="px-2 py-1 rounded text-red-600 hover:bg-red-100 disabled:opacity-30 disabled:cursor-not-allowed text-sm font-bold"
+                  aria-label="Next period"
+                >
+                  ›
+                </button>
+              </div>
+
+              {/* Year dropdown (shown in year mode) */}
+              <Show when={filterMode() === 'year' && availableYears().length > 1}>
+                <select
+                  value={filterYear()}
+                  onChange={(e) => setFilterYear(Number(e.currentTarget.value))}
+                  class="text-sm border border-red-200 rounded-md px-2 py-1 text-red-600 bg-white focus:outline-none focus:ring-1 focus:ring-red-500"
+                  aria-label="Select year"
+                >
+                  <For each={availableYears()}>
+                    {(y) => <option value={y}>{y}</option>}
+                  </For>
+                </select>
+              </Show>
+            </Show>
+          </div>
+        </Show>
+
+        <Show when={!hasData()}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>
             <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
           </div>
         </Show>
 
-        <Show when={(sessions() ?? []).length > 0}>
+        <Show when={hasData()}>
+          {/* Stats cards */}
           <div class="grid grid-cols-5 gap-3 mb-6">
-            <StatCard label="Total tomates" value={total()} />
-            <StatCard label="Today" value={todayCount() ?? 0} />
-            <StatCard label="This week" value={week()} />
+            <StatCard label="Total tomates" value={total()} sublabel={filterMode() !== 'all' ? filterLabel() : undefined} />
+            <Show when={filterMode() === 'all'}>
+              <StatCard label="Today" value={todayCount()} />
+            </Show>
+            <Show when={filterMode() !== 'all'}>
+              <StatCard label="Best day" value={bestDay()?.count ?? '—'} sublabel={bestDay()?.date} />
+            </Show>
+            <Show when={filterMode() === 'all'}>
+              <StatCard label="This week" value={week() ?? 0} />
+            </Show>
+            <Show when={filterMode() !== 'all'}>
+              <StatCard
+                label="Avg / day"
+                value={(() => {
+                  const days = filterMode() === 'month'
+                    ? new Date(filterYear(), filterMonth() + 1, 0).getDate()
+                    : 365;
+                  return total() === 0 ? '—' : (total() / days).toFixed(1);
+                })()}
+              />
+            </Show>
             <StatCard
               label="Best day"
               value={bestDay()?.count ?? '—'}
               sublabel={bestDay()?.date}
             />
-            <StatCard
-              label="Current streak"
-              value={`${streak()}d`}
-            />
+            <Show when={filterMode() === 'all'}>
+              <StatCard
+                label="Current streak"
+                value={`${streak() ?? 0}d`}
+              />
+            </Show>
+            <Show when={filterMode() !== 'all'}>
+              <StatCard label="Active days" value={Object.keys(heatmapData()).length} />
+            </Show>
           </div>
 
           <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-            <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
-            <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+            <h2 class="text-sm font-semibold text-gray-700 mb-3">
+              {filterMode() === 'all' ? '365-day activity' : `${filterLabel()} activity`}
+            </h2>
+            <Heatmap days={heatmapDays()} cellSize={14} data={heatmapData()} />
 
             <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
               <span>Less</span>

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -149,4 +149,52 @@ describe('storage helpers', () => {
     await setPendingCelebration(false);
     await expect(getPendingCelebration()).resolves.toBe(false);
   });
+
+  it('caps sessions to MAX_SESSIONS (2000) when adding a new session', async () => {
+    // Pre-fill 2000 sessions
+    const bulk: CompletedSession[] = [];
+    for (let i = 0; i < 2000; i++) {
+      bulk.push(createSession(i, { id: `s-${i}` }));
+    }
+    await fakeBrowser.storage.local.set({ sessions: bulk });
+
+    const newSession = createSession(99999, { id: 'new' });
+    await addCompletedSession(newSession);
+
+    const stored = await fakeBrowser.storage.local.get('sessions');
+    const result = stored['sessions'] as CompletedSession[];
+    expect(result.length).toBe(2000);
+    expect(result[result.length - 1].id).toBe('new');
+    expect(result[0].id).toBe('s-1'); // oldest was dropped
+  });
+
+  it('retries and applies cap on QuotaExceededError', async () => {
+    // Pre-fill 1999 sessions
+    const bulk: CompletedSession[] = [];
+    for (let i = 0; i < 1999; i++) {
+      bulk.push(createSession(i, { id: `s-${i}` }));
+    }
+    await fakeBrowser.storage.local.set({ sessions: bulk });
+
+    let callCount = 0;
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+      callCount++;
+      if (callCount === 1) {
+        const err = new Error('QuotaExceededError');
+        err.name = 'QuotaExceededError';
+        throw err;
+      }
+      return originalSet(items);
+    });
+
+    const newSession = createSession(99999, { id: 'new' });
+    await addCompletedSession(newSession);
+
+    expect(callCount).toBe(2);
+    const stored = await fakeBrowser.storage.local.get('sessions');
+    const result = stored['sessions'] as CompletedSession[];
+    expect(result.length).toBeLessThanOrEqual(2000);
+    expect(result[result.length - 1].id).toBe('new');
+  });
 });

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -249,6 +249,7 @@ describe('timer state machine', () => {
       shortBreakDuration: 5 * 60 * 1000,
       longBreakDuration: 30 * 60 * 1000,
       openBreakTab: true,
+      dailyGoal: 8,
     });
   });
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -18,6 +18,8 @@ const KEYS = {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
+const MAX_SESSIONS = 2000;
+const PRUNE_FACTOR = 0.1;
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -52,9 +54,28 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
 };
 
+const pruneOldestSessions = (sessions: CompletedSession[]): CompletedSession[] => {
+  const pruneCount = Math.max(1, Math.floor(sessions.length * PRUNE_FACTOR));
+  return sessions.slice(pruneCount);
+};
+
+const capSessions = (sessions: CompletedSession[]): CompletedSession[] =>
+  sessions.length > MAX_SESSIONS ? sessions.slice(sessions.length - MAX_SESSIONS) : sessions;
+
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  const toPersist = capSessions([...sessions, session]);
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: toPersist });
+  } catch (err: unknown) {
+    const isQuota =
+      err instanceof Error &&
+      (err.name === 'QuotaExceededError' || err.message.toLowerCase().includes('quota'));
+    if (!isQuota) throw err;
+    const pruned = pruneOldestSessions(sessions);
+    const retryPersist = capSessions([...pruned, session]);
+    await browser.storage.local.set({ [KEYS.SESSIONS]: retryPersist });
+  }
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,7 @@ export type TimerConfig = {
   shortBreakDuration: number;
   longBreakDuration: number;
   openBreakTab: boolean;
+  dailyGoal: number;
 };
 
 export type TimerState = {
@@ -31,6 +32,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,
   openBreakTab: true,
+  dailyGoal: 8,
 };
 
 export const INITIAL_STATE: TimerState = {


### PR DESCRIPTION
## Summary

Fixes six open issues from the original sweep — two bugs and four UX/feat improvements.

- **#197 (bug):** Restored `withTimeout(5000ms)` around `GET_STATE` in `popup/App.tsx`. When the background service worker doesn't respond within 5 s the popup now shows a *"Could not connect to timer"* fallback instead of hanging indefinitely.

- **#202 (bug):** `addCompletedSession` now applies the `MAX_SESSIONS` (2000) cap **on the quota-error retry path** as well as the happy path. Added `capSessions` + `pruneOldestSessions` helpers and a proper `QuotaExceededError` name-check. Two new tests cover: (a) cap enforcement when 2000+ sessions exist, (b) the quota-error retry flow.

- **#196 (ux):** Added `dailyGoal: number` field to `TimerConfig` (default 8). The popup's `TodayCount` component now renders a thin progress bar (green when goal reached). A dismissible green toast *"You've reached today's goal! 🎉"* appears when the session count crosses the goal. The options page exposes the daily goal setting.

- **#198 (ux):** `Heatmap` now renders an extra row of year labels (e.g. `2025` / `2026`) above the month labels whenever the rolling window spans more than one calendar year. Controlled by a `yearLabels` memo; zero extra DOM when a single year is displayed.

- **#199 (feat):** Stats page gains **All time / Year / Month** quick-filter buttons with prev/next navigation arrows and a year dropdown, letting users browse historical yearly or monthly heatmaps.

- **#200 (feat):** Stats cards recalculate for the active filter period. In year/month mode the cards switch to: total, best-day, avg/day, and active-days — replacing the hardcoded all-time/week/streak metrics that don't apply to sub-period views.

## Test plan

- [x] `bun run build` — clean build, no type errors
- [x] `bun run vitest run lib/__tests__/ tests/` — 27 tests pass (storage × 12, timer × 14, smoke × 1)
- [ ] Manual: open popup with background worker killed → verify "Could not connect" message appears after 5 s
- [ ] Manual: set daily goal to 2, complete 2 sessions → verify green toast + green progress bar
- [ ] Manual: view stats page Jan 1 / early January → verify year labels on heatmap
- [ ] Manual: stats Year/Month nav arrows cycle through periods, cards update

Closes #196
Closes #197
Closes #198
Closes #199
Closes #200
Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)