### PR TITLE
fix(a11y): wrap settings confirmation in aria-live region

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, onMount } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
@@ -111,9 +111,9 @@ export default function App() {
             Reset to defaults
           </button>
 
-          <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
-          </Show>
+          <span aria-live="polite" role="status" class="text-sm text-green-600">
+            {saved() ? 'Settings saved ✓' : ''}
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replaces `<Show when={saved()}>` mount/unmount pattern with persistent `aria-live="polite" role="status"` container
- Screen readers now detect and announce the "Settings saved" confirmation

## Verification
- [x] Tests pass
- [x] No file overlap with other open PRs

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)