### PR TITLE
fix: scope popup storage listener to sessions key; remove wrong getURL type cast (#156, #164)

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -49,8 +49,11 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const onSessionsChanged = (changes: Record<string, unknown>) => {
+      if ('sessions' in changes) void refreshStats();
+    };
+    browser.storage.onChanged.addListener(onSessionsChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onSessionsChanged));
   });
 
   createEffect(() => {
@@ -151,7 +154,7 @@ export default function App() {
 
       <button
         type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
       >
         View all stats →


### PR DESCRIPTION
## Summary

- **#156**: The `browser.storage.onChanged` listener in `popup/App.tsx` was unscoped — it fired `refreshStats()` (which calls `getTodayCount()` + `getHeatmapData()`) on every storage change, including every timer tick update to `timerState`. Replaced with a named `onSessionsChanged` function that checks `'sessions' in changes` before calling `refreshStats`.
- **#164**: `browser.runtime.getURL('/stats.html' as '/popup.html')` had a misleading type cast declaring the stats URL as popup.html. Removed the cast entirely — the string literal `'/stats.html'` is inferred correctly by TypeScript.

## Test plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npx vitest run` — 86/86 tests pass
- [ ] Manual: open popup, start a timer, confirm stats heatmap/count only re-renders on session completion (not every second)
- [ ] Manual: click "View all stats →" — confirm stats tab opens (not popup.html)

Closes #156
Closes #164