### PR TITLE
test: add multi-hop missed alarm recovery coverage

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -273,4 +273,94 @@ describe('background service worker', () => {
       }),
     );
   });
+
+  it('recovers a missed WORKING alarm on startup when endTime is hours in the past and transitions to SHORT_BREAK', async () => {
+    // Simulate the browser being closed while a WORKING session was active.
+    // The endTime is several hours in the past, well past when the session ended.
+    const now = 3 * 60 * 60 * 1_000; // 3 hours in ms as "now"
+    const sessionStart = 1_000;
+    const sessionEnd = sessionStart + DEFAULT_CONFIG.workDuration; // endTime is hours before "now"
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    await setCurrentLabel('Overnight session');
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: sessionStart,
+        endTime: sessionEnd,
+        duration: DEFAULT_CONFIG.workDuration,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onStartup.trigger();
+
+    // recoverMissedAlarm hop: WORKING → SHORT_BREAK (startTime=now, endTime=now+shortBreak)
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: now,
+        endTime: now + DEFAULT_CONFIG.shortBreakDuration,
+        duration: DEFAULT_CONFIG.shortBreakDuration,
+        sessionCount: 1,
+        completedToday: 1,
+      }),
+    );
+    // The completed WORKING session must be recorded
+    await expect(getSessionHistory()).resolves.toEqual([
+      {
+        id: expect.any(String),
+        label: 'Overnight session',
+        startTime: sessionStart,
+        endTime: now,
+        date: toDateKey(sessionStart),
+        duration: DEFAULT_CONFIG.workDuration,
+      },
+    ]);
+    // A timer alarm must be scheduled for the break's end
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
+      expect.objectContaining({
+        scheduledTime: now + DEFAULT_CONFIG.shortBreakDuration,
+      }),
+    );
+  });
+
+  it('recovers a missed SHORT_BREAK alarm on startup when break endTime is in the past and returns to IDLE', async () => {
+    // Simulate browser restart where a SHORT_BREAK was active but has also elapsed.
+    const now = 2 * 60 * 60 * 1_000; // 2 hours in ms as "now"
+    const breakStart = 1_000;
+    const breakEnd = breakStart + DEFAULT_CONFIG.shortBreakDuration; // endTime is hours before "now"
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    await setTimerState(
+      createState({
+        phase: 'SHORT_BREAK',
+        startTime: breakStart,
+        endTime: breakEnd,
+        duration: DEFAULT_CONFIG.shortBreakDuration,
+        sessionCount: 1,
+        cyclePosition: 0,
+        completedToday: 1,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onStartup.trigger();
+
+    // recoverMissedAlarm hop: SHORT_BREAK → IDLE (cyclePosition increments)
+    await expect(getTimerState()).resolves.toEqual(
+      createState({
+        phase: 'IDLE',
+        startTime: null,
+        endTime: null,
+        duration: null,
+        sessionCount: 1,
+        cyclePosition: 1,
+        completedToday: 1,
+      }),
+    );
+    // No additional session should be recorded (only WORKING sessions are persisted)
+    await expect(getSessionHistory()).resolves.toEqual([]);
+    // All alarms must be cleared
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toBeUndefined();
+    await expect(fakeBrowser.alarms.get('badge-refresh')).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
Closes #270

## Summary
- Adds two tests for the missed alarm recovery path triggered on `browser.runtime.onStartup`
- Test 1: WORKING session with `endTime` several hours in the past → recovers to SHORT_BREAK, records the completed session in history, schedules the break alarm
- Test 2: SHORT_BREAK with `endTime` in the past → recovers to IDLE, clears alarms, does not record a session

## Test plan
- [ ] `npx vitest run entrypoints/__tests__/background.test.ts` passes (9 tests)
- [ ] `npx tsc --noEmit` passes cleanly