### PR TITLE
fix: add dark mode color variants to popup, stats, and options pages

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -77,44 +77,44 @@ export default function App() {
   };
 
   return (
-    <div class="min-h-screen bg-red-50 flex items-start justify-center pt-16">
-      <div class="w-full max-w-[400px] bg-white rounded-lg shadow-sm p-6">
-        <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 flex items-start justify-center pt-16">
+      <div class="w-full max-w-[400px] bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400 mb-6">Tomate Settings</h1>
 
         <div class="space-y-4">
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Work Duration (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Work Duration (minutes)</span>
             <input
               type="number"
               min={1}
               max={120}
               value={work()}
               onInput={(e) => setWork(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Short Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Short Break (minutes)</span>
             <input
               type="number"
               min={1}
               max={30}
               value={shortBreak()}
               onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Long Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Long Break (minutes)</span>
             <input
               type="number"
               min={5}
               max={60}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
 
@@ -123,9 +123,9 @@ export default function App() {
               type="checkbox"
               checked={openBreakTab()}
               onChange={(e) => setOpenBreakTab(e.currentTarget.checked)}
-              class="w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500"
             />
-            <span class="text-sm font-medium text-gray-700">Open stats tab when session completes</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Open stats tab when session completes</span>
           </label>
 
           <label class="flex items-center gap-3 cursor-pointer">
@@ -133,9 +133,9 @@ export default function App() {
               type="checkbox"
               checked={playCompletionSound()}
               onChange={(e) => setPlayCompletionSound(e.currentTarget.checked)}
-              class="w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500"
             />
-            <span class="text-sm font-medium text-gray-700">Play completion sound</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Play completion sound</span>
           </label>
         </div>
 
@@ -144,7 +144,7 @@ export default function App() {
             type="button"
             onClick={handleSave}
             disabled={!isValid()}
-            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Save
           </button>
@@ -152,18 +152,18 @@ export default function App() {
           <button
             type="button"
             onClick={handleReset}
-            class="text-sm text-gray-500 hover:text-gray-700 underline"
+            class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 underline"
           >
             Reset to defaults
           </button>
 
           <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
+            <span class="text-sm text-green-600 dark:text-green-400">Settings saved ✓</span>
           </Show>
         </div>
 
         <Show when={error()}>
-          <p class="mt-3 text-sm text-red-600" role="alert">{error()}</p>
+          <p class="mt-3 text-sm text-red-600 dark:text-red-400" role="alert">{error()}</p>
         </Show>
       </div>
     </div>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -107,13 +107,13 @@ export default function App() {
   };
 
   return (
-    <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
+    <div class="w-[360px] min-h-[400px] bg-red-50 dark:bg-gray-900 p-4 flex flex-col items-center">
       <div class="w-full flex justify-between items-center mb-4">
-        <h1 class="text-xl font-bold text-red-600">Tomate</h1>
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400">Tomate</h1>
         <button
           type="button"
           onClick={() => browser.runtime.openOptionsPage()}
-          class="text-gray-400 hover:text-gray-600 text-lg"
+          class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 text-lg"
           aria-label="Settings"
         >
           ⚙️
@@ -121,9 +121,9 @@ export default function App() {
       </div>
 
       <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+      <div class="text-4xl font-mono font-bold text-gray-800 dark:text-gray-100 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
+      <div class="text-sm text-gray-500 dark:text-gray-400 mt-1">
         <Switch>
           <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
           <Match when={state().phase === 'WORKING'}>Working</Match>
@@ -152,7 +152,7 @@ export default function App() {
       <button
         type="button"
         onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
-        class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        class="mt-2 text-xs text-red-400 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300 underline"
       >
         View all stats →
       </button>

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -21,10 +21,10 @@ type StatCardProps = {
 
 function StatCard(props: StatCardProps) {
   return (
-    <div class="bg-white rounded-xl p-4 shadow-sm border border-red-100 flex flex-col items-center gap-1">
-      <span class="text-2xl font-bold text-red-600">{props.value}</span>
-      <span class="text-xs text-gray-500 font-medium">{props.label}</span>
-      {props.sublabel && <span class="text-[10px] text-gray-400">{props.sublabel}</span>}
+    <div class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-red-100 dark:border-gray-700 flex flex-col items-center gap-1">
+      <span class="text-2xl font-bold text-red-600 dark:text-red-400">{props.value}</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400 font-medium">{props.label}</span>
+      {props.sublabel && <span class="text-[10px] text-gray-400 dark:text-gray-500">{props.sublabel}</span>}
     </div>
   );
 }
@@ -60,13 +60,13 @@ export default function App() {
   const streak = () => computeStreak(sessions() ?? []);
 
   return (
-    <div class="min-h-screen bg-red-50 py-10 px-4">
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
+          <h1 class="text-2xl font-bold text-red-600 dark:text-red-400">Tomate Stats</h1>
           <Show when={(sessions() ?? []).length > 0}>
             <button
-              class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
+              class="text-sm px-3 py-1.5 rounded-lg border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900 transition-colors"
               onClick={() => exportCSV(sessions() ?? [])}
             >
               Export CSV
@@ -97,12 +97,12 @@ export default function App() {
             />
           </div>
 
-          <div class="bg-white rounded-xl p-4 shadow-sm border border-red-100 mb-6">
+          <div class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-red-100 dark:border-gray-700 mb-6">
             <div class="flex items-center justify-between mb-2">
-              <span class="text-sm font-semibold text-gray-700">Daily Goal</span>
-              <span class="text-xs text-gray-500">{todayCount() ?? 0} / {dailyGoal()}</span>
+              <span class="text-sm font-semibold text-gray-700 dark:text-gray-200">Daily Goal</span>
+              <span class="text-xs text-gray-500 dark:text-gray-400">{todayCount() ?? 0} / {dailyGoal()}</span>
             </div>
-            <div class="w-full bg-gray-200 rounded-full h-2.5">
+            <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5">
               <div
                 class="h-2.5 rounded-full transition-all duration-300"
                 style={{
@@ -112,15 +112,15 @@ export default function App() {
               />
             </div>
             <Show when={goalProgress() >= 100}>
-              <p class="text-xs text-green-600 mt-1 font-medium">Daily goal reached!</p>
+              <p class="text-xs text-green-600 dark:text-green-400 mt-1 font-medium">Daily goal reached!</p>
             </Show>
           </div>
 
-          <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-            <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
+          <div class="bg-white dark:bg-gray-800 rounded-xl p-5 shadow-sm border border-red-100 dark:border-gray-700">
+            <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">365-day activity</h2>
             <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
 
-            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
+            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400 dark:text-gray-500">
               <span>Less</span>
               <For each={INTENSITY_LEGEND}>
                 {(item) => (


### PR DESCRIPTION
Closes #206
Closes #208
Closes #210

## Summary
- **popup/App.tsx**: added `dark:bg-gray-900` page background, `dark:text-red-400` title, `dark:text-gray-100` timer display, `dark:text-gray-400` phase label, dark gear button hover states, dark stats link hover
- **stats/App.tsx**: added `dark:bg-gray-900` page background, dark StatCard backgrounds/borders/text, dark Export CSV button, dark Daily Goal card (bg, text, progress bar), dark activity heatmap card
- **options/App.tsx**: added `dark:bg-gray-900/gray-800` page/card backgrounds, `dark:text-gray-200` all form labels, `dark:bg-gray-700/border-gray-600` inputs, dark checkbox borders, `dark:focus:ring-offset-gray-800` save button, dark reset/saved/error text

## Test plan
- [ ] All 88 existing tests pass (`npm test`)
- [ ] Toggle OS to dark mode — popup shows dark gray background with light text
- [ ] Stats page renders dark card backgrounds with readable text in dark mode
- [ ] Options page inputs and labels are legible in dark mode