### PR TITLE
perf: skip getTodayCount during break phases and avoid array materialisation (#380, #381)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -41,7 +41,7 @@ export default defineBackground(() => {
   const badgeApi = browser.action;
 
   const refreshBadge = async (): Promise<void> => {
-    const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
+    const state = await getTimerState();
 
     let text = '';
     let color = BADGE_RED;
@@ -54,6 +54,7 @@ export default defineBackground(() => {
       }
       case 'SHORT_BREAK':
       case 'LONG_BREAK': {
+        // Badge shows static "BRK" — no count needed, skip storage read.
         text = 'BRK';
         color = BADGE_GREEN;
         break;
@@ -65,6 +66,7 @@ export default defineBackground(() => {
       }
       case 'IDLE':
       default: {
+        const todayCount = await getTodayCount();
         text = todayCount > 0 ? String(todayCount) : '';
         color = BADGE_RED;
         break;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -87,7 +87,11 @@ export const getTodayCount = async (): Promise<number> => {
   const todayKey = toDateKey(Date.now());
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
 
-  return sessions.filter((session) => session.date === todayKey).length;
+  let count = 0;
+  for (const session of sessions) {
+    if (session.date === todayKey) count++;
+  }
+  return count;
 };
 
 export const getPendingCelebration = async (): Promise<boolean> =>


### PR DESCRIPTION
## Summary

- **#381** — `refreshBadge()` previously called `getTodayCount()` unconditionally via `Promise.all([getTimerState(), getTodayCount()])`. During `SHORT_BREAK` and `LONG_BREAK` the badge always shows the static text `"BRK"` and the count is never used. The fix reads state first and only calls `getTodayCount()` in the `IDLE` branch where the count is actually needed, eliminating one storage round-trip per BADGE_REFRESH alarm tick during break phases.
- **#380** — `getTodayCount()` used `Array.prototype.filter(...).length`, which allocates a new filtered array containing all matching sessions before counting them. Replaced with a simple `for...of` loop that increments a counter in-place, so no intermediate array is created. Sessions are still loaded from storage in full (the schema has no date index), but the in-memory pass is now O(n) with no allocation.

## Test plan
- [x] `bun run build` — clean, no TypeScript errors
- [x] `bun test` — 32/32 pass
- [ ] Manual: start a SHORT_BREAK or LONG_BREAK, confirm badge shows "BRK" without triggering extra storage reads (observable via background service-worker devtools)
- [ ] Manual: in IDLE with sessions today, confirm badge still shows correct count

Closes #380
Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)