### PR TITLE
perf: avoid O(n) session scan in getTodayCount by using completedToday counter

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -125,6 +125,7 @@ describe('background service worker', () => {
         duration: DEFAULT_CONFIG.shortBreakDuration,
         sessionCount: 1,
         completedToday: 1,
+        lastWorkDate: toDateKey(5_000),
       }),
     );
     await expect(getPendingCelebration()).resolves.toBe(true);
@@ -210,6 +211,7 @@ describe('background service worker', () => {
         duration: DEFAULT_CONFIG.shortBreakDuration,
         sessionCount: 1,
         completedToday: 1,
+        lastWorkDate: toDateKey(10_000),
       }),
     );
     await expect(getPendingCelebration()).resolves.toBe(true);

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -16,7 +16,6 @@ import {
   getConfig,
   getCurrentLabel,
   getTimerState,
-  getTodayCount,
   setConfig,
   setPendingCelebration,
   setTimerState,
@@ -41,7 +40,10 @@ export default defineBackground(() => {
   const badgeApi = browser.action;
 
   const refreshBadge = async (): Promise<void> => {
-    const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
+    const state = await getTimerState();
+    // completedToday is valid only for lastWorkDate; return 0 if the date has rolled over.
+    const todayKey = toDateKey(Date.now());
+    const todayCount = state.lastWorkDate === todayKey ? state.completedToday : 0;
 
     let text = '';
     let color = BADGE_RED;

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -119,17 +119,23 @@ describe('storage helpers', () => {
     });
   });
 
-  it('counts only todays sessions', async () => {
+  it('counts only todays sessions via TimerState.completedToday', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(new Date(2026, 2, 20, 12, 0, 0).getTime());
 
-    const todayTimestamp = new Date(2026, 2, 20, 9, 0, 0).getTime();
-    const yesterdayTimestamp = new Date(2026, 2, 19, 9, 0, 0).getTime();
-
-    await addCompletedSession(createSession(todayTimestamp, { id: 'today-1' }));
-    await addCompletedSession(createSession(todayTimestamp + 1_000, { id: 'today-2' }));
-    await addCompletedSession(createSession(yesterdayTimestamp, { id: 'yesterday-1' }));
+    const todayKey = toDateKey(new Date(2026, 2, 20, 12, 0, 0).getTime());
+    // getTodayCount reads completedToday from TimerState (O(1)), not the sessions array.
+    await setTimerState(createState({ completedToday: 2, lastWorkDate: todayKey }));
 
     await expect(getTodayCount()).resolves.toBe(2);
+  });
+
+  it('returns 0 from getTodayCount when lastWorkDate is a previous day', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date(2026, 2, 20, 12, 0, 0).getTime());
+
+    const yesterdayKey = toDateKey(new Date(2026, 2, 19, 9, 0, 0).getTime());
+    await setTimerState(createState({ completedToday: 3, lastWorkDate: yesterdayKey }));
+
+    await expect(getTodayCount()).resolves.toBe(0);
   });
 
   it('truncates labels to 50 characters before storing', async () => {

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -221,7 +221,11 @@ describe('timer state machine', () => {
       completedToday: 0,
     });
 
-    expect(recoverMissedAlarm(state, config, 3_000)).toEqual({
+    const recoverTime = 3_000;
+    const d = new Date(recoverTime);
+    const expectedLastWorkDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+    expect(recoverMissedAlarm(state, config, recoverTime)).toEqual({
       ...state,
       phase: 'SHORT_BREAK',
       startTime: 3_000,
@@ -229,7 +233,7 @@ describe('timer state machine', () => {
       duration: 500,
       sessionCount: 1,
       completedToday: 1,
-      lastWorkDate: '1969-12-31',
+      lastWorkDate: expectedLastWorkDate,
     });
   });
 

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -229,6 +229,7 @@ describe('timer state machine', () => {
       duration: 500,
       sessionCount: 1,
       completedToday: 1,
+      lastWorkDate: '1969-12-31',
     });
   });
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -86,10 +86,11 @@ export const getHeatmapData = async (days: number): Promise<Record<string, numbe
 };
 
 export const getTodayCount = async (): Promise<number> => {
+  const state = await getTimerState();
   const todayKey = toDateKey(Date.now());
-  const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-
-  return sessions.filter((session) => session.date === todayKey).length;
+  // completedToday is keyed to lastWorkDate; if the date has rolled over since
+  // the last session, the counter belongs to a previous day so today's count is 0.
+  return state.lastWorkDate === todayKey ? state.completedToday : 0;
 };
 
 export const getPendingCelebration = async (): Promise<boolean> =>

--- a/lib/timer.ts
+++ b/lib/timer.ts
@@ -2,12 +2,21 @@ import { INITIAL_STATE, type TimerConfig, type TimerPhase, type TimerState } fro
 
 const getNow = (now?: number): number => now ?? Date.now();
 
+const toLocalDateKey = (timestamp: number): string => {
+  const d = new Date(timestamp);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+};
+
 const toIdleState = (state: TimerState): TimerState => ({
   ...state,
   ...INITIAL_STATE,
   sessionCount: state.sessionCount,
   cyclePosition: state.cyclePosition,
   completedToday: state.completedToday,
+  lastWorkDate: state.lastWorkDate,
 });
 
 const getPhaseDuration = (phase: TimerPhase, config: TimerConfig): number | null => {
@@ -47,10 +56,14 @@ export const completeTimer = (state: TimerState, config: TimerConfig, now?: numb
 
   switch (state.phase) {
     case 'WORKING': {
+      const todayKey = toLocalDateKey(currentTime);
+      // Reset completedToday if we've crossed midnight since the last session.
+      const prevCount = state.lastWorkDate === todayKey ? state.completedToday : 0;
       const completedState = {
         ...state,
         sessionCount: state.sessionCount + 1,
-        completedToday: state.completedToday + 1,
+        completedToday: prevCount + 1,
+        lastWorkDate: todayKey,
       };
 
       if (state.cyclePosition === 3) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,8 @@ export type TimerState = {
   sessionCount: number;
   cyclePosition: number;
   completedToday: number;
+  /** ISO date key (YYYY-MM-DD) of the last day completedToday was incremented; used to reset the counter at midnight. */
+  lastWorkDate: string;
 };
 
 export type CompletedSession = {
@@ -45,4 +47,5 @@ export const INITIAL_STATE: TimerState = {
   sessionCount: 0,
   cyclePosition: 0,
   completedToday: 0,
+  lastWorkDate: '',
 };


### PR DESCRIPTION
Closes #380

## Summary

- Adds `lastWorkDate: string` field to `TimerState` (persisted alongside `completedToday`)
- `completeTimer()` in `lib/timer.ts` now sets `lastWorkDate` to today's date key on each WORKING completion, and resets `completedToday` to 0 when the date rolls over (midnight handling)
- `getTodayCount()` in `lib/storage.ts` now reads a single `TimerState` object (O(1)) instead of loading and scanning the entire sessions array (O(n))
- `refreshBadge()` in `entrypoints/background.ts` no longer calls `getTodayCount()` as a parallel storage read — it derives the count inline from the already-loaded `TimerState`, saving one storage round-trip per badge refresh

## Test plan

- [ ] All 87 existing tests pass (`npm test`)
- [ ] Updated `getTodayCount` tests to assert the counter reads from `TimerState` rather than the sessions array
- [ ] Added test for midnight rollover: `lastWorkDate` from a previous day returns 0
- [ ] Background tests updated to include `lastWorkDate` in post-completion state assertions