### PR TITLE
fix: subscribe to storage changes to keep stats page current

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, For, Show } from 'solid-js';
+import { createResource, For, Show, onCleanup } from 'solid-js';
 
 import { getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
@@ -46,9 +46,19 @@ function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
 }
 
 export default function App() {
-  const [yearData] = createResource(() => getHeatmapData(365));
-  const [sessions] = createResource(() => getSessionHistory());
-  const [todayCount] = createResource(() => getTodayCount());
+  const [yearData, { refetch: refetchYearData }] = createResource(() => getHeatmapData(365));
+  const [sessions, { refetch: refetchSessions }] = createResource(() => getSessionHistory());
+  const [todayCount, { refetch: refetchTodayCount }] = createResource(() => getTodayCount());
+
+  const handleStorageChange = (changes: Record<string, browser.storage.StorageChange>) => {
+    if ('sessions' in changes) {
+      refetchSessions();
+      refetchYearData();
+      refetchTodayCount();
+    }
+  };
+  browser.storage.onChanged.addListener(handleStorageChange);
+  onCleanup(() => browser.storage.onChanged.removeListener(handleStorageChange));
 
   const total = () => computeTotalCount(sessions() ?? []);
   const week = () => computeWeekCount(sessions() ?? []);


### PR DESCRIPTION
## Summary

- Destructures `refetch` from each `createResource` call (`refetchSessions`, `refetchYearData`, `refetchTodayCount`)
- Registers a `browser.storage.onChanged` listener directly in the component body that calls all three refetches when the `sessions` key changes
- Uses `onCleanup` to remove the listener on unmount, preventing leaks
- Imports `onCleanup` from `solid-js` (no `onMount` needed — listener is registered at component init time, consistent with popup pattern)

## Test plan

- [ ] `bun run build` passes with no TypeScript errors
- [ ] Open stats page, complete a Pomodoro session in the popup — stats (total, today, heatmap) update without a manual reload
- [ ] Close the stats page tab and confirm no lingering listener errors in the console

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)