### PR TITLE
feat: add prev/next year navigation to stats heatmap

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -4,6 +4,8 @@ type HeatmapProps = {
   data: Record<string, number>;
   days: number;
   cellSize?: number;
+  /** When provided, renders all days of this calendar year instead of a rolling window. */
+  year?: number;
 };
 
 type HeatmapCell = {
@@ -45,8 +47,29 @@ const toDateKey = (date: Date): string => {
 const generateHeatmapGrid = (
   data: Record<string, number>,
   days: number,
+  year?: number,
 ): HeatmapCell[] => {
   const cells: HeatmapCell[] = [];
+
+  if (year !== undefined) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const isCurrentYear = year === today.getFullYear();
+    const endDate = isCurrentYear ? today : new Date(year, 11, 31);
+    const startDate = new Date(year, 0, 1);
+
+    for (const d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+      const key = toDateKey(d);
+      cells.push({
+        date: key,
+        count: data[key] ?? 0,
+        dayOfWeek: d.getDay(),
+      });
+    }
+
+    return cells;
+  }
+
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -70,7 +93,7 @@ export default function Heatmap(props: HeatmapProps) {
   const cellSize = () => props.cellSize ?? 12;
   const gap = 2;
 
-  const grid = createMemo(() => generateHeatmapGrid(props.data, props.days));
+  const grid = createMemo(() => generateHeatmapGrid(props.data, props.days, props.year));
 
   const toMonRow = (jsDay: number) => (jsDay === 0 ? 6 : jsDay - 1);
 

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,6 +1,6 @@
-import { createResource, For, Show } from 'solid-js';
+import { createResource, createSignal, For, Show } from 'solid-js';
 
-import { getConfig, getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
+import { getConfig, getSessionHistory, getHeatmapDataForYear, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
 
 import Heatmap from '@/components/Heatmap';
@@ -46,7 +46,10 @@ function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
 }
 
 export default function App() {
-  const [yearData] = createResource(() => getHeatmapData(365));
+  const currentYear = new Date().getFullYear();
+  const [selectedYear, setSelectedYear] = createSignal(currentYear);
+
+  const [yearData] = createResource(selectedYear, (year) => getHeatmapDataForYear(year));
   const [sessions] = createResource(() => getSessionHistory());
   const [todayCount] = createResource(() => getTodayCount());
   const [config] = createResource(() => getConfig());
@@ -117,8 +120,30 @@ export default function App() {
           </div>
 
           <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-            <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
-            <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
+            <div class="flex items-center justify-between mb-3">
+              <h2 class="text-sm font-semibold text-gray-700">Activity</h2>
+              <div class="flex items-center gap-2">
+                <button
+                  aria-label="Previous year"
+                  class="w-6 h-6 flex items-center justify-center rounded hover:bg-red-100 text-red-600 transition-colors"
+                  onClick={() => setSelectedYear((y) => y - 1)}
+                >
+                  &#8249;
+                </button>
+                <span class="text-sm font-medium text-gray-700 w-10 text-center">
+                  {selectedYear()}
+                </span>
+                <button
+                  aria-label="Next year"
+                  disabled={selectedYear() >= currentYear}
+                  class="w-6 h-6 flex items-center justify-center rounded hover:bg-red-100 text-red-600 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  onClick={() => setSelectedYear((y) => Math.min(y + 1, currentYear))}
+                >
+                  &#8250;
+                </button>
+              </div>
+            </div>
+            <Heatmap days={365} year={selectedYear()} cellSize={14} data={yearData() ?? {}} />
 
             <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
               <span>Less</span>

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -85,6 +85,18 @@ export const getHeatmapData = async (days: number): Promise<Record<string, numbe
   }, {});
 };
 
+export const getHeatmapDataForYear = async (year: number): Promise<Record<string, number>> => {
+  const allSessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
+  const prefix = String(year);
+
+  return allSessions
+    .filter((s) => s.date.startsWith(prefix))
+    .reduce<Record<string, number>>((acc, session) => {
+      acc[session.date] = (acc[session.date] ?? 0) + 1;
+      return acc;
+    }, {});
+};
+
 export const getTodayCount = async (): Promise<number> => {
   const todayKey = toDateKey(Date.now());
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];


### PR DESCRIPTION
Closes #199

## Summary
- Add `selectedYear` signal (default: current year) in the stats page
- Add `getHeatmapDataForYear(year)` to `lib/storage.ts` that filters sessions by calendar year
- Add prev/next year buttons with the selected year label in the heatmap section header
- The next-year button is disabled when already viewing the current year
- Update `Heatmap` component with an optional `year` prop: when set, renders Jan 1–Dec 31 of that year (capped at today for the current year) instead of a rolling N-day window

## Test plan
- [ ] All 86 existing tests pass (`npx vitest run`)
- [ ] Viewing current year shows activity up to today
- [ ] Clicking previous year shows Jan–Dec of that year with correct data
- [ ] Next-year button is disabled on current year