### PR TITLE
fix: dynamic TimerRing SVG title and clean stats link aria-label (#233, #234)

### DIFF
--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -3,6 +3,15 @@ import type { TimerPhase } from '@/lib/types';
 type TimerRingProps = {
   progress: number;
   phase: TimerPhase;
+  remainingLabel?: string;
+};
+
+const PHASE_LABELS: Record<TimerPhase, string> = {
+  IDLE: 'Idle',
+  WORKING: 'Working',
+  SHORT_BREAK: 'Short Break',
+  LONG_BREAK: 'Long Break',
+  BREAK_SUGGESTION: 'Break Suggestion',
 };
 
 const PHASE_COLORS: Record<TimerPhase, string> = {
@@ -21,10 +30,14 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 export default function TimerRing(props: TimerRingProps) {
   const offset = () => CIRCUMFERENCE * (1 - props.progress);
   const color = () => PHASE_COLORS[props.phase];
+  const title = () => {
+    const phase = PHASE_LABELS[props.phase];
+    return props.remainingLabel ? `${phase} — ${props.remainingLabel} remaining` : phase;
+  };
 
   return (
     <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      <title>Timer progress</title>
+      <title>{title()}</title>
       <circle
         cx={SIZE / 2}
         cy={SIZE / 2}

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -63,7 +63,17 @@ export default function App() {
     <div class="min-h-screen bg-red-50 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
+          <div class="flex items-center gap-3">
+            <button
+              type="button"
+              aria-label="Back to timer"
+              class="text-red-400 hover:text-red-600 transition-colors"
+              onClick={() => window.close()}
+            >
+              ←
+            </button>
+            <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
+          </div>
           <Show when={(sessions() ?? []).length > 0}>
             <button
               class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"


### PR DESCRIPTION
## Summary

- Closes #233
- Closes #234

## Changes

**`components/TimerRing.tsx`** — Issue #233
- Replaced the static `<title>Timer progress</title>` with a computed reactive title that reflects the current phase (e.g. "Working", "Short Break", "Idle")
- Added optional `remainingLabel?: string` prop; when provided, the title becomes `"Working — 04:30 remaining"`, giving screen readers full context
- Added `PHASE_LABELS` map for human-readable phase names

**`entrypoints/stats/App.tsx`** — Issue #234
- Added a `←` back-navigation button at the top-left of the stats page
- Button carries `aria-label="Back to timer"` so screen readers announce the destination without the raw arrow glyph
- Clicking it calls `window.close()` to return to the popup tab

## Test plan

- [ ] Open popup with screen reader active; verify SVG title announces current phase on focus
- [ ] Start a timer; verify title updates to include remaining time when `remainingLabel` is wired up
- [ ] Open stats page with screen reader; tab to the back button — verify announcement is "Back to timer" not "←"
- [ ] Click back button to confirm it closes the tab