### PR TITLE
test: verify cross-midnight sessions are attributed to completion date

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -187,6 +187,34 @@ describe('background service worker', () => {
     );
   });
 
+  it('attributes a cross-midnight session to the completion date, not the start date', async () => {
+    // startTime is on Jan 1 1970; completionNow is 24 h + 1 min later on Jan 2 1970.
+    // The >24 h gap guarantees different calendar dates in every UTC offset (UTC-14..UTC+14).
+    const startTime = 1_000; // Jan 1 1970 00:00:01 UTC
+    const completionNow = 86_461_000; // Jan 2 1970 00:01:01 UTC
+    vi.spyOn(Date, 'now').mockReturnValue(completionNow);
+    await setCurrentLabel('Late night focus');
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime,
+        endTime: startTime + DEFAULT_CONFIG.workDuration,
+        duration: DEFAULT_CONFIG.workDuration,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.alarms.onAlarm.trigger({
+      name: 'tomate-timer',
+      scheduledTime: startTime + DEFAULT_CONFIG.workDuration,
+    });
+
+    const history = await getSessionHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].date).toBe(toDateKey(completionNow));
+    expect(history[0].date).not.toBe(toDateKey(startTime));
+  });
+
   it('recovers a missed working alarm on startup and records the completed session', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000);
     await setCurrentLabel('Recovered work');


### PR DESCRIPTION
## Summary

- Adds a regression test to `entrypoints/__tests__/background.test.ts` that verifies sessions starting before midnight and completing after midnight are attributed to the **completion date** (`endTime`/`Date.now()`), not the start date.
- Uses `startTime = 1_000` (Jan 1 1970 00:00:01 UTC) and a mocked `Date.now() = 86_461_000` (Jan 2 1970 00:01:01 UTC) — a 24 h + 1 min gap that guarantees different calendar dates across all UTC offsets.
- Asserts `history[0].date === toDateKey(completionNow)` and explicitly asserts it does **not** equal `toDateKey(startTime)`.

## Test plan

- [ ] `npm test entrypoints/__tests__/background.test.ts` passes (8/8 tests green)
- [ ] The new test title is visible: *"attributes a cross-midnight session to the completion date, not the start date"*
- [ ] No other files modified