### PR TITLE
ux: inform users duration changes apply to next session (#149)

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -81,6 +81,10 @@ export default function App() {
       <div class="w-full max-w-[400px] bg-white rounded-lg shadow-sm p-6">
         <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
 
+        <p class="text-xs text-gray-500 mb-4 -mt-2">
+          Duration changes apply to new sessions only — active timers are not affected.
+        </p>
+
         <div class="space-y-4">
           <label class="block">
             <span class="text-sm font-medium text-gray-700">Work Duration (minutes)</span>
@@ -158,7 +162,7 @@ export default function App() {
           </button>
 
           <Show when={saved()}>
-            <span class="text-sm text-green-600">Settings saved ✓</span>
+            <span class="text-sm text-green-600">Settings saved. Duration changes apply to the next session.</span>
           </Show>
         </div>
 


### PR DESCRIPTION
## Summary

- Adds a hint paragraph below the page heading: "Duration changes apply to new sessions only — active timers are not affected."
- Updates the save confirmation banner from "Settings saved ✓" to "Settings saved. Duration changes apply to the next session." so users don't expect an in-flight timer to change immediately.

## Test plan

- [ ] Open options page and verify the hint paragraph appears above the duration inputs
- [ ] Change a duration and save — confirm the banner reads "Settings saved. Duration changes apply to the next session."
- [ ] Verify all 86 existing tests still pass (`npx vitest run`)
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

Closes #149