### PR TITLE
fix: scope popup storage listener to sessions key; surface stats load errors

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
-import { browser } from 'wxt/browser';
+import { browser, type Browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
 import { playCelebration } from '@/lib/celebration';
@@ -33,7 +33,7 @@ export default function App() {
     setHeatmapData(await getHeatmapData(120));
   };
 
-  const onStorageChanged = (changes: Record<string, browser.storage.StorageChange>) => {
+  const onStorageChanged = (changes: Record<string, Browser.storage.StorageChange>) => {
     if ('sessions' in changes) {
       refreshStats();
     }

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -33,6 +33,12 @@ export default function App() {
     setHeatmapData(await getHeatmapData(120));
   };
 
+  const onStorageChanged = (changes: Record<string, browser.storage.StorageChange>) => {
+    if ('sessions' in changes) {
+      refreshStats();
+    }
+  };
+
   onMount(async () => {
     const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
     setState(currentState as TimerState);
@@ -49,8 +55,8 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    browser.storage.onChanged.addListener(onStorageChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onStorageChanged));
   });
 
   createEffect(() => {

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -47,7 +47,7 @@ function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
 
 export default function App() {
   const [yearData] = createResource(() => getHeatmapData(365));
-  const [sessions] = createResource(() => getSessionHistory());
+  const [sessions, { refetch: refetchSessions }] = createResource(() => getSessionHistory());
   const [todayCount] = createResource(() => getTodayCount());
   const [config] = createResource(() => getConfig());
 
@@ -58,6 +58,8 @@ export default function App() {
   const week = () => computeWeekCount(sessions() ?? []);
   const bestDay = () => computeBestDay(sessions() ?? []);
   const streak = () => computeStreak(sessions() ?? []);
+
+  const loadError = () => sessions.error ?? yearData.error ?? todayCount.error ?? config.error;
 
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
@@ -74,14 +76,31 @@ export default function App() {
           </Show>
         </div>
 
-        <Show when={(sessions() ?? []).length === 0}>
+        <Show when={loadError()}>
+          <div
+            role="alert"
+            class="text-center py-8 text-red-700 bg-red-100 rounded-xl border border-red-200 px-4"
+          >
+            <p class="text-lg font-semibold">Could not load stats</p>
+            <p class="text-sm mt-1">{String(loadError())}</p>
+            <button
+              type="button"
+              onClick={() => refetchSessions()}
+              class="mt-3 text-sm px-4 py-1.5 rounded-lg border border-red-300 text-red-700 hover:bg-red-200 transition-colors"
+            >
+              Retry
+            </button>
+          </div>
+        </Show>
+
+        <Show when={!loadError() && (sessions() ?? []).length === 0}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>
             <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
           </div>
         </Show>
 
-        <Show when={(sessions() ?? []).length > 0}>
+        <Show when={!loadError() && (sessions() ?? []).length > 0}>
           <div class="grid grid-cols-5 gap-3 mb-6">
             <StatCard label="Total tomates" value={total()} />
             <StatCard label="Today" value={todayCount() ?? 0} />


### PR DESCRIPTION
## Summary

- **#156 (perf)** — `entrypoints/popup/App.tsx`: The `storage.onChanged` listener previously called `refreshStats()` on every storage write (timer state, config, label, etc.). It is now wrapped in an `onStorageChanged` handler that guards on `'sessions' in changes`, so the two async reads (`getTodayCount` + `getHeatmapData`) only fire when session data actually changes.

- **#151 (ux)** — `entrypoints/stats/App.tsx`: All four `createResource` calls were silently discarding errors, leaving the page blank or showing stale data. A derived `loadError()` signal now coalesces errors from all resources. When any load fails, a visible `role="alert"` banner is shown with the error message and a **Retry** button that re-fetches sessions.

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` — clean
- [ ] Tests: `npx vitest run` — 86/86 pass
- [ ] Popup: open extension, change config or label mid-session, confirm heatmap/count does NOT re-fetch; complete a session and confirm it DOES update
- [ ] Stats: simulate a storage failure (mock `getSessionHistory` to reject) and confirm the error banner and Retry button appear instead of a blank page

Closes #156
Closes #151