### PR TITLE
perf: lazy-load config only for actions that need it

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -140,10 +140,11 @@ export default defineBackground(() => {
   };
 
   const handleMessage = async (message: MessageAction) => {
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+    const state = await getTimerState();
 
     switch (message.action) {
       case 'START_TIMER': {
+        const config = await getConfig();
         const nextState = startTimer(state, config);
         await setTimerState(nextState);
 
@@ -166,6 +167,7 @@ export default defineBackground(() => {
         return state;
       }
       case 'ACCEPT_LONG_BREAK': {
+        const config = await getConfig();
         const nextState = acceptLongBreak(state, config);
         await setTimerState(nextState);
 


### PR DESCRIPTION
## Summary
- Refactors `handleMessage` to only call `getConfig()` for START_TIMER and ACCEPT_LONG_BREAK
- GET_STATE, ABANDON_TIMER, SKIP_LONG_BREAK skip the unnecessary storage read
- **Merge note**: overlaps with `fix/250-multi-hop-recovery` on background.ts — merge this first

## Verification
- [x] Tests pass
- [x] File overlap noted: background.ts (merge before #250)

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)