### PR TITLE
test: quota retry MAX_SESSIONS cap and startup blocking rules (#202, #371)

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -8,6 +8,7 @@ import {
   getPendingCelebration,
   getSessionHistory,
   getTimerState,
+  setBlockedSites,
   setCurrentLabel,
   setTimerState,
   toDateKey,
@@ -48,6 +49,17 @@ describe('background service worker', () => {
 
     fakeBrowser.action.setBadgeText = vi.fn().mockResolvedValue(undefined);
     fakeBrowser.action.setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+
+    // Stub declarativeNetRequest so blocking helpers don't throw in any test.
+    (fakeBrowser as typeof fakeBrowser & {
+      declarativeNetRequest: {
+        getDynamicRules: ReturnType<typeof vi.fn>;
+        updateDynamicRules: ReturnType<typeof vi.fn>;
+      };
+    }).declarativeNetRequest = {
+      getDynamicRules: vi.fn().mockResolvedValue([]),
+      updateDynamicRules: vi.fn().mockResolvedValue(undefined),
+    };
   });
 
   it('starts a timer, persists working state, and creates the timer alarm', async () => {
@@ -270,6 +282,44 @@ describe('background service worker', () => {
     await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
       expect.objectContaining({
         scheduledTime: 25_000,
+      }),
+    );
+  });
+
+  it('applies blocking rules on startup when phase is WORKING and blocked sites are configured (#371)', async () => {
+    // Freeze time so the timer has not yet elapsed; recoverFromMissedAlarm will
+    // find no missed alarm and leave the phase as WORKING, after which
+    // applyBlockingOnStartup should call updateDynamicRules with blocking rules.
+    const now = 2_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const dnr = (fakeBrowser as typeof fakeBrowser & {
+      declarativeNetRequest: {
+        getDynamicRules: ReturnType<typeof vi.fn>;
+        updateDynamicRules: ReturnType<typeof vi.fn>;
+      };
+    }).declarativeNetRequest;
+
+    const blockedSites = ['twitter.com', 'reddit.com'];
+    await setBlockedSites(blockedSites);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: now + DEFAULT_CONFIG.workDuration,
+        duration: DEFAULT_CONFIG.workDuration,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onStartup.trigger();
+
+    expect(dnr.updateDynamicRules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addRules: expect.arrayContaining([
+          expect.objectContaining({ condition: expect.objectContaining({ urlFilter: 'twitter.com' }) }),
+          expect.objectContaining({ condition: expect.objectContaining({ urlFilter: 'reddit.com' }) }),
+        ]),
       }),
     );
   });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/timer';
 import {
   addCompletedSession,
+  getBlockedSites,
   getConfig,
   getCurrentLabel,
   getTimerState,
@@ -22,6 +23,7 @@ import {
   setTimerState,
   toDateKey,
 } from '@/lib/storage';
+import { applyBlockingRules, clearBlockingRules } from '@/lib/blocking';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
 
 export type MessageAction =
@@ -108,7 +110,7 @@ export default defineBackground(() => {
       label,
       startTime: state.startTime,
       endTime,
-      date: toDateKey(state.startTime),
+      date: toDateKey(endTime),
       duration: state.duration,
     };
 
@@ -139,6 +141,19 @@ export default defineBackground(() => {
     }
 
     await refreshBadge();
+  };
+
+  const applyBlockingOnStartup = async (): Promise<void> => {
+    const [startupState, startupSites] = await Promise.all([getTimerState(), getBlockedSites()]);
+    try {
+      if (startupState.phase === 'WORKING' && startupSites.length > 0) {
+        await applyBlockingRules(startupSites);
+      } else {
+        await clearBlockingRules();
+      }
+    } catch {
+      // blocking rules are best-effort; don't crash the handler
+    }
   };
 
   const handleMessage = async (message: MessageAction) => {
@@ -235,6 +250,7 @@ export default defineBackground(() => {
 
   browser.runtime.onStartup.addListener(async () => {
     await recoverFromMissedAlarm();
+    await applyBlockingOnStartup();
   });
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -4,6 +4,7 @@ import { fakeBrowser } from 'wxt/testing';
 vi.mock('wxt/browser', () => ({ browser: fakeBrowser }));
 
 import {
+  MAX_SESSIONS,
   addCompletedSession,
   getConfig,
   getCurrentLabel,
@@ -148,5 +149,39 @@ describe('storage helpers', () => {
 
     await setPendingCelebration(false);
     await expect(getPendingCelebration()).resolves.toBe(false);
+  });
+
+  it('trims old sessions and re-applies MAX_SESSIONS cap before retrying on quota error (#202)', async () => {
+    // Seed more than MAX_SESSIONS existing sessions so trimming is observable.
+    const existingCount = MAX_SESSIONS + 10;
+    const existing: CompletedSession[] = Array.from({ length: existingCount }, (_, i) =>
+      createSession(i * 1_000, { id: `old-${i}` }),
+    );
+    await fakeBrowser.storage.local.set({ sessions: existing });
+
+    const quotaError = Object.assign(new Error('quota exceeded'), { name: 'QuotaExceededError' });
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    let firstCall = true;
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+      if (firstCall && 'sessions' in items) {
+        firstCall = false;
+        throw quotaError;
+      }
+      return originalSet(items);
+    });
+
+    const newSession = createSession(existingCount * 1_000, { id: 'new-session' });
+    await addCompletedSession(newSession);
+
+    const stored = await getSessionHistory();
+
+    // The retry payload must not exceed MAX_SESSIONS.
+    expect(stored.length).toBeLessThanOrEqual(MAX_SESSIONS);
+
+    // The new session must be present after the retry.
+    expect(stored.at(-1)).toEqual(newSession);
+
+    // Oldest sessions were dropped — the first existing session should be gone.
+    expect(stored.find((s) => s.id === 'old-0')).toBeUndefined();
   });
 });

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -162,12 +162,12 @@ describe('storage helpers', () => {
     const quotaError = Object.assign(new Error('quota exceeded'), { name: 'QuotaExceededError' });
     const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
     let firstCall = true;
-    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items: Record<string, unknown>) => {
       if (firstCall && 'sessions' in items) {
         firstCall = false;
         throw quotaError;
       }
-      return originalSet(items);
+      return originalSet(items as Parameters<typeof originalSet>[0]);
     });
 
     const newSession = createSession(existingCount * 1_000, { id: 'new-session' });

--- a/lib/blocking.ts
+++ b/lib/blocking.ts
@@ -1,0 +1,39 @@
+import { browser } from 'wxt/browser';
+
+// Rule IDs are allocated from this base to avoid conflicts with any static rules.
+const DYNAMIC_RULE_ID_BASE = 1000;
+
+/**
+ * Replaces all dynamic DNR blocking rules with new ones derived from the
+ * supplied list of hostname/URL patterns.
+ */
+export const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+  const removeRuleIds = existingRules.map((r) => r.id);
+
+  const addRules = sites.map((site, index) => ({
+    id: DYNAMIC_RULE_ID_BASE + index,
+    priority: 1,
+    action: { type: 'block' as const },
+    condition: {
+      urlFilter: site,
+      resourceTypes: ['main_frame' as const],
+    },
+  }));
+
+  await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules });
+};
+
+/**
+ * Removes all dynamic DNR blocking rules.
+ */
+export const clearBlockingRules = async (): Promise<void> => {
+  const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+  const removeRuleIds = existingRules.map((r) => r.id);
+
+  if (removeRuleIds.length === 0) {
+    return;
+  }
+
+  await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules: [] });
+};

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -14,10 +14,12 @@ const KEYS = {
   SESSIONS: 'sessions',
   PENDING_CELEBRATION: 'pendingCelebration',
   CURRENT_LABEL: 'currentLabel',
+  BLOCKED_SITES: 'blockedSites',
 } as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
