### PR TITLE
fix: stats skeletons, options validation, popup focus management, storage type (#12 #14 #18 #49)

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -16,6 +16,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'IDLE'}>
           <button
             type="button"
+            data-focus-target
             onClick={props.onStart}
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
           >
@@ -25,6 +26,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'WORKING'}>
           <button
             type="button"
+            data-focus-target
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
@@ -34,6 +36,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'SHORT_BREAK' || props.phase === 'LONG_BREAK'}>
           <button
             type="button"
+            data-focus-target
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
@@ -43,6 +46,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'BREAK_SUGGESTION'}>
           <button
             type="button"
+            data-focus-target
             onClick={props.onAcceptLongBreak}
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
           >

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,10 +1,17 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, createMemo, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
 import { DEFAULT_CONFIG, type TimerConfig } from '@/lib/types';
 
 const MS_PER_MINUTE = 60_000;
+
+const WORK_MIN = 1;
+const WORK_MAX = 120;
+const SHORT_BREAK_MIN = 1;
+const SHORT_BREAK_MAX = 30;
+const LONG_BREAK_MIN = 5;
+const LONG_BREAK_MAX = 60;
 
 export default function App() {
   const [work, setWork] = createSignal(25);
@@ -21,7 +28,37 @@ export default function App() {
     setOpenBreakTab(config.openBreakTab !== false);
   });
 
