### PR TITLE
fix: scope popup storage listener to sessions key and disable controls during in-flight actions (#156, #158)

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -3,6 +3,7 @@ import type { TimerPhase } from '@/lib/types';
 
 type ControlsProps = {
   phase: TimerPhase;
+  disabled?: boolean;
   onStart: () => void;
   onAbandon: () => void;
   onAcceptLongBreak: () => void;
@@ -17,7 +18,9 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onStart}
-            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
+            disabled={props.disabled}
+            aria-busy={props.disabled}
+            class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Start
           </button>
@@ -26,7 +29,9 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={props.disabled}
+            aria-busy={props.disabled}
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Abandon
           </button>
@@ -35,7 +40,9 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={props.disabled}
+            aria-busy={props.disabled}
+            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Skip Break
           </button>
@@ -44,14 +51,18 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAcceptLongBreak}
-            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
+            disabled={props.disabled}
+            aria-busy={props.disabled}
+            class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Long Break
           </button>
           <button
             type="button"
             onClick={props.onSkipLongBreak}
-            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            disabled={props.disabled}
+            aria-busy={props.disabled}
+            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Skip
           </button>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -27,10 +27,18 @@ export default function App() {
   const [todayCount, setTodayCount] = createSignal(0);
   const [dailyGoal, setDailyGoal] = createSignal<number | undefined>(undefined);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [actionPending, setActionPending] = createSignal(false);
 
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
     setHeatmapData(await getHeatmapData(120));
+  };
+
+  // Only re-fetch stats when the sessions key changes, not on every storage write.
+  const onSessionsChanged = (changes: Record<string, unknown>) => {
+    if ('sessions' in changes) {
+      void refreshStats();
+    }
   };
 
   onMount(async () => {
@@ -49,8 +57,8 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    browser.storage.onChanged.addListener(onSessionsChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onSessionsChanged));
   });
 
   createEffect(() => {
@@ -79,25 +87,21 @@ export default function App() {
     return 1 - remaining() / s.duration;
   };
 
-  const startTimer = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'START_TIMER' });
-    setState(newState as TimerState);
+  const dispatchAction = async (action: string) => {
+    if (actionPending()) return;
+    setActionPending(true);
+    try {
+      const newState = await browser.runtime.sendMessage({ action });
+      setState(newState as TimerState);
+    } finally {
+      setActionPending(false);
+    }
   };
 
-  const abandonTimer = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
-    setState(newState as TimerState);
-  };
-
-  const acceptLongBreak = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
-    setState(newState as TimerState);
-  };
-
-  const skipLongBreak = async () => {
-    const newState = await browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
-    setState(newState as TimerState);
-  };
+  const startTimer = () => dispatchAction('START_TIMER');
+  const abandonTimer = () => dispatchAction('ABANDON_TIMER');
+  const acceptLongBreak = () => dispatchAction('ACCEPT_LONG_BREAK');
+  const skipLongBreak = () => dispatchAction('SKIP_LONG_BREAK');
 
   let labelTimeout: ReturnType<typeof setTimeout>;
   const handleLabelChange = (value: string) => {
@@ -137,6 +141,7 @@ export default function App() {
 
       <Controls
         phase={state().phase}
+        disabled={actionPending()}
         onStart={startTimer}
         onAbandon={abandonTimer}
         onAcceptLongBreak={acceptLongBreak}
@@ -151,7 +156,7 @@ export default function App() {
 
       <button
         type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
       >
         View all stats →


### PR DESCRIPTION
## Summary

- **#156 (perf):** The `refreshStats` storage listener previously fired on every storage write (timer state, label, config, etc.), triggering redundant `getTodayCount` + `getHeatmapData(120)` calls on each timer tick. The listener is now scoped to the `sessions` key so it only re-fetches when session data actually changes.
- **#158 (ux/bug):** Controls buttons had no disabled state. Rapid clicks while a `sendMessage` was in-flight could dispatch duplicate `START_TIMER` / `ABANDON_TIMER` actions. A new `actionPending` signal now sets `disabled` + `aria-busy` on the active button for the duration of the async call, preventing double-submission.

## Changes

- `entrypoints/popup/App.tsx`: added `actionPending` signal; replaced four individual async handlers with a single `dispatchAction` guard; replaced unscoped `refreshStats` listener with `onSessionsChanged` that checks `'sessions' in changes`.
- `components/Controls.tsx`: added optional `disabled` prop; all buttons forward `disabled={props.disabled}` and `aria-busy={props.disabled}` with `disabled:opacity-50 disabled:cursor-not-allowed` Tailwind classes.

## Test plan

- `npx tsc --noEmit` — clean
- `npx vitest run` — 86/86 tests pass
- Manual: open popup, click Start, observe button dims and cannot be clicked again until background responds

Closes #156
Closes #158