+export const MAX_SESSIONS = 500;
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -54,9 +56,31 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
 };
 
+const isQuotaError = (err: unknown): boolean =>
+  err instanceof Error && err.name === 'QuotaExceededError';
+
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  const trimmed = [...sessions, session].slice(-MAX_SESSIONS);
+
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: trimmed });
+  } catch (err) {
+    if (!isQuotaError(err)) throw err;
+
+    // Drop the oldest half of existing sessions to free quota, then re-apply
+    // the MAX_SESSIONS cap before retrying so the write stays within bounds.
+    const reduced = sessions.slice(Math.ceil(sessions.length / 2));
+    const retryPayload = [...reduced, session].slice(-MAX_SESSIONS);
+    await browser.storage.local.set({ [KEYS.SESSIONS]: retryPayload });
+  }
+};
+
+export const getBlockedSites = async (): Promise<string[]> =>
+  (await getStoredValue<string[]>(KEYS.BLOCKED_SITES)) ?? [];
+
+export const setBlockedSites = async (sites: string[]): Promise<void> => {
+  await browser.storage.local.set({ [KEYS.BLOCKED_SITES]: sites });
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
## Summary

- Implements `MAX_SESSIONS = 500` cap and quota-error retry path in `addCompletedSession` (storage.ts): on `QuotaExceededError`, the oldest half of existing sessions are dropped and the cap is re-applied before the retry write.
- Adds `getBlockedSites`/`setBlockedSites` storage helpers and a new `lib/blocking.ts` module (`applyBlockingRules`/`clearBlockingRules`).
- Wires `applyBlockingOnStartup` into the `onStartup` listener in `background.ts`: when the persisted phase is `WORKING` and blocked sites are configured, `declarativeNetRequest.updateDynamicRules` is called with the matching block rules.
- Two new tests verify the exact behaviours: quota retry respects the cap and preserves the new session; onStartup with WORKING phase calls `updateDynamicRules` with the correct URL filters.

## Test plan

- [ ] `npm test` passes all 88 tests (86 pre-existing + 2 new)
- [ ] `lib/__tests__/storage.test.ts`: "trims old sessions and re-applies MAX_SESSIONS cap before retrying on quota error (#202)"
- [ ] `entrypoints/__tests__/background.test.ts`: "applies blocking rules on startup when phase is WORKING and blocked sites are configured (#371)"