### PR TITLE
test: verify UPDATE_CONFIG zero duration is clamped, not forwarded (#237)

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -17,7 +17,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
-            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
+            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors duration-300"
           >
             Start
           </button>
@@ -26,7 +26,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors duration-300"
           >
             Abandon
           </button>
@@ -35,7 +35,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors duration-300"
           >
             Skip Break
           </button>
@@ -44,14 +44,14 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAcceptLongBreak}
-            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
+            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors duration-300"
           >
             Long Break
           </button>
           <button
             type="button"
             onClick={props.onSkipLongBreak}
-            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors duration-300"
           >
             Skip
           </button>

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -44,7 +44,7 @@ export default function TimerRing(props: TimerRingProps) {
         stroke-dasharray={String(CIRCUMFERENCE)}
         stroke-dashoffset={offset()}
         transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
-        class="transition-[stroke-dashoffset] duration-500 ease-linear"
+        class="transition-[stroke-dashoffset,stroke] duration-500 ease-linear"
       />
     </svg>
   );

--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -10,6 +10,7 @@ import {
   getTimerState,
   setCurrentLabel,
   setTimerState,
+  toDateKey,
 } from '@/lib/storage';
 import { DEFAULT_CONFIG, INITIAL_STATE, type TimerConfig, type TimerState } from '@/lib/types';
 
@@ -29,11 +30,13 @@ const createConfig = (overrides: Partial<TimerConfig> = {}): TimerConfig => ({
   ...overrides,
 });
 
+let testId = 0;
+
 const initBackground = async (): Promise<void> => {
   (globalThis as typeof globalThis & { defineBackground: (main?: () => void | Promise<void>) => { main?: () => void | Promise<void> } }).defineBackground =
     (main) => ({ main });
 
-  const background = (await import(`../background?test=${Math.random()}`)) as BackgroundModule;
+  const background = (await import(`../background?test=${testId++}`)) as BackgroundModule;
   await background.default.main?.();
 };
 
@@ -42,6 +45,11 @@ describe('background service worker', () => {
     vi.restoreAllMocks();
     fakeBrowser.reset();
     await fakeBrowser.storage.local.clear();
+
+    // fakeBrowser.runtime.sendMessage passes an empty sender object (sender.id = undefined).
+    // The background's onMessage guard rejects messages where sender.id !== runtime.id, so
+    // clear runtime.id to match the empty sender so test messages are accepted (#236).
+    (fakeBrowser.runtime as unknown as { id: string | undefined }).id = undefined;
 
     fakeBrowser.action.setBadgeText = vi.fn().mockResolvedValue(undefined);
     fakeBrowser.action.setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
@@ -131,7 +139,7 @@ describe('background service worker', () => {
         label: 'Focus block',
         startTime: 1_000,
         endTime: 5_000,
-        date: '1970-01-01',
+        date: toDateKey(1_000),
         duration: 3_000,
       },
     ]);
@@ -216,7 +224,7 @@ describe('background service worker', () => {
         label: 'Recovered work',
         startTime: 1_000,
         endTime: 10_000,
-        date: '1970-01-01',
+        date: toDateKey(1_000),
         duration: 1_000,
       },
     ]);
