### PR TITLE
fix: store saved-banner timer ID and add onCleanup; fix getSessionHistory off-by-one

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, onCleanup, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
@@ -20,6 +20,8 @@ export default function App() {
   const [extraConfig, setExtraConfig] = createSignal<Partial<TimerConfig>>({});
   const [saved, setSaved] = createSignal(false);
   const [error, setError] = createSignal('');
+  let savedTimer: ReturnType<typeof setTimeout> | undefined;
+  onCleanup(() => clearTimeout(savedTimer));
 
   onMount(async () => {
     const config = await getConfig();
@@ -63,7 +65,8 @@ export default function App() {
       // Background may not be reachable; config is already saved
     }
     setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    clearTimeout(savedTimer);
+    savedTimer = setTimeout(() => setSaved(false), 2000);
   };
 
   const handleReset = () => {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -70,8 +70,7 @@ export const getSessionHistory = async (days?: number): Promise<CompletedSession
     return [];
   }
 
-  const today = startOfLocalDay(Date.now()).getTime();
-  const earliestKey = toDateKey(today - (days - 1) * DAY_MS);
+  const earliestKey = toDateKey(startOfLocalDay(Date.now() - (days - 1) * DAY_MS).getTime());
 
   return sessions.filter((session) => session.date >= earliestKey);
 };


### PR DESCRIPTION
Closes #262
Closes #395