### PR TITLE
fix: wrap setTimerState in handleMessage with try-catch

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -140,68 +140,73 @@ export default defineBackground(() => {
   };
 
   const handleMessage = async (message: MessageAction) => {
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+    try {
+      const [state, config] = await Promise.all([getTimerState(), getConfig()]);
 
-    switch (message.action) {
-      case 'START_TIMER': {
-        const nextState = startTimer(state, config);
-        await setTimerState(nextState);
+      switch (message.action) {
+        case 'START_TIMER': {
+          const nextState = startTimer(state, config);
+          await setTimerState(nextState);
 
-        if (nextState.endTime !== null) {
-          await scheduleTimerAlarm(nextState.endTime);
-          await startBadgeRefresh();
+          if (nextState.endTime !== null) {
+            await scheduleTimerAlarm(nextState.endTime);
+            await startBadgeRefresh();
+          }
+
+          await refreshBadge();
+          return nextState;
         }
-
-        await refreshBadge();
-        return nextState;
-      }
-      case 'ABANDON_TIMER': {
-        const nextState = abandonTimer(state);
-        await setTimerState(nextState);
-        await clearActiveAlarms();
-        await refreshBadge();
-        return nextState;
-      }
-      case 'GET_STATE': {
-        return state;
-      }
-      case 'ACCEPT_LONG_BREAK': {
-        const nextState = acceptLongBreak(state, config);
-        await setTimerState(nextState);
-
-        if (nextState.endTime !== null) {
-          await scheduleTimerAlarm(nextState.endTime);
-          await startBadgeRefresh();
-        }
-
-        await refreshBadge();
-        return nextState;
-      }
-      case 'SKIP_LONG_BREAK': {
-        const nextState = skipLongBreak(state);
-        await setTimerState(nextState);
-        await clearActiveAlarms();
-        await refreshBadge();
-        return nextState;
-      }
-      case 'UPDATE_CONFIG': {
-        await setConfig(message.config);
-        const nextState = adjustDuration(state, message.config);
-        await setTimerState(nextState);
-
-        if (isActivePhase(nextState.phase) && nextState.endTime !== null) {
-          await scheduleTimerAlarm(nextState.endTime);
-          await startBadgeRefresh();
-        } else {
+        case 'ABANDON_TIMER': {
+          const nextState = abandonTimer(state);
+          await setTimerState(nextState);
           await clearActiveAlarms();
+          await refreshBadge();
+          return nextState;
         }
+        case 'GET_STATE': {
+          return state;
+        }
+        case 'ACCEPT_LONG_BREAK': {
+          const nextState = acceptLongBreak(state, config);
+          await setTimerState(nextState);
 
-        await refreshBadge();
-        return nextState;
+          if (nextState.endTime !== null) {
+            await scheduleTimerAlarm(nextState.endTime);
+            await startBadgeRefresh();
+          }
+
+          await refreshBadge();
+          return nextState;
+        }
+        case 'SKIP_LONG_BREAK': {
+          const nextState = skipLongBreak(state);
+          await setTimerState(nextState);
+          await clearActiveAlarms();
+          await refreshBadge();
+          return nextState;
+        }
+        case 'UPDATE_CONFIG': {
+          await setConfig(message.config);
+          const nextState = adjustDuration(state, message.config);
+          await setTimerState(nextState);
+
+          if (isActivePhase(nextState.phase) && nextState.endTime !== null) {
+            await scheduleTimerAlarm(nextState.endTime);
+            await startBadgeRefresh();
+          } else {
+            await clearActiveAlarms();
+          }
+
+          await refreshBadge();
+          return nextState;
+        }
+        default: {
+          return state;
+        }
       }
-      default: {
-        return state;
-      }
+    } catch (err) {
+      console.error('[handleMessage] failed for action "%s":', message.action, err);
+      return { error: true, message: err instanceof Error ? err.message : String(err) };
     }
   };
 


### PR DESCRIPTION
## Summary

- Wraps the entire `handleMessage` body in a try-catch in `entrypoints/background.ts`
- On failure (e.g. storage quota exceeded), logs the error via `console.error` and returns `{ error: true, message: string }` instead of leaving the popup's `sendMessage` promise unresolved
- Mirrors the guard added in `onAlarm` by issue #369 — closes the same gap for the message handler path
- No refactor of handler logic; only error propagation added

## Test plan

- [x] `bun run build` — TypeScript compiles cleanly
- [x] `bun test` — all 32 tests pass
- [ ] Manual: simulate storage failure (mock `setTimerState` to throw) and confirm popup receives `{ error: true }` rather than `undefined`

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)