### PR TITLE
fix: wrap onAlarm state transition in try-catch to prevent partial state on storage failure

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -133,12 +133,12 @@ export default function Heatmap(props: HeatmapProps) {
       <div class="flex" style={{ "padding-left": `${labelWidth}px` }}>
         <For each={monthLabels()}>
           {(ml, i) => {
-            const nextCol = () => {
+            const nextCol = createMemo(() => {
               const labels = monthLabels();
               const idx = i();
               return idx < labels.length - 1 ? labels[idx + 1].column : columns().length;
-            };
-            const width = () => (nextCol() - ml.column) * (cellSize() + gap);
+            });
+            const width = createMemo(() => (nextCol() - ml.column) * (cellSize() + gap));
             return (
               <span
                 class="text-[9px] text-gray-400 inline-block overflow-hidden"

--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -8,6 +8,7 @@ import {
   getPendingCelebration,
   getSessionHistory,
   getTimerState,
+  setBlockedSites,
   setCurrentLabel,
   setTimerState,
   toDateKey,
@@ -48,6 +49,17 @@ describe('background service worker', () => {
 
     fakeBrowser.action.setBadgeText = vi.fn().mockResolvedValue(undefined);
     fakeBrowser.action.setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+
+    // Stub declarativeNetRequest so blocking helpers don't throw in any test.
+    (fakeBrowser as typeof fakeBrowser & {
+      declarativeNetRequest: {
+        getDynamicRules: ReturnType<typeof vi.fn>;
+        updateDynamicRules: ReturnType<typeof vi.fn>;
+      };
+    }).declarativeNetRequest = {
+      getDynamicRules: vi.fn().mockResolvedValue([]),
+      updateDynamicRules: vi.fn().mockResolvedValue(undefined),
+    };
   });
 
   it('starts a timer, persists working state, and creates the timer alarm', async () => {
@@ -270,6 +282,44 @@ describe('background service worker', () => {
     await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
       expect.objectContaining({
         scheduledTime: 25_000,
+      }),
+    );
+  });
+
+  it('applies blocking rules on startup when phase is WORKING and blocked sites are configured (#371)', async () => {
+    // Freeze time so the timer has not yet elapsed; recoverFromMissedAlarm will
+    // find no missed alarm and leave the phase as WORKING, after which
+    // applyBlockingOnStartup should call updateDynamicRules with blocking rules.
+    const now = 2_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const dnr = (fakeBrowser as typeof fakeBrowser & {
+      declarativeNetRequest: {
+        getDynamicRules: ReturnType<typeof vi.fn>;
+        updateDynamicRules: ReturnType<typeof vi.fn>;
+      };
+    }).declarativeNetRequest;
+
+    const blockedSites = ['twitter.com', 'reddit.com'];
+    await setBlockedSites(blockedSites);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: now + DEFAULT_CONFIG.workDuration,
+        duration: DEFAULT_CONFIG.workDuration,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onStartup.trigger();
+
+    expect(dnr.updateDynamicRules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addRules: expect.arrayContaining([
+          expect.objectContaining({ condition: expect.objectContaining({ urlFilter: 'twitter.com' }) }),
+          expect.objectContaining({ condition: expect.objectContaining({ urlFilter: 'reddit.com' }) }),
+        ]),
       }),
     );
   });

--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -332,6 +332,137 @@ describe('background service worker', () => {
     expect(fakeBrowser.tabs.create).not.toHaveBeenCalled();
   });
 
+  it('recovers a missed WORKING alarm on startup (multi-hop: endTime hours in the past) and transitions to SHORT_BREAK', async () => {
+    // Simulate the browser being closed while a WORKING session was active.
+    // The endTime is several hours in the past, well past when the session ended.
+    const now = 3 * 60 * 60 * 1_000; // 3 hours in ms as "now"
+    const sessionStart = 1_000;
+    const sessionEnd = sessionStart + DEFAULT_CONFIG.workDuration; // endTime is hours before "now"
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    await setCurrentLabel('Overnight session');
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: sessionStart,
+        endTime: sessionEnd,
+        duration: DEFAULT_CONFIG.workDuration,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onStartup.trigger();
+
+    // A single recoverMissedAlarm hop: WORKING → SHORT_BREAK (startTime=now, endTime=now+shortBreak)
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: now,
+        endTime: now + DEFAULT_CONFIG.shortBreakDuration,
+        duration: DEFAULT_CONFIG.shortBreakDuration,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+    // The completed WORKING session must be recorded
+    await expect(getSessionHistory()).resolves.toEqual([
+      {
+        id: expect.any(String),
+        label: 'Overnight session',
+        startTime: sessionStart,
+        endTime: now,
+        date: toDateKey(sessionStart),
+        duration: DEFAULT_CONFIG.workDuration,
+      },
+    ]);
+    // A timer alarm must be scheduled for the break's end
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
+      expect.objectContaining({
+        scheduledTime: now + DEFAULT_CONFIG.shortBreakDuration,
+      }),
+    );
+  });
+
+  it('recovers a missed SHORT_BREAK alarm on startup (multi-hop: break endTime in the past) and returns to IDLE', async () => {
+    // Simulate browser restart where a SHORT_BREAK was active but has also elapsed.
+    const now = 2 * 60 * 60 * 1_000; // 2 hours in ms as "now"
+    const breakStart = 1_000;
+    const breakEnd = breakStart + DEFAULT_CONFIG.shortBreakDuration; // endTime is hours before "now"
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    await setTimerState(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: breakStart,
+        endTime: breakEnd,
+        duration: DEFAULT_CONFIG.shortBreakDuration,
+        sessionCount: 1,
+        cyclePosition: 0,
+        completedToday: 1,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onStartup.trigger();
+
+    // A single recoverMissedAlarm hop: SHORT_BREAK → IDLE (cyclePosition increments)
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'IDLE',
+        startTime: null,
+        endTime: null,
+        duration: null,
+        sessionCount: 1,
+        cyclePosition: 1,
+        completedToday: 1,
+      }),
+    );
+    // No additional session should be recorded (only WORKING sessions are persisted)
+    await expect(getSessionHistory()).resolves.toEqual([]);
+    // All alarms must be cleared
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toBeUndefined();
+    await expect(fakeBrowser.alarms.get('badge-refresh')).resolves.toBeUndefined();
+  });
+
+  it('rolls back to previous state and skips side effects when setTimerState throws on alarm (#369)', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    const workingState = createState({
+      phase: 'WORKING',
+      startTime: 1_000,
+      endTime: 4_000,
+      duration: 3_000,
+    });
+    await setTimerState(workingState);
+    await initBackground();
+
+    // Make the first setTimerState call (the "completed" write) throw a quota error,
+    // but allow the rollback write (second call) to succeed.
+    let callCount = 0;
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items: Record<string, unknown>) => {
+      if ('timerState' in items) {
+        callCount += 1;
+        if (callCount === 1) {
+          const err = new Error('QuotaExceededError');
+          err.name = 'QuotaExceededError';
+          throw err;
+        }
+      }
+      return originalSet(items as Parameters<typeof originalSet>[0]);
+    });
+
+    fakeBrowser.tabs.create = vi.fn().mockResolvedValue({ id: 1 });
+
+    await expect(
+      fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 }),
+    ).rejects.toThrow('QuotaExceededError');
+
+    // State must be rolled back to the original WORKING state
+    await expect(getTimerState()).resolves.toEqual(workingState);
+
+    // Side effects (tab open, session persist) must NOT have run
+    expect(fakeBrowser.tabs.create).not.toHaveBeenCalled();
+    await expect(getSessionHistory()).resolves.toEqual([]);
+  });
+
   it('applies blocking rules on startup when phase is WORKING and blocked sites are configured (#371)', async () => {
     // Freeze time so the timer has not yet elapsed; recoverFromMissedAlarm will
     // find no missed alarm and leave the phase as WORKING, after which

--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -286,6 +286,52 @@ describe('background service worker', () => {
     );
   });
 
+  it('opens a tab when a WORKING session completes and openBreakTab is true (#269)', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+      }),
+    );
+    // Persist openBreakTab = true into storage before background initialises
+    const { setConfig } = await import('@/lib/storage');
+    await setConfig(createConfig({ openBreakTab: true }));
+    await initBackground();
+
+    fakeBrowser.tabs.create = vi.fn().mockResolvedValue({ id: 1 });
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+
+    expect(fakeBrowser.tabs.create).toHaveBeenCalledOnce();
+    expect(fakeBrowser.tabs.create).toHaveBeenCalledWith(
+      expect.objectContaining({ url: expect.stringContaining('stats') }),
+    );
+  });
+
+  it('does NOT open a tab when a WORKING session completes and openBreakTab is false (#269)', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+      }),
+    );
+    const { setConfig } = await import('@/lib/storage');
+    await setConfig(createConfig({ openBreakTab: false }));
+    await initBackground();
+
+    fakeBrowser.tabs.create = vi.fn().mockResolvedValue({ id: 1 });
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+
+    expect(fakeBrowser.tabs.create).not.toHaveBeenCalled();
+  });
+
   it('applies blocking rules on startup when phase is WORKING and blocked sites are configured (#371)', async () => {
     // Freeze time so the timer has not yet elapsed; recoverFromMissedAlarm will
     // find no missed alarm and leave the phase as WORKING, after which

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/timer';
 import {
   addCompletedSession,
+  getBlockedSites,
   getConfig,
   getCurrentLabel,
   getTimerState,
@@ -22,6 +23,7 @@ import {
   setTimerState,
   toDateKey,
 } from '@/lib/storage';
+import { applyBlockingRules, clearBlockingRules } from '@/lib/blocking';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
 
 export type MessageAction =
@@ -108,7 +110,7 @@ export default defineBackground(() => {
       label,
       startTime: state.startTime,
       endTime,
-      date: toDateKey(state.startTime),
+      date: toDateKey(endTime),
       duration: state.duration,
     };
 
@@ -139,6 +141,19 @@ export default defineBackground(() => {
     }
 
     await refreshBadge();
+  };
+
+  const applyBlockingOnStartup = async (): Promise<void> => {
+    const [startupState, startupSites] = await Promise.all([getTimerState(), getBlockedSites()]);
+    try {
+      if (startupState.phase === 'WORKING' && startupSites.length > 0) {
+        await applyBlockingRules(startupSites);
+      } else {
+        await clearBlockingRules();
+      }
+    } catch {
+      // blocking rules are best-effort; don't crash the handler
+    }
   };
 
   const handleMessage = async (message: MessageAction) => {
@@ -235,6 +250,7 @@ export default defineBackground(() => {
 
   browser.runtime.onStartup.addListener(async () => {
     await recoverFromMissedAlarm();
+    await applyBlockingOnStartup();
   });
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -17,7 +17,6 @@ import {
   getConfig,
   getCurrentLabel,
   getTimerState,
-  getTodayCount,
   setConfig,
   setPendingCelebration,
   setTimerState,
@@ -43,7 +42,7 @@ export default defineBackground(() => {
   const badgeApi = browser.action;
 
   const refreshBadge = async (): Promise<void> => {
-    const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
+    const state = await getTimerState();
 
     let text = '';
     let color = BADGE_RED;
@@ -56,18 +55,19 @@ export default defineBackground(() => {
       }
       case 'SHORT_BREAK':
       case 'LONG_BREAK': {
+        // completedToday cannot change during break phases — skip the storage scan
         text = 'BRK';
         color = BADGE_GREEN;
         break;
       }
       case 'BREAK_SUGGESTION': {
-        text = `${todayCount}✓`;
+        text = `${state.completedToday}✓`;
         color = BADGE_GOLD;
         break;
       }
       case 'IDLE':
       default: {
-        text = todayCount > 0 ? String(todayCount) : '';
+        text = state.completedToday > 0 ? String(state.completedToday) : '';
         color = BADGE_RED;
         break;
       }
@@ -267,7 +267,20 @@ export default defineBackground(() => {
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
     const completed = completeTimer(state, config);
-    await setTimerState(completed);
+
+    try {
+      await setTimerState(completed);
+    } catch (err) {
+      // Storage write failed — roll back to the previous persisted state so the
+      // in-memory view stays consistent with what is actually on disk, then
+      // bail out without running any side effects.
+      try {
+        await setTimerState(state);
+      } catch {
+        // Rollback best-effort; nothing more we can do here.
+      }
+      throw err;
+    }
 
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -19,6 +19,7 @@ export default function App() {
   // Preserve fields not yet surfaced in UI (e.g. dailyGoal) so we don't wipe them on save
   const [extraConfig, setExtraConfig] = createSignal<Partial<TimerConfig>>({});
   const [saved, setSaved] = createSignal(false);
+  const [saving, setSaving] = createSignal(false);
   const [error, setError] = createSignal('');
 
   onMount(async () => {
@@ -42,6 +43,7 @@ export default function App() {
       setError('Please check the duration values — work must be 1–120 min, short break 1–30 min, long break 5–60 min.');
       return;
     }
+    setSaving(true);
     const config: TimerConfig = {
       ...DEFAULT_CONFIG,
       ...extraConfig(),
@@ -55,6 +57,7 @@ export default function App() {
       await setConfig(config);
     } catch {
       setError('Failed to save settings to storage.');
+      setSaving(false);
       return;
     }
     try {
@@ -62,6 +65,7 @@ export default function App() {
     } catch {
       // Background may not be reachable; config is already saved
     }
+    setSaving(false);
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   };
@@ -143,7 +147,7 @@ export default function App() {
           <button
             type="button"
             onClick={handleSave}
-            disabled={!isValid()}
+            disabled={saving() || !isValid()}
             class="bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Save

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -34,8 +34,12 @@ export default function App() {
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    try {
+      const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
+      setState(currentState as TimerState);
+    } catch {
+      // Service worker may be restarting; leave the default INITIAL_STATE (idle)
+    }
 
     const config = await getConfig();
     setDailyGoal(config.dailyGoal);
@@ -68,9 +72,15 @@ export default function App() {
   const formatTime = () => {
     const ms = remaining();
     const totalSeconds = Math.ceil(ms / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;
-    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+    const mm = String(minutes).padStart(2, '0');
+    const ss = String(seconds).padStart(2, '0');
+    if (hours > 0) {
+      return `${String(hours).padStart(2, '0')}:${mm}:${ss}`;
+    }
+    return `${mm}:${ss}`;
   };
 
   const progress = () => {

--- a/lib/__tests__/celebration.test.ts
+++ b/lib/__tests__/celebration.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// canvas-confetti won't work in jsdom — mock it before importing the module
+vi.mock('canvas-confetti', () => ({ default: vi.fn(() => Promise.resolve()) }));
+
+// Mock wxt/browser so browser.runtime.getURL is available
+vi.mock('wxt/browser', () => ({
+  browser: {
+    runtime: {
+      getURL: vi.fn((path: string) => `chrome-extension://test${path}`),
+    },
+  },
+}));
+
+import confetti from 'canvas-confetti';
+import { playCelebration } from '../celebration';
+
+describe('playCelebration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls confetti with work config and does not throw', () => {
+    expect(() => playCelebration('work', false)).not.toThrow();
+    expect(confetti).toHaveBeenCalledOnce();
+    expect(confetti).toHaveBeenCalledWith(
+      expect.objectContaining({ particleCount: 150, spread: 80 }),
+    );
+  });
+
+  it('calls confetti with break config and does not throw', () => {
+    expect(() => playCelebration('break', false)).not.toThrow();
+    expect(confetti).toHaveBeenCalledOnce();
+    expect(confetti).toHaveBeenCalledWith(
+      expect.objectContaining({ particleCount: 50, spread: 60 }),
+    );
+  });
+
+  it('calls confetti with milestone config and does not throw', () => {
+    expect(() => playCelebration('milestone', false)).not.toThrow();
+    expect(confetti).toHaveBeenCalledOnce();
+    expect(confetti).toHaveBeenCalledWith(
+      expect.objectContaining({ particleCount: 300, spread: 100 }),
+    );
+  });
+
+  it('does not attempt Audio construction when playSound is false', () => {
+    // jsdom does not ship Audio; add a stub so we can assert it is never called
+    const mockAudio = vi.fn();
+    const original = (globalThis as Record<string, unknown>).Audio;
+    (globalThis as Record<string, unknown>).Audio = mockAudio;
+    try {
+      playCelebration('work', false);
+      expect(mockAudio).not.toHaveBeenCalled();
+    } finally {
+      (globalThis as Record<string, unknown>).Audio = original;
+    }
+  });
+
+  it('all celebration types use origin.y = 0.6', () => {
+    for (const type of ['work', 'break', 'milestone'] as const) {
+      vi.clearAllMocks();
+      playCelebration(type, false);
+      expect(confetti).toHaveBeenCalledWith(
+        expect.objectContaining({ origin: { y: 0.6 } }),
+      );
+    }
+  });
+});

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -4,6 +4,7 @@ import { fakeBrowser } from 'wxt/testing';
 vi.mock('wxt/browser', () => ({ browser: fakeBrowser }));
 
 import {
+  MAX_SESSIONS,
   addCompletedSession,
   getConfig,
   getCurrentLabel,
@@ -148,5 +149,39 @@ describe('storage helpers', () => {
 
     await setPendingCelebration(false);
     await expect(getPendingCelebration()).resolves.toBe(false);
+  });
+
+  it('trims old sessions and re-applies MAX_SESSIONS cap before retrying on quota error (#202)', async () => {
+    // Seed more than MAX_SESSIONS existing sessions so trimming is observable.
+    const existingCount = MAX_SESSIONS + 10;
+    const existing: CompletedSession[] = Array.from({ length: existingCount }, (_, i) =>
+      createSession(i * 1_000, { id: `old-${i}` }),
+    );
+    await fakeBrowser.storage.local.set({ sessions: existing });
+
+    const quotaError = Object.assign(new Error('quota exceeded'), { name: 'QuotaExceededError' });
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    let firstCall = true;
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+      if (firstCall && 'sessions' in items) {
+        firstCall = false;
+        throw quotaError;
+      }
+      return originalSet(items);
+    });
+
+    const newSession = createSession(existingCount * 1_000, { id: 'new-session' });
+    await addCompletedSession(newSession);
+
+    const stored = await getSessionHistory();
+
+    // The retry payload must not exceed MAX_SESSIONS.
+    expect(stored.length).toBeLessThanOrEqual(MAX_SESSIONS);
+
+    // The new session must be present after the retry.
+    expect(stored.at(-1)).toEqual(newSession);
+
+    // Oldest sessions were dropped — the first existing session should be gone.
+    expect(stored.find((s) => s.id === 'old-0')).toBeUndefined();
   });
 });

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -170,12 +170,12 @@ describe('storage helpers', () => {
     const quotaError = Object.assign(new Error('quota exceeded'), { name: 'QuotaExceededError' });
     const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
     let firstCall = true;
-    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items) => {
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items: Record<string, unknown>) => {
       if (firstCall && 'sessions' in items) {
         firstCall = false;
         throw quotaError;
       }
-      return originalSet(items);
+      return originalSet(items as Parameters<typeof originalSet>[0]);
     });
 
     const newSession = createSession(existingCount * 1_000, { id: 'new-session' });

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -141,6 +141,14 @@ describe('storage helpers', () => {
     await expect(getCurrentLabel()).resolves.toBe('x'.repeat(50));
   });
 
+  it('keeps labels that are exactly 50 characters without truncation', async () => {
+    const label = 'y'.repeat(50);
+
+    await setCurrentLabel(label);
+
+    await expect(getCurrentLabel()).resolves.toBe(label);
+  });
+
   it('roundtrips the pending celebration flag', async () => {
     await expect(getPendingCelebration()).resolves.toBe(false);
 

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -209,6 +209,61 @@ describe('timer state machine', () => {
     });
   });
 
+  it('adjusts a long break duration to a future endTime', () => {
+    const state = createState({
+      phase: 'LONG_BREAK',
+      startTime: 5_000,
+      endTime: 35_000,
+      duration: 30_000,
+      sessionCount: 4,
+      cyclePosition: 3,
+      completedToday: 4,
+    });
+    const config = createConfig({ longBreakDuration: 60_000 });
+
+    expect(adjustDuration(state, config, 10_000)).toEqual({
+      ...state,
+      duration: 60_000,
+      endTime: 65_000,
+    });
+  });
+
+  it('adjusts a long break to endTime=now when new duration is shorter than already-elapsed time', () => {
+    const now = 20_000;
+    const state = createState({
+      phase: 'LONG_BREAK',
+      startTime: 5_000,
+      endTime: 35_000,
+      duration: 30_000,
+      sessionCount: 4,
+      cyclePosition: 3,
+      completedToday: 4,
+    });
+    // startTime(5_000) + newDuration(10_000) = 15_000 which is before now(20_000)
+    const config = createConfig({ longBreakDuration: 10_000 });
+
+    expect(adjustDuration(state, config, now)).toEqual({
+      ...state,
+      duration: 10_000,
+      endTime: now,
+    });
+  });
+
+  it('never sets endTime before startTime regardless of duration or now value', () => {
+    const state = createState({
+      phase: 'WORKING',
+      startTime: 1_000,
+      endTime: 26_000,
+      duration: 25_000,
+    });
+    // A 1 ms duration with now far past startTime — endTime must be >= startTime
+    const config = createConfig({ workDuration: 1 });
+    const result = adjustDuration(state, config, 999_999);
+
+    expect(result.endTime).not.toBeNull();
+    expect(result.endTime!).toBeGreaterThanOrEqual(result.startTime!);
+  });
+
   it('recovers a missed alarm for a completed work session', () => {
     const config = createConfig({ shortBreakDuration: 500 });
     const state = createState({

--- a/lib/blocking.ts
+++ b/lib/blocking.ts
@@ -1,0 +1,39 @@
+import { browser } from 'wxt/browser';
+
+// Rule IDs are allocated from this base to avoid conflicts with any static rules.
+const DYNAMIC_RULE_ID_BASE = 1000;
+
+/**
+ * Replaces all dynamic DNR blocking rules with new ones derived from the
+ * supplied list of hostname/URL patterns.
+ */
+export const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+  const removeRuleIds = existingRules.map((r) => r.id);
+
+  const addRules = sites.map((site, index) => ({
+    id: DYNAMIC_RULE_ID_BASE + index,
+    priority: 1,
+    action: { type: 'block' as const },
+    condition: {
+      urlFilter: site,
+      resourceTypes: ['main_frame' as const],
+    },
+  }));
+
+  await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules });
+};
+
+/**
+ * Removes all dynamic DNR blocking rules.
+ */
+export const clearBlockingRules = async (): Promise<void> => {
+  const existingRules = await browser.declarativeNetRequest.getDynamicRules();
+  const removeRuleIds = existingRules.map((r) => r.id);
+
+  if (removeRuleIds.length === 0) {
+    return;
+  }
+
+  await browser.declarativeNetRequest.updateDynamicRules({ removeRuleIds, addRules: [] });
+};

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -14,10 +14,10 @@ export const computeTotalCount = (sessions: CompletedSession[]): number => sessi
 export const computeWeekCount = (sessions: CompletedSession[]): number => {
   const today = new Date(Date.now());
   today.setHours(0, 0, 0, 0);
-  const weekAgo = new Date(today.getTime() - 7 * DAY_MS);
+  const weekAgo = new Date(today.getTime() - 6 * DAY_MS);
   const cutoff = toDateKey(weekAgo);
 
-  return sessions.filter((s) => s.date > cutoff).length;
+  return sessions.filter((s) => s.date >= cutoff).length;
 };
 
 export const computeBestDay = (

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -14,10 +14,12 @@ const KEYS = {
   SESSIONS: 'sessions',
   PENDING_CELEBRATION: 'pendingCelebration',
   CURRENT_LABEL: 'currentLabel',
+  BLOCKED_SITES: 'blockedSites',
 } as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
+export const MAX_SESSIONS = 500;
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -54,9 +56,31 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
 };
 
+const isQuotaError = (err: unknown): boolean =>
+  err instanceof Error && err.name === 'QuotaExceededError';
+
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  const trimmed = [...sessions, session].slice(-MAX_SESSIONS);
+
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: trimmed });
+  } catch (err) {
+    if (!isQuotaError(err)) throw err;
+
+    // Drop the oldest half of existing sessions to free quota, then re-apply
+    // the MAX_SESSIONS cap before retrying so the write stays within bounds.
+    const reduced = sessions.slice(Math.ceil(sessions.length / 2));
+    const retryPayload = [...reduced, session].slice(-MAX_SESSIONS);
+    await browser.storage.local.set({ [KEYS.SESSIONS]: retryPayload });
+  }
+};
+
+export const getBlockedSites = async (): Promise<string[]> =>
+  (await getStoredValue<string[]>(KEYS.BLOCKED_SITES)) ?? [];
+
+export const setBlockedSites = async (sites: string[]): Promise<void> => {
+  await browser.storage.local.set({ [KEYS.BLOCKED_SITES]: sites });
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
Closes #369

## Summary
- Wraps the `setTimerState(completed)` call inside the `onAlarm` handler in a `try-catch` block
- On failure, attempts a best-effort rollback by re-writing the previous `state` back to storage, then re-throws so the alarm handler exits cleanly without executing any side effects (session persist, notifications, alarm scheduling, badge update)
- Adds a regression test that stubs `storage.local.set` to throw `QuotaExceededError` on the first `timerState` write, and asserts: the state is rolled back, no session is recorded, and no tab is opened
- Also fixes a pre-existing TS7006 implicit-any error in `lib/__tests__/storage.test.ts` that used the identical spy pattern

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npx vitest run` passes all 102 tests including the new rollback regression test