### PR TITLE
test: add onStartup alarm recovery and dedup tests

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -10,6 +10,7 @@ import {
   getTimerState,
   setCurrentLabel,
   setTimerState,
+  toDateKey,
 } from '@/lib/storage';
 import { DEFAULT_CONFIG, INITIAL_STATE, type TimerConfig, type TimerState } from '@/lib/types';
 
@@ -29,11 +30,13 @@ const createConfig = (overrides: Partial<TimerConfig> = {}): TimerConfig => ({
   ...overrides,
 });
 
+let testId = 0;
+
 const initBackground = async (): Promise<void> => {
   (globalThis as typeof globalThis & { defineBackground: (main?: () => void | Promise<void>) => { main?: () => void | Promise<void> } }).defineBackground =
     (main) => ({ main });
 
-  const background = (await import(`../background?test=${Math.random()}`)) as BackgroundModule;
+  const background = (await import(`../background?test=${testId++}`)) as BackgroundModule;
   await background.default.main?.();
 };
 
@@ -131,7 +134,7 @@ describe('background service worker', () => {
         label: 'Focus block',
         startTime: 1_000,
         endTime: 5_000,
-        date: '1970-01-01',
+        date: toDateKey(1_000),
         duration: 3_000,
       },
     ]);
@@ -216,7 +219,7 @@ describe('background service worker', () => {
         label: 'Recovered work',
         startTime: 1_000,
         endTime: 10_000,
-        date: '1970-01-01',
+        date: toDateKey(1_000),
         duration: 1_000,
       },
     ]);
@@ -238,6 +241,80 @@ describe('background service worker', () => {
     await initBackground();
 
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
+  });
+
+  it('recovers a missed working alarm via onStartup and records the completed session', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    await setCurrentLabel('Startup recovery');
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 2_000,
+        duration: 1_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onStartup.trigger();
+
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: 10_000,
+        endTime: 10_000 + DEFAULT_CONFIG.shortBreakDuration,
+        duration: DEFAULT_CONFIG.shortBreakDuration,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+    await expect(getPendingCelebration()).resolves.toBe(true);
+    await expect(getSessionHistory()).resolves.toEqual([
+      {
+        id: expect.any(String),
+        label: 'Startup recovery',
+        startTime: 1_000,
+        endTime: 10_000,
+        date: toDateKey(1_000),
+        duration: 1_000,
+      },
+    ]);
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
+      expect.objectContaining({
+        scheduledTime: 10_000 + DEFAULT_CONFIG.shortBreakDuration,
+      }),
+    );
+  });
+
+  it('does not double-persist a session when both onInstalled and onStartup fire', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    await setCurrentLabel('Dedup test');
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 2_000,
+        duration: 1_000,
+      }),
+    );
+    await initBackground();
+
+    // Trigger both lifecycle events sequentially (as would happen on browser restart)
+    await fakeBrowser.runtime.onInstalled.trigger({ reason: 'install', temporary: false } as never);
+    await fakeBrowser.runtime.onStartup.trigger();
+
+    // Only one session should be persisted — the second call should see the
+    // already-recovered (SHORT_BREAK) state and bail out via recoverMissedAlarm returning null
+    const sessions = await getSessionHistory();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toEqual(
+      expect.objectContaining({
+        label: 'Dedup test',
+        startTime: 1_000,
+        endTime: 10_000,
+        duration: 1_000,
+      }),
+    );
   });
 
   it('updates config during an active timer and recreates the timer alarm', async () => {


### PR DESCRIPTION
## Summary
- Tests `onStartup` listener triggers missed alarm recovery correctly
- Tests that both `onInstalled` + `onStartup` firing = only 1 persisted session (dedup)
- Also fixes testId++ pattern and timezone-safe date assertions

## Verification
- [x] All 9 background tests pass
- [x] Overlaps with #391 on background.test.ts — either merge order works

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)