@@ -238,6 +246,37 @@ describe('background service worker', () => {
     await initBackground();
 
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
+  });
+
+  it('clamps workDuration: 0 to at least 1000ms in UPDATE_CONFIG, preventing an infinite alarm loop', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    const zeroConfig = createConfig({ workDuration: 0, shortBreakDuration: 0, longBreakDuration: 0 });
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 5_000,
+        endTime: 15_000,
+        duration: 10_000,
+      }),
+    );
+    await initBackground();
+
+    const response = await fakeBrowser.runtime.sendMessage({ action: 'UPDATE_CONFIG', config: zeroConfig });
+
+    // All durations must be clamped to at least 1000ms in the persisted config.
+    const savedConfig = await getConfig();
+    expect(savedConfig.workDuration).toBeGreaterThanOrEqual(1_000);
+    expect(savedConfig.shortBreakDuration).toBeGreaterThanOrEqual(1_000);
+    expect(savedConfig.longBreakDuration).toBeGreaterThanOrEqual(1_000);
+
+    // endTime must not equal startTime (5_000), which is already in the past at now=10_000.
+    // A zero-duration would produce endTime = 5_000 + 0 = 5_000 ≤ now, scheduling an alarm
+    // at or before the current time and immediately re-triggering it (infinite loop, #237).
+    const endTime = (response as { endTime: number }).endTime;
+    expect(endTime).toBeGreaterThan(10_000);
+
+    const alarm = await fakeBrowser.alarms.get('tomate-timer');
+    expect(alarm?.scheduledTime).toBeGreaterThan(10_000);
   });
 
   it('updates config during an active timer and recreates the timer alarm', async () => {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -16,7 +16,6 @@ import {
   getConfig,
   getCurrentLabel,
   getTimerState,
-  getTodayCount,
   setConfig,
   setPendingCelebration,
   setTimerState,
@@ -41,7 +40,10 @@ export default defineBackground(() => {
   const badgeApi = browser.action;
 
   const refreshBadge = async (): Promise<void> => {
-    const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
+    const state = await getTimerState();
+    // completedToday is valid only for lastWorkDate; return 0 if the date rolled over.
+    const todayKey = toDateKey(Date.now());
+    const todayCount = state.lastWorkDate === todayKey ? state.completedToday : 0;
 
     let text = '';
     let color = BADGE_RED;
@@ -59,7 +61,7 @@ export default defineBackground(() => {
         break;
       }
       case 'BREAK_SUGGESTION': {
-        text = `${state.completedToday}✓`;
+        text = `${todayCount}✓`;
         color = BADGE_GOLD;
         break;
       }
@@ -220,7 +222,9 @@ export default defineBackground(() => {
     return handleMessage(message as MessageAction);
   });
 
-  browser.alarms.onAlarm.addListener(async (alarm) => {
+  let alarmHandling = false;
+
+  const handleAlarm = async (alarm: browser.alarms.Alarm): Promise<void> => {
     if (alarm.name === ALARM_BADGE_REFRESH) {
       await refreshBadge();
       return;
@@ -268,5 +272,15 @@ export default defineBackground(() => {
     }
 
     await refreshBadge();
+  };
+
+  browser.alarms.onAlarm.addListener(async (alarm) => {
+    if (alarmHandling) return;
+    alarmHandling = true;
+    try {
+      await handleAlarm(alarm);
+    } finally {
+      alarmHandling = false;
+    }
   });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -213,7 +213,12 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  browser.runtime.onMessage.addListener((message, sender) => {
+    if (sender.id !== browser.runtime.id) {
+      return false;
+    }
+    return handleMessage(message as MessageAction);
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -13,6 +13,10 @@ export default function App() {
   const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [saved, setSaved] = createSignal(false);
 
+  const isValidWork = () => work() >= 1 && work() <= 120;
+  const isValidShortBreak = () => shortBreak() >= 1 && shortBreak() <= 30;
+  const isValidLongBreak = () => longBreak() >= 5 && longBreak() <= 60;
+
   onMount(async () => {
     const config = await getConfig();
     setWork(Math.round(config.workDuration / MS_PER_MINUTE));
@@ -42,45 +46,54 @@ export default function App() {
   };
 
   return (
-    <div class="min-h-screen bg-red-50 flex items-start justify-center pt-16">
-      <div class="w-full max-w-[400px] bg-white rounded-lg shadow-sm p-6">
-        <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 flex items-start justify-center pt-16">
+      <div class="w-full max-w-[400px] bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
+        <h1 class="text-xl font-bold text-red-600 dark:text-red-400 mb-6">Tomate Settings</h1>
 
         <div class="space-y-4">
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Work Duration (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Work Duration (minutes)</span>
             <input
               type="number"
               min={1}
               max={120}
               value={work()}
               onInput={(e) => setWork(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              aria-describedby="work-hint"
+              aria-invalid={!isValidWork()}
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="work-hint" class="text-xs text-gray-500 dark:text-gray-400">1–120 minutes</span>
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Short Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Short Break (minutes)</span>
             <input
               type="number"
               min={1}
               max={30}
               value={shortBreak()}
               onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              aria-describedby="short-break-hint"
+              aria-invalid={!isValidShortBreak()}
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="short-break-hint" class="text-xs text-gray-500 dark:text-gray-400">1–30 minutes</span>
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Long Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Long Break (minutes)</span>
             <input
               type="number"
               min={5}
               max={60}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              aria-describedby="long-break-hint"
+              aria-invalid={!isValidLongBreak()}
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
+            <span id="long-break-hint" class="text-xs text-gray-500 dark:text-gray-400">5–60 minutes</span>
           </label>
 
           <label class="flex items-center gap-3 cursor-pointer">
@@ -88,9 +101,9 @@ export default function App() {
               type="checkbox"
               checked={openBreakTab()}
               onChange={(e) => setOpenBreakTab(e.currentTarget.checked)}
-              class="w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500"
             />
-            <span class="text-sm font-medium text-gray-700">Open stats tab when session completes</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Open stats tab when session completes</span>
           </label>
         </div>
 
@@ -98,7 +111,7 @@ export default function App() {
           <button
             type="button"
             onClick={handleSave}
-            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
           >
             Save
           </button>
@@ -106,14 +119,16 @@ export default function App() {
           <button
             type="button"
             onClick={handleReset}
-            class="text-sm text-gray-500 hover:text-gray-700 underline"
+            class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 underline"
           >
             Reset to defaults
           </button>
 
-          <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
-          </Show>
+          <span aria-live="polite" aria-atomic="true">
+            <Show when={saved()}>
+              <span class="text-sm text-green-600 dark:text-green-400">Settings saved ✓</span>
+            </Show>
+          </span>
         </div>
       </div>
     </div>

--- a/lib/__tests__/stats.test.ts
+++ b/lib/__tests__/stats.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeBestDay, computeStreak, computeTotalCount, computeWeekCount } from '../stats';
+import type { CompletedSession } from '../types';
+
+const makeSession = (date: string, id = date): CompletedSession => ({
+  id,
+  label: 'work',
+  startTime: 0,
+  endTime: 0,
+  date,
+  duration: 1_500_000,
+});
+
+// Compute date keys relative to actual today so tests are always valid
+const dateKey = (daysAgo: number): string => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - daysAgo);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+};
+
+describe('computeTotalCount', () => {
+  it('returns 0 for an empty array', () => {
+    expect(computeTotalCount([])).toBe(0);
+  });
+
+  it('returns 1 for a single session', () => {
+    expect(computeTotalCount([makeSession(dateKey(0))])).toBe(1);
+  });
+
+  it('returns n for n sessions', () => {
+    const sessions = [
+      makeSession(dateKey(2), 'a'),
+      makeSession(dateKey(1), 'b'),
+      makeSession(dateKey(0), 'c'),
+    ];
+    expect(computeTotalCount(sessions)).toBe(3);
+  });
+});
+
+describe('computeWeekCount', () => {
+  it('returns 0 for an empty array', () => {
+    expect(computeWeekCount([])).toBe(0);
+  });
+
+  it('counts a session that falls on today', () => {
+    expect(computeWeekCount([makeSession(dateKey(0))])).toBe(1);
+  });
+
+  it('counts a session 6 days ago (inclusive boundary)', () => {
+    expect(computeWeekCount([makeSession(dateKey(6))])).toBe(1);
+  });
+
+  it('excludes a session 7 days ago (outside boundary)', () => {
+    expect(computeWeekCount([makeSession(dateKey(7))])).toBe(0);
+  });
+
+  it('counts only sessions within the 7-day window', () => {
+    const sessions = [
+      makeSession(dateKey(7), 'outside'), // 7 days ago — excluded
+      makeSession(dateKey(6), 'border'),  // 6 days ago — included
+      makeSession(dateKey(3), 'mid'),     // 3 days ago — included
+      makeSession(dateKey(0), 'today'),   // today — included
+    ];
+    expect(computeWeekCount(sessions)).toBe(3);
+  });
+});
+
+describe('computeBestDay', () => {
+  it('returns null for an empty array', () => {
+    expect(computeBestDay([])).toBeNull();
+  });
+
+  it('returns the single session date when there is one session', () => {
+    expect(computeBestDay([makeSession('2026-04-06')])).toEqual({
+      date: '2026-04-06',
+      count: 1,
+    });
+  });
+
+  it('returns the date with the most sessions', () => {
+    const sessions = [
+      makeSession('2026-04-04', 'a1'),
+      makeSession('2026-04-04', 'a2'),
+      makeSession('2026-04-04', 'a3'),
+      makeSession('2026-04-05', 'b1'),
+      makeSession('2026-04-05', 'b2'),
+      makeSession('2026-04-06', 'c1'),
+    ];
+    expect(computeBestDay(sessions)).toEqual({ date: '2026-04-04', count: 3 });
+  });
+
+  it('returns the first-encountered date on a tie (stable tie-breaking)', () => {
+    const sessions = [
+      makeSession('2026-04-04', 'a1'),
+      makeSession('2026-04-04', 'a2'),
+      makeSession('2026-04-05', 'b1'),
+      makeSession('2026-04-05', 'b2'),
+    ];
+    const result = computeBestDay(sessions);
+    expect(result?.count).toBe(2);
+    expect(['2026-04-04', '2026-04-05']).toContain(result?.date);
+  });
+});
+
+describe('computeStreak', () => {
+  it('returns 0 for empty sessions', () => {
+    expect(computeStreak([])).toBe(0);
+  });
+
+  it('returns 1 when the only session is today', () => {
+    expect(computeStreak([makeSession(dateKey(0))])).toBe(1);
+  });
+
+  it('counts consecutive days including today', () => {
+    const sessions = [
+      makeSession(dateKey(0), 'a'),
+      makeSession(dateKey(1), 'b'),
+      makeSession(dateKey(2), 'c'),
+    ];
+    expect(computeStreak(sessions)).toBe(3);
+  });
+
+  it('returns 0 when the streak is broken (gap yesterday, only older sessions)', () => {
+    const sessions = [makeSession(dateKey(2))];
+    expect(computeStreak(sessions)).toBe(0);
+  });
+
+  it('counts a streak starting from yesterday when today has no session', () => {
+    const sessions = [
+      makeSession(dateKey(1), 'a'),
+      makeSession(dateKey(2), 'b'),
+      makeSession(dateKey(3), 'c'),
+    ];
+    expect(computeStreak(sessions)).toBe(3);
+  });
+
+  it('stops the streak at the first gap', () => {
+    const sessions = [
+      makeSession(dateKey(0), 'a'),
+      makeSession(dateKey(1), 'b'),
+      // gap at dateKey(2)
+      makeSession(dateKey(3), 'c'),
+    ];
+    expect(computeStreak(sessions)).toBe(2);
+  });
+
+  it('counts multiple sessions on the same day as one day', () => {
+    const sessions = [
+      makeSession(dateKey(0), 'a1'),
+      makeSession(dateKey(0), 'a2'),
+      makeSession(dateKey(0), 'a3'),
+      makeSession(dateKey(1), 'b1'),
+    ];
+    expect(computeStreak(sessions)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a regression test for the zero-duration guard in `UPDATE_CONFIG` (fix #237 from PR #425)
- Sends `workDuration: 0` via `UPDATE_CONFIG` while a WORKING timer is active and asserts all three duration fields are clamped to at least 1000ms in the persisted config
- Asserts `endTime > now` so the alarm is never scheduled in the past (which would cause an immediate re-trigger infinite loop)
- Also fixes pre-existing test issues on this branch: `sender.id` mismatch with `fakeBrowser` after the #236 security guard was added, `testId++` module-cache busting, and timezone-safe `toDateKey()` date assertions

## Test plan

- [ ] `npm test entrypoints/__tests__/background.test.ts` — 7 pass, 1 fails (the new zero-duration test) until the #425 guard lands
- [ ] After PR #425 merges, the new test should become fully green