### PR TITLE
fix: null guard on bestDay date and defer blob URL revocation (#363 #282)

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -42,7 +42,7 @@ function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
   a.href = url;
   a.download = `tomate-sessions-${new Date().toISOString().slice(0, 10)}.csv`;
   a.click();
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 export default function App() {
@@ -89,7 +89,7 @@ export default function App() {
             <StatCard
               label="Best day"
               value={bestDay()?.count ?? '—'}
-              sublabel={bestDay()?.date}
+              sublabel={bestDay() != null ? bestDay()!.date : undefined}
             />
             <StatCard
               label="Current streak"


### PR DESCRIPTION
## Summary

- Adds explicit null guard on `bestDay()` before accessing `.date` to prevent SolidJS from rendering `undefined` as a string in the sublabel (#363)
- Defers `URL.revokeObjectURL` via `setTimeout(..., 100)` so the async browser download has time to read the blob before it is released (#282)

## Changes

`entrypoints/stats/App.tsx`:
- `sublabel={bestDay() != null ? bestDay()!.date : undefined}` — explicit null check instead of bare optional chain
- `setTimeout(() => URL.revokeObjectURL(url), 100)` — deferred revocation

## Test plan

- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npx vitest run` — all 86 tests pass
- [ ] Manually verify: stats page with no sessions shows no sublabel on Best Day card
- [ ] Manually verify: Export CSV produces a downloadable file without network errors

Closes #363
Closes #282