### PR TITLE
fix: guard persistCompletedSession against null startTime and add onCleanup for label timeout

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -99,7 +99,9 @@ export default defineBackground(() => {
     endTime: number,
   ): Promise<void> => {
     if (state.startTime === null || state.duration === null) {
-      return;
+      throw new Error(
+        `persistCompletedSession: startTime (${state.startTime}) or duration (${state.duration}) is null — cannot persist session`,
+      );
     }
 
     const label = await getCurrentLabel();

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -100,6 +100,7 @@ export default function App() {
   };
 
   let labelTimeout: ReturnType<typeof setTimeout>;
+  onCleanup(() => clearTimeout(labelTimeout));
   const handleLabelChange = (value: string) => {
     setLabel(value);
     clearTimeout(labelTimeout);


### PR DESCRIPTION
## Summary

- Closes #354: `persistCompletedSession` in `entrypoints/background.ts` now throws an explicit `Error` when `startTime` or `duration` is `null`, surfacing the invariant violation instead of silently dropping the session.
- Closes #350: `entrypoints/popup/App.tsx` now calls `onCleanup(() => clearTimeout(labelTimeout))` at component scope so the debounced `setCurrentLabel` call is cancelled on popup unmount, preventing stale-closure fires after the popup closes.

## Test plan

- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npx vitest run` — all 86 tests pass
- [ ] Manually open popup, type in label field, close popup within 300 ms — confirm no "setter called after unmount" warning in console
- [ ] Confirm that a session completing while `startTime` is set persists normally
- [ ] Confirm that if a code path ever triggers `persistCompletedSession` with a null `startTime`, an Error is thrown (visible in extension background service worker logs) rather than silently producing a corrupted session