### PR TITLE
a11y: add aria-live region to popup phase text (#153)

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -123,7 +123,12 @@ export default function App() {
       <TimerRing progress={progress()} phase={state().phase} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
+      <div
+        role="status"
+        aria-live={state().phase === 'BREAK_SUGGESTION' ? 'assertive' : 'polite'}
+        aria-atomic="true"
+        class="text-sm text-gray-500 mt-1"
+      >
         <Switch>
           <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
           <Match when={state().phase === 'WORKING'}>Working</Match>


### PR DESCRIPTION
## Summary

- Wraps the phase status text (`Ready to focus`, `Working`, `Short Break`, etc.) in a `<div role="status" aria-live="polite" aria-atomic="true">` so screen readers announce phase changes automatically when the timer state changes
- For `BREAK_SUGGESTION` (an urgent transition after 4 work sessions), `aria-live` switches to `"assertive"` so the announcement interrupts current speech rather than waiting for the next pause

## Test plan

- [ ] Open the popup and start a timer — verify "Working" is announced by a screen reader
- [ ] When a session completes and phase changes to BREAK_SUGGESTION — verify the announcement interrupts (assertive)
- [ ] Verify no visual change to the popup UI
- [ ] `npx vitest run` — all 86 tests pass
- [ ] `npx tsc --noEmit` — no errors

Closes #153