### PR TITLE
fix: guard notifications API availability and surface stats load errors

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -255,13 +255,17 @@ export default defineBackground(() => {
 
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
-      if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
-        await browser.notifications.create({
-          type: 'basic',
-          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-          title: '🍅 Tomate Complete!',
-          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-        });
+      try {
+        if (browser.notifications?.create) {
+          await browser.notifications.create({
+            type: 'basic',
+            iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+            title: '🍅 Tomate Complete!',
+            message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+          });
+        }
+      } catch {
+        // notifications API may be unavailable on non-Chrome browsers
       }
       if (config.openBreakTab !== false) {
         try {
@@ -273,13 +277,17 @@ export default defineBackground(() => {
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
-        await browser.notifications.create({
-          type: 'basic',
-          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-        });
+      try {
+        if (browser.notifications?.create) {
+          await browser.notifications.create({
+            type: 'basic',
+            iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+            title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+            message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+          });
+        }
+      } catch {
+        // notifications API may be unavailable on non-Chrome browsers
       }
     }
 

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -74,6 +74,15 @@ export default function App() {
           </Show>
         </div>
 
+        <Show when={sessions.error || yearData.error || todayCount.error || config.error}>
+          <div
+            class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm mb-4"
+            role="alert"
+          >
+            Failed to load session data. Try reloading the page.
+          </div>
+        </Show>
+
         <Show when={(sessions() ?? []).length === 0}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>


### PR DESCRIPTION
## Summary

- **#283**: Wrapped both `browser.notifications.create()` calls in `try-catch` blocks with an optional-chaining guard (`browser.notifications?.create`). On Firefox and other non-Chrome browsers the notifications API may be absent or throw on access; errors are now silently swallowed instead of crashing the alarm handler.
- **#368**: Added a visible error banner in `entrypoints/stats/App.tsx` using all four `createResource` error signals (`sessions.error`, `yearData.error`, `todayCount.error`, `config.error`). When any storage read fails, the user sees "Failed to load session data. Try reloading the page." instead of a silent empty page.

Closes #283
Closes #368

## Test plan

- [ ] Verify TypeScript check passes: `npx tsc --noEmit` (no new errors)
- [ ] Verify all 92 tests pass: `npx vitest run`
- [ ] On Firefox/non-Chrome: confirm timer completion alarm fires without crashing (no unhandled promise rejection in background)
- [ ] Simulate a storage read failure in stats page (e.g., mock `getSessionHistory` to reject) and confirm the red error banner appears
- [ ] Confirm normal stats page load still works as expected when no errors occur