### PR TITLE
ux: add visible label and character counter to TaskLabel (#154)

### DIFF
--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -1,17 +1,52 @@
+import { createSignal } from 'solid-js';
+
+const MAX_LENGTH = 50;
+
 type TaskLabelProps = {
   value: string;
   onChange: (value: string) => void;
 };
 
 export default function TaskLabel(props: TaskLabelProps) {
+  const [focused, setFocused] = createSignal(false);
+
+  const remaining = () => MAX_LENGTH - props.value.length;
+  const showCounter = () => focused() || props.value.length > 0;
+
   return (
-    <input
-      type="text"
-      value={props.value}
-      onInput={(e) => props.onChange(e.currentTarget.value)}
-      placeholder="What are you working on?"
-      maxLength={50}
-      class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
-    />
+    <div class="w-full mt-4">
+      <label
+        for="task-label-input"
+        class="block text-xs font-medium text-gray-500 mb-1"
+      >
+        Task label{' '}
+        <span class="font-normal text-gray-400">(optional, max {MAX_LENGTH} chars)</span>
+      </label>
+      <div class="relative">
+        <input
+          id="task-label-input"
+          type="text"
+          value={props.value}
+          onInput={(e) => props.onChange(e.currentTarget.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          placeholder="What are you working on?"
+          maxLength={MAX_LENGTH}
+          aria-describedby="task-label-counter"
+          class="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400 pr-10"
+        />
+        {showCounter() && (
+          <span
+            id="task-label-counter"
+            aria-live="polite"
+            class={`absolute right-2 top-1/2 -translate-y-1/2 text-xs tabular-nums select-none ${
+              remaining() <= 10 ? 'text-red-400' : 'text-gray-400'
+            }`}
+          >
+            {remaining()}
+          </span>
+        )}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Wraps the bare `<input>` in a `<div>` with a proper `<label>` element ("Task label — optional, max 50 chars") associated via `for`/`id`, so screen readers announce it correctly on focus
- Adds a live character-remaining counter that appears when the field is focused or non-empty; turns red when ≤ 10 characters remain
- The counter uses `aria-describedby` so assistive technology reads the remaining count as the user types
- Placeholder text kept as a secondary visual hint, no longer the only source of information

## Test plan

- [ ] Open popup and click the task label input — verify the "Task label (optional, max 50 chars)" label is visible above it
- [ ] Start typing — verify a character counter appears in the right side of the input
- [ ] Type until ≤ 10 chars remain — verify counter turns red
- [ ] Type 50 characters — verify counter shows `0` and no further input is accepted
- [ ] Blur the input with text present — verify the counter stays visible
- [ ] Blur the input when empty — verify the counter hides
- [ ] `npx vitest run` — all 86 tests pass
- [ ] `npx tsc --noEmit` — no errors

Closes #154