### PR TITLE
fix: constrain confetti particles to popup bounds

### DIFF
--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -26,7 +26,7 @@ const CONFETTI_CONFIGS: Record<string, confetti.Options> = {
 };
 
 export const playCelebration = (type: 'work' | 'milestone' | 'break', playSound = true): void => {
-  confetti(CONFETTI_CONFIGS[type]).then(() => confetti.reset());
+  void confetti(CONFETTI_CONFIGS[type])?.then(() => confetti.reset());
 
   if (playSound) {
     try {

--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -6,24 +6,27 @@ const CONFETTI_CONFIGS: Record<string, confetti.Options> = {
     particleCount: 150,
     spread: 80,
     origin: { y: 0.6 },
+    scalar: 0.7,
     colors: ['#DC2626', '#16A34A', '#FBBF24'],
   },
   milestone: {
     particleCount: 300,
     spread: 100,
     origin: { y: 0.6 },
+    scalar: 0.7,
     colors: ['#DC2626', '#16A34A', '#FBBF24', '#7C3AED', '#2563EB'],
   },
   break: {
     particleCount: 50,
     spread: 60,
     origin: { y: 0.6 },
+    scalar: 0.7,
     colors: ['#60A5FA', '#34D399', '#A78BFA'],
   },
 };
 
 export const playCelebration = (type: 'work' | 'milestone' | 'break', playSound = true): void => {
-  confetti(CONFETTI_CONFIGS[type]);
+  confetti(CONFETTI_CONFIGS[type]).then(() => confetti.reset());
 
   if (playSound) {
     try {


### PR DESCRIPTION
## Summary

- Adds `scalar: 0.7` to all confetti configs to reduce particle size and keep particles within the extension popup's constrained viewport
- Chains `.then(() => confetti.reset())` after each confetti call to clean up the full-viewport canvas overlay once the animation completes, preventing overflow artifacts

Closes #214