### PR TITLE
test: getConfig() v1→v2 migration and onInstalled update reason coverage

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -243,6 +243,31 @@ describe('background service worker', () => {
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
   });
 
+  it('reschedules the alarm when onInstalled fires with reason update and a timer is active', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000);
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 2_000,
+        duration: 1_000,
+      }),
+    );
+    await initBackground();
+
+    await fakeBrowser.runtime.onInstalled.trigger({ reason: 'update', temporary: false } as never);
+
+    // The missed alarm is recovered: working session completes, SHORT_BREAK is scheduled
+    const state = await getTimerState();
+    expect(state.phase).toBe('SHORT_BREAK');
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toEqual(
+      expect.objectContaining({
+        scheduledTime: 10_000 + DEFAULT_CONFIG.shortBreakDuration,
+      }),
+    );
+    await expect(getPendingCelebration()).resolves.toBe(true);
+  });
+
   it('updates config during an active timer and recreates the timer alarm', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000);
     const updatedConfig = createConfig({ workDuration: 20_000, shortBreakDuration: 1_000 });

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -149,4 +149,23 @@ describe('storage helpers', () => {
     await setPendingCelebration(false);
     await expect(getPendingCelebration()).resolves.toBe(false);
   });
+
+  it('merges a v1 partial config with DEFAULT_CONFIG fields on read', async () => {
+    // Simulate a v1 config stored before openBreakTab, playCompletionSound, and dailyGoal existed
+    const v1Config = {
+      workDuration: 30 * 60 * 1000,
+      shortBreakDuration: 10 * 60 * 1000,
+      longBreakDuration: 20 * 60 * 1000,
+    };
+    await fakeBrowser.storage.local.set({ config: v1Config });
+
+    const result = await getConfig();
+
+    expect(result).toEqual({
+      ...v1Config,
+      openBreakTab: DEFAULT_CONFIG.openBreakTab,
+      playCompletionSound: DEFAULT_CONFIG.playCompletionSound,
+      dailyGoal: DEFAULT_CONFIG.dailyGoal,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a storage test that stores a partial v1 config (only `workDuration`, `shortBreakDuration`, `longBreakDuration`) directly into `browser.storage.local` and asserts `getConfig()` fills in the missing `DEFAULT_CONFIG` fields (`openBreakTab`, `playCompletionSound`, `dailyGoal`)
- Adds a background test that fires `browser.runtime.onInstalled` with reason `'update'` while a WORKING timer is active and asserts the missed alarm recovery path runs: state transitions to `SHORT_BREAK`, the timer alarm is rescheduled, and `pendingCelebration` is set to `true`

Closes #178
Closes #177

## Test plan

- [x] `npx tsc --noEmit` — passes on main project (worktree missing generated `.wxt/tsconfig.json` — pre-existing condition)
- [x] `npx vitest run` — 88 tests pass (2 new, 86 pre-existing)