### PR TITLE
test: add sender verification and alarm race guard test coverage

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -273,4 +273,60 @@ describe('background service worker', () => {
       }),
     );
   });
+
+  it('rejects a message from a foreign extension sender and does not alter timer state', async () => {
+    await setTimerState(createState({ phase: 'IDLE' }));
+    await initBackground();
+
+    // Trigger onMessage directly with a sender whose id does not match browser.runtime.id.
+    const foreignSender = { id: 'foreign-extension-id' };
+    const results = await (fakeBrowser.runtime.onMessage as unknown as {
+      trigger: (msg: unknown, sender: unknown) => Promise<unknown[]>;
+    }).trigger({ action: 'START_TIMER' }, foreignSender);
+
+    // The listener must have returned false (rejecting the message).
+    expect(results).toContain(false);
+    // Timer state must remain IDLE — the message was not processed.
+    await expect(getTimerState()).resolves.toEqual(createState({ phase: 'IDLE' }));
+  });
+
+  it('processes a message from the same extension and advances timer state', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    await setTimerState(createState({ phase: 'IDLE' }));
+    await initBackground();
+
+    // Trigger onMessage with a sender whose id matches browser.runtime.id.
+    const ownSender = { id: fakeBrowser.runtime.id };
+    await (fakeBrowser.runtime.onMessage as unknown as {
+      trigger: (msg: unknown, sender: unknown) => Promise<unknown[]>;
+    }).trigger({ action: 'START_TIMER' }, ownSender);
+
+    // Timer must have transitioned to WORKING.
+    const state = await getTimerState();
+    expect(state.phase).toBe('WORKING');
+  });
+
+  it('deduplicates concurrent onAlarm calls — only one alarm handler runs at a time', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+      }),
+    );
+    await initBackground();
+
+    // Fire two alarm events without awaiting between them.  The second call must
+    // be dropped by the alarmHandling guard because the first has not finished.
+    const alarmEvent = { name: 'tomate-timer', scheduledTime: 4_000 };
+    const p1 = fakeBrowser.alarms.onAlarm.trigger(alarmEvent);
+    const p2 = fakeBrowser.alarms.onAlarm.trigger(alarmEvent);
+    await Promise.all([p1, p2]);
+
+    // Only one session should have been recorded.
+    const history = await getSessionHistory();
+    expect(history).toHaveLength(1);
+  });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -237,9 +237,16 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  browser.runtime.onMessage.addListener((message, sender) => {
+    if (sender.id !== undefined && sender.id !== browser.runtime.id) {
+      return false;
+    }
+    return handleMessage(message as MessageAction);
+  });
 
-  browser.alarms.onAlarm.addListener(async (alarm) => {
+  let alarmHandling = false;
+
+  const handleAlarm = async (alarm: browser.alarms.Alarm): Promise<void> => {
     if (alarm.name === ALARM_BADGE_REFRESH) {
       await refreshBadge();
       return;
@@ -291,5 +298,15 @@ export default defineBackground(() => {
     }
 
     await refreshBadge();
+  };
+
+  browser.alarms.onAlarm.addListener(async (alarm) => {
+    if (alarmHandling) return;
+    alarmHandling = true;
+    try {
+      await handleAlarm(alarm);
+    } finally {
+      alarmHandling = false;
+    }
   });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { browser } from 'wxt/browser';
+import { browser, type Browser } from 'wxt/browser';
 
 import {
   abandonTimer,
@@ -246,7 +246,7 @@ export default defineBackground(() => {
 
   let alarmHandling = false;
 
-  const handleAlarm = async (alarm: browser.alarms.Alarm): Promise<void> => {
+  const handleAlarm = async (alarm: Browser.alarms.Alarm): Promise<void> => {
     if (alarm.name === ALARM_BADGE_REFRESH) {
       await refreshBadge();
       return;


### PR DESCRIPTION
## Summary

- Adds sender verification to `onMessage` listener: rejects messages where `sender.id` is defined but does not match `browser.runtime.id`
- Adds `alarmHandling` in-memory lock to `onAlarm` handler to prevent concurrent executions
- Adds three new tests covering both fixes: foreign sender rejection, same-extension acceptance, and concurrent alarm deduplication