+  const workError = createMemo(() => {
+    const v = work();
+    if (!Number.isFinite(v) || v < WORK_MIN || v > WORK_MAX) {
+      return `Must be between ${WORK_MIN} and ${WORK_MAX} minutes.`;
+    }
+    return null;
+  });
+
+  const shortBreakError = createMemo(() => {
+    const v = shortBreak();
+    if (!Number.isFinite(v) || v < SHORT_BREAK_MIN || v > SHORT_BREAK_MAX) {
+      return `Must be between ${SHORT_BREAK_MIN} and ${SHORT_BREAK_MAX} minutes.`;
+    }
+    return null;
+  });
+
+  const longBreakError = createMemo(() => {
+    const v = longBreak();
+    if (!Number.isFinite(v) || v < LONG_BREAK_MIN || v > LONG_BREAK_MAX) {
+      return `Must be between ${LONG_BREAK_MIN} and ${LONG_BREAK_MAX} minutes.`;
+    }
+    return null;
+  });
+
+  const hasErrors = createMemo(
+    () => workError() !== null || shortBreakError() !== null || longBreakError() !== null,
+  );
+
   const handleSave = async () => {
+    if (hasErrors()) return;
+
     const config: TimerConfig = {
       workDuration: work() * MS_PER_MINUTE,
       shortBreakDuration: shortBreak() * MS_PER_MINUTE,
@@ -47,41 +84,80 @@ export default function App() {
         <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
 
         <div class="space-y-4">
-          <label class="block">
-            <span class="text-sm font-medium text-gray-700">Work Duration (minutes)</span>
-            <input
-              type="number"
-              min={1}
-              max={120}
-              value={work()}
-              onInput={(e) => setWork(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
-            />
-          </label>
+          <div>
+            <label class="block">
+              <span class="text-sm font-medium text-gray-700">
+                Work Duration (minutes)
+              </span>
+              <input
+                type="number"
+                min={WORK_MIN}
+                max={WORK_MAX}
+                value={work()}
+                onInput={(e) => setWork(Number(e.currentTarget.value))}
+                aria-describedby="work-hint work-error"
+                class={`mt-1 block w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 ${
+                  workError()
+                    ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                    : 'border-gray-300 focus:border-red-500 focus:ring-red-500'
+                }`}
+              />
+            </label>
+            <p id="work-hint" class="mt-1 text-xs text-gray-400">Range: {WORK_MIN}–{WORK_MAX} min</p>
+            <Show when={workError()}>
+              <p id="work-error" class="mt-1 text-xs text-red-600" role="alert">{workError()}</p>
+            </Show>
+          </div>
 
-          <label class="block">
-            <span class="text-sm font-medium text-gray-700">Short Break (minutes)</span>
-            <input
-              type="number"
-              min={1}
-              max={30}
-              value={shortBreak()}
-              onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
-            />
-          </label>
+          <div>
+            <label class="block">
+              <span class="text-sm font-medium text-gray-700">
+                Short Break (minutes)
+              </span>
+              <input
+                type="number"
+                min={SHORT_BREAK_MIN}
+                max={SHORT_BREAK_MAX}
+                value={shortBreak()}
+                onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
+                aria-describedby="short-break-hint short-break-error"
+                class={`mt-1 block w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 ${
+                  shortBreakError()
+                    ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                    : 'border-gray-300 focus:border-red-500 focus:ring-red-500'
+                }`}
+              />
+            </label>
+            <p id="short-break-hint" class="mt-1 text-xs text-gray-400">Range: {SHORT_BREAK_MIN}–{SHORT_BREAK_MAX} min</p>
+            <Show when={shortBreakError()}>
+              <p id="short-break-error" class="mt-1 text-xs text-red-600" role="alert">{shortBreakError()}</p>
+            </Show>
+          </div>
 
-          <label class="block">
-            <span class="text-sm font-medium text-gray-700">Long Break (minutes)</span>
-            <input
-              type="number"
-              min={5}
-              max={60}
-              value={longBreak()}
-              onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
-            />
-          </label>
+          <div>
+            <label class="block">
+              <span class="text-sm font-medium text-gray-700">
+                Long Break (minutes)
+              </span>
+              <input
+                type="number"
+                min={LONG_BREAK_MIN}
+                max={LONG_BREAK_MAX}
+                value={longBreak()}
+                onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
+                aria-describedby="long-break-hint long-break-error"
+                class={`mt-1 block w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1 ${
+                  longBreakError()
+                    ? 'border-red-400 focus:border-red-500 focus:ring-red-500'
+                    : 'border-gray-300 focus:border-red-500 focus:ring-red-500'
+                }`}
+              />
+            </label>
+            <p id="long-break-hint" class="mt-1 text-xs text-gray-400">Range: {LONG_BREAK_MIN}–{LONG_BREAK_MAX} min</p>
+            <Show when={longBreakError()}>
+              <p id="long-break-error" class="mt-1 text-xs text-red-600" role="alert">{longBreakError()}</p>
+            </Show>
+          </div>
 
           <label class="flex items-center gap-3 cursor-pointer">
             <input
@@ -98,7 +174,12 @@ export default function App() {
           <button
             type="button"
             onClick={handleSave}
-            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            disabled={hasErrors()}
+            class={`px-4 py-2 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 ${
+              hasErrors()
+                ? 'bg-red-300 text-white cursor-not-allowed'
+                : 'bg-red-600 text-white hover:bg-red-700'
+            }`}
           >
             Save
           </button>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
-import { browser } from 'wxt/browser';
+import { browser, type Browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
 import { playCelebration } from '@/lib/celebration';
@@ -44,8 +44,11 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const onStorageChanged = (_changes: Record<string, Browser.storage.StorageChange>): void => {
+      void refreshStats();
+    };
+    browser.storage.onChanged.addListener(onStorageChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onStorageChanged));
   });
 
   createEffect(() => {
@@ -58,6 +61,16 @@ export default function App() {
     } else {
       setRemaining(0);
     }
+  });
+
+  // Move keyboard focus to the primary action button on each phase transition (#49)
+  createEffect(() => {
+    // Access phase to track changes
+    state().phase;
+    queueMicrotask(() => {
+      const btn = document.querySelector<HTMLElement>('[data-focus-target]');
+      btn?.focus();
+    });
   });
 
   const formatTime = () => {

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -70,47 +70,74 @@ export default function App() {
           </Show>
         </div>
 
-        <Show when={(sessions() ?? []).length === 0}>
-          <div class="text-center py-8 text-gray-500 dark:text-gray-400">
-            <p class="text-lg">No sessions yet</p>
-            <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
-          </div>
-        </Show>
-
-        <Show when={(sessions() ?? []).length > 0}>
-          <div class="grid grid-cols-5 gap-3 mb-6">
-            <StatCard label="Total tomates" value={total()} />
-            <StatCard label="Today" value={todayCount() ?? 0} />
-            <StatCard label="This week" value={week()} />
-            <StatCard
-              label="Best day"
-              value={bestDay()?.count ?? '—'}
-              sublabel={bestDay()?.date}
-            />
-            <StatCard
-              label="Current streak"
-              value={`${streak()}d`}
-            />
-          </div>
-
-          <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-            <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
-            <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
-
-            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
-              <span>Less</span>
-              <For each={INTENSITY_LEGEND}>
-                {(item) => (
-                  <div
-                    class="w-3 h-3 rounded-sm"
-                    style={{ "background-color": item.color }}
-                    title={item.label}
-                  />
-                )}
-              </For>
-              <span>More</span>
+        {/* Loading skeleton while sessions fetch */}
+        <Show
+          when={!sessions.loading}
+          fallback={
+            <div>
+              <div class="grid grid-cols-5 gap-3 mb-6">
+                <For each={Array(5).fill(null)}>
+                  {() => (
+                    <div class="bg-white rounded-xl p-4 shadow-sm border border-red-100 h-24 animate-pulse" />
+                  )}
+                </For>
+              </div>
+              <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100 h-40 animate-pulse" />
             </div>
-          </div>
+          }
+        >
+          <Show when={(sessions() ?? []).length === 0}>
+            <div class="text-center py-8 text-gray-500">
+              <p class="text-lg">No sessions yet</p>
+              <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
+            </div>
+          </Show>
+
+          <Show when={(sessions() ?? []).length > 0}>
+            <div class="grid grid-cols-5 gap-3 mb-6">
+              <Show
+                when={!todayCount.loading}
+                fallback={<div class="bg-white rounded-xl h-24 animate-pulse border border-red-100" />}
+              >
+                <StatCard label="Total tomates" value={total()} />
+                <StatCard label="Today" value={todayCount() ?? 0} />
+                <StatCard label="This week" value={week()} />
+                <StatCard
+                  label="Best day"
+                  value={bestDay()?.count ?? '—'}
+                  sublabel={bestDay()?.date}
+                />
+                <StatCard
+                  label="Current streak"
+                  value={`${streak()}d`}
+                />
+              </Show>
+            </div>
+
+            <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
+              <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
+              <Show
+                when={!yearData.loading}
+                fallback={<div class="h-32 animate-pulse bg-gray-100 rounded-lg" />}
+              >
+                <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+              </Show>
+
+              <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
+                <span>Less</span>
+                <For each={INTENSITY_LEGEND}>
+                  {(item) => (
+                    <div
+                      class="w-3 h-3 rounded-sm"
+                      style={{ "background-color": item.color }}
+                      title={item.label}
+                    />
+                  )}
+                </For>
+                <span>More</span>
+              </div>
+            </div>
+          </Show>
         </Show>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Resolves the two conflicting PRs (#94 and #95) that targeted issues #12, #14, #18, and #49 by implementing all four fixes cleanly on top of current main.

- **Closes #12** — Options inputs now show range hints (e.g. «Range: 1–120 min») and real-time inline validation errors with a red border. Save button is disabled while any field is out of range.
- **Closes #14** — Storage change listener in `popup/App.tsx` is now typed as `Record<string, Browser.storage.StorageChange>` instead of the raw `(changes: Record<string, unknown>)` mismatch.
- **Closes #18** — Stats page wraps all stat cards and the heatmap in `animate-pulse` skeleton fallbacks while `createResource` fetches resolve, eliminating the empty-then-fill flash on cold load.
- **Closes #49** — Controls buttons get `data-focus-target`; a `createEffect` in popup fires `queueMicrotask` to shift focus to the primary button on every phase transition, keeping keyboard users oriented.

## Test plan
- [x] `bun run build` passes
- [x] `bun test` — 32 tests pass, 0 failures
- [ ] Load stats page and observe pulse skeletons before data populates
- [ ] Type an invalid value (e.g. 200) in Work Duration — red border + error message appear; Save is disabled
- [ ] Open popup with keyboard only — focus lands on Start/Abandon/Skip as phase changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)