### PR TITLE
perf: parallelize popup onMount storage loads and reduce session array copies

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -34,19 +34,22 @@ export default function App() {
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    const [currentState, config, pending, currentLabel] = await Promise.all([
+      browser.runtime.sendMessage({ action: 'GET_STATE' }) as Promise<TimerState>,
+      getConfig(),
+      getPendingCelebration(),
+      getCurrentLabel(),
+    ]);
 
-    const config = await getConfig();
+    setState(currentState);
     setDailyGoal(config.dailyGoal);
+    setLabel(currentLabel);
 
-    const pending = await getPendingCelebration();
     if (pending) {
       playCelebration('work', config.playCompletionSound);
       await setPendingCelebration(false);
     }
 
-    setLabel(await getCurrentLabel());
     await refreshStats();
 
     browser.storage.onChanged.addListener(refreshStats);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -56,7 +56,8 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
 
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  sessions.push(session);
+  await browser.storage.local.set({ [KEYS.SESSIONS]: sessions });
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
Closes #172
Closes #175

## Summary

- **#172**: `onMount` in `entrypoints/popup/App.tsx` previously awaited four independent storage calls sequentially (`GET_STATE`, `getConfig`, `getPendingCelebration`, `getCurrentLabel`). All four now run in parallel via `Promise.all`, eliminating the sequential stall that caused a visible flash on popup open.

- **#175**: `addCompletedSession` in `lib/storage.ts` used `[...sessions, session]` which spread the existing array into a brand-new array before writing it back. Replaced with `sessions.push(session)` so only one array allocation exists (the one read from storage), reducing peak memory by one full copy of the sessions list.

## Test plan
- [ ] `npx tsc --noEmit` passes (no type errors)
- [ ] `npx vitest run` passes (86/86 tests)
- [ ] Open popup — no visible flash on load; timer state, label, count, and heatmap appear together
- [ ] Complete a pomodoro session — session is recorded correctly, today count increments