### PR TITLE
test: add isolated badge-refresh alarm handler tests

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -4,12 +4,14 @@ import { fakeBrowser } from 'wxt/testing';
 vi.mock('wxt/browser', () => ({ browser: fakeBrowser }));
 
 import {
+  addCompletedSession,
   getConfig,
   getPendingCelebration,
   getSessionHistory,
   getTimerState,
   setCurrentLabel,
   setTimerState,
+  toDateKey,
 } from '@/lib/storage';
 import { DEFAULT_CONFIG, INITIAL_STATE, type TimerConfig, type TimerState } from '@/lib/types';
 
@@ -29,11 +31,13 @@ const createConfig = (overrides: Partial<TimerConfig> = {}): TimerConfig => ({
   ...overrides,
 });
 
+let testId = 0;
+
 const initBackground = async (): Promise<void> => {
   (globalThis as typeof globalThis & { defineBackground: (main?: () => void | Promise<void>) => { main?: () => void | Promise<void> } }).defineBackground =
     (main) => ({ main });
 
-  const background = (await import(`../background?test=${Math.random()}`)) as BackgroundModule;
+  const background = (await import(`../background?test=${testId++}`)) as BackgroundModule;
   await background.default.main?.();
 };
 
@@ -131,7 +135,7 @@ describe('background service worker', () => {
         label: 'Focus block',
         startTime: 1_000,
         endTime: 5_000,
-        date: '1970-01-01',
+        date: toDateKey(1_000),
         duration: 3_000,
       },
     ]);
@@ -216,7 +220,7 @@ describe('background service worker', () => {
         label: 'Recovered work',
         startTime: 1_000,
         endTime: 10_000,
-        date: '1970-01-01',
+        date: toDateKey(1_000),
         duration: 1_000,
       },
     ]);
@@ -238,6 +242,162 @@ describe('background service worker', () => {
     await initBackground();
 
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
+  });
+
+  describe('ALARM_BADGE_REFRESH handler isolation', () => {
+    it('only updates the badge — no state writes, no new alarm creation', async () => {
+      const workingState = createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 1_000 + DEFAULT_CONFIG.workDuration,
+        duration: DEFAULT_CONFIG.workDuration,
+        sessionCount: 1,
+        completedToday: 1,
+      });
+      vi.spyOn(Date, 'now').mockReturnValue(60_000);
+      await setTimerState(workingState);
+      await initBackground();
+
+      // Snapshot state and alarms before firing badge-refresh
+      const stateBefore = await getTimerState();
+      const alarmsBefore = await fakeBrowser.alarms.getAll();
+
+      await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 60_000 });
+
+      // State must be untouched
+      const stateAfter = await getTimerState();
+      expect(stateAfter).toEqual(stateBefore);
+
+      // No new alarms created (alarm set should remain the same)
+      const alarmsAfter = await fakeBrowser.alarms.getAll();
+      expect(alarmsAfter.map((a) => a.name).sort()).toEqual(alarmsBefore.map((a) => a.name).sort());
+
+      // Badge was updated
+      expect(fakeBrowser.action.setBadgeText).toHaveBeenCalled();
+      expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenCalled();
+    });
+
+    it('does not persist any completed session', async () => {
+      await setTimerState(
+        createState({
+          phase: 'WORKING',
+          startTime: 1_000,
+          endTime: 100_000,
+          duration: 99_000,
+        }),
+      );
+      await initBackground();
+
+      await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 50_000 });
+
+      await expect(getSessionHistory()).resolves.toEqual([]);
+    });
+  });
+
+  describe('refreshBadge shows correct text per phase', () => {
+    it('WORKING phase shows remaining minutes', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(5 * 60_000); // 5 minutes elapsed
+      await setTimerState(
+        createState({
+          phase: 'WORKING',
+          startTime: 0,
+          endTime: 25 * 60_000, // 25 minutes total
+          duration: 25 * 60_000,
+        }),
+      );
+      await initBackground();
+
+      await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 5 * 60_000 });
+
+      // 20 minutes remaining → badge text "20"
+      expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: '20' });
+      expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenLastCalledWith({ color: '#DC2626' });
+    });
+
+    it('SHORT_BREAK phase shows "BRK"', async () => {
+      await setTimerState(
+        createState({
+          phase: 'SHORT_BREAK',
+          startTime: 1_000,
+          endTime: 100_000,
+          duration: 99_000,
+          sessionCount: 1,
+          completedToday: 1,
+        }),
+      );
+      await initBackground();
+
+      await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 50_000 });
+
+      expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: 'BRK' });
+      expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenLastCalledWith({ color: '#16A34A' });
+    });
+
+    it('LONG_BREAK phase shows "BRK"', async () => {
+      await setTimerState(
+        createState({
+          phase: 'LONG_BREAK',
+          startTime: 1_000,
+          endTime: 200_000,
+          duration: 199_000,
+          sessionCount: 4,
+          completedToday: 4,
+        }),
+      );
+      await initBackground();
+
+      await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 100_000 });
+
+      expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: 'BRK' });
+      expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenLastCalledWith({ color: '#16A34A' });
+    });
+
+    it('IDLE phase with completed sessions shows today count', async () => {
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+      // Add a completed session for today so getTodayCount returns 1
+      await addCompletedSession({
+        id: 'test-session',
+        label: 'Test',
+        startTime: now - 500,
+        endTime: now - 100,
+        date: toDateKey(now),
+        duration: 400,
+      });
+      await setTimerState(createState({ phase: 'IDLE', completedToday: 1 }));
+      await initBackground();
+
+      await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 1_000 });
+
+      expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: '1' });
+      expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenLastCalledWith({ color: '#DC2626' });
+    });
+
+    it('IDLE phase with zero sessions shows empty badge', async () => {
+      await setTimerState(createState({ phase: 'IDLE' }));
+      await initBackground();
+
+      await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 1_000 });
+
+      expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: '' });
+    });
+
+    it('BREAK_SUGGESTION phase shows completed count with checkmark', async () => {
+      await setTimerState(
+        createState({
+          phase: 'BREAK_SUGGESTION',
+          sessionCount: 4,
+          cyclePosition: 3,
+          completedToday: 4,
+        }),
+      );
+      await initBackground();
+
+      await fakeBrowser.alarms.onAlarm.trigger({ name: 'badge-refresh', scheduledTime: 1_000 });
+
+      expect(fakeBrowser.action.setBadgeText).toHaveBeenLastCalledWith({ text: '4✓' });
+      expect(fakeBrowser.action.setBadgeBackgroundColor).toHaveBeenLastCalledWith({ color: '#CA8A04' });
+    });
   });
 
   it('updates config during an active timer and recreates the timer alarm', async () => {


### PR DESCRIPTION
## Summary
- 2 isolation tests: badge-refresh only updates badge, no state mutations
- 6 per-phase badge text tests: WORKING (minutes), BREAK ("BRK"), IDLE (count), BREAK_SUGGESTION (count✓)
- Also fixes testId++ pattern and timezone-safe date assertions

## Verification
- [x] All 15 background tests pass
- [x] Overlaps with #390 on background.test.ts — either merge order works

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)