### PR TITLE
fix: aria-describedby range hints, aria-invalid, and aria-live save confirmation

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -90,8 +90,11 @@ export default function App() {
               max={120}
               value={work()}
               onInput={(e) => setWork(Number(e.currentTarget.value))}
+              aria-describedby="work-hint"
+              aria-invalid={!isValidWork(work())}
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="work-hint" class="text-xs text-gray-500">1–120 minutes</span>
           </label>
 
           <label class="block">
@@ -102,8 +105,11 @@ export default function App() {
               max={30}
               value={shortBreak()}
               onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
+              aria-describedby="short-break-hint"
+              aria-invalid={!isValidShortBreak(shortBreak())}
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="short-break-hint" class="text-xs text-gray-500">1–30 minutes</span>
           </label>
 
           <label class="block">
@@ -114,8 +120,11 @@ export default function App() {
               max={60}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
+              aria-describedby="long-break-hint"
+              aria-invalid={!isValidLongBreak(longBreak())}
               class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="long-break-hint" class="text-xs text-gray-500">5–60 minutes</span>
           </label>
 
           <label class="flex items-center gap-3 cursor-pointer">
@@ -157,9 +166,11 @@ export default function App() {
             Reset to defaults
           </button>
 
-          <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
-          </Show>
+          <span aria-live="polite" aria-atomic="true">
+            <Show when={saved()}>
+              <span class="text-sm text-green-600">Settings saved ✓</span>
+            </Show>
+          </span>
         </div>
 
         <Show when={error()}>


### PR DESCRIPTION
## Summary

- Adds `aria-describedby` pointing to hint spans (`1–120 minutes`, `1–30 minutes`, `5–60 minutes`) on all three duration inputs so screen readers announce the valid range
- Adds `aria-invalid` on each duration input, driven by the existing `isValidWork/ShortBreak/LongBreak` predicates, so AT announces constraint violations immediately
- Wraps the "Settings saved ✓" confirmation in `aria-live="polite" aria-atomic="true"` so screen readers announce it when it appears

Closes #231
Closes #232

## Test plan

- [ ] All 86 unit tests pass (`npm test`)
- [ ] Screen reader (VoiceOver/NVDA) announces range hint when focus enters a duration input
- [ ] Entering an out-of-range value causes the field to be announced as invalid
- [ ] After saving, screen reader announces "Settings saved ✓"