### PR TITLE
fix: remove wrong type cast in stats URL and add dark mode to Controls buttons

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -17,7 +17,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
-            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
+            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 dark:bg-red-700 dark:hover:bg-red-600 dark:active:bg-red-500 transition-colors"
           >
             Start
           </button>
@@ -26,7 +26,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 dark:active:bg-gray-500 transition-colors"
           >
             Abandon
           </button>
@@ -35,7 +35,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 dark:active:bg-gray-500 transition-colors"
           >
             Skip Break
           </button>
@@ -44,14 +44,14 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAcceptLongBreak}
-            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
+            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 dark:bg-green-700 dark:hover:bg-green-600 dark:active:bg-green-500 transition-colors"
           >
             Long Break
           </button>
           <button
             type="button"
             onClick={props.onSkipLongBreak}
-            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 dark:active:bg-gray-500 transition-colors"
           >
             Skip
           </button>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -151,7 +151,7 @@ export default function App() {
 
       <button
         type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
       >
         View all stats →


### PR DESCRIPTION
## Summary

- Fix incorrect `'/popup.html'` type cast on `getURL('/stats.html')` call in the popup's "View all stats" button — the URL was correct but the type assertion misleads IDE tooling and refactoring tools into treating the URL as a popup.html reference (#164)
- Add `dark:` Tailwind color variants to all timer control buttons in `Controls.tsx` so Start, Abandon, Skip Break, Long Break, and Skip buttons remain readable when `html.dark` is applied (#181)

## Files changed

- `entrypoints/popup/App.tsx` — remove erroneous `as '/popup.html'` cast
- `components/Controls.tsx` — add `dark:bg-*`, `dark:text-*`, `dark:hover:bg-*`, `dark:active:bg-*` to every button variant

## Test plan

- [x] `npx tsc --noEmit` passes with no new errors
- [x] `npx vitest run` — all 86 tests pass
- [ ] Manual: open popup in dark mode (`html.dark`), verify all button states are readable
- [ ] Manual: confirm "View all stats →" still navigates to the stats page correctly

Closes #164
Closes #181