### PR TITLE
fix: reschedule pending timer on update; parallelize persist+badge

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -121,6 +121,12 @@ export default defineBackground(() => {
     const recovered = recoverMissedAlarm(state, config);
 
     if (!recovered) {
+      // No missed alarm — but if a timer is actively running, Chrome may have
+      // cleared its alarm during an update/restart, so reschedule it (#142).
+      if (isActivePhase(state.phase) && state.endTime !== null) {
+        await scheduleTimerAlarm(state.endTime);
+        await startBadgeRefresh();
+      }
       await refreshBadge();
       return;
     }
@@ -253,8 +259,9 @@ export default defineBackground(() => {
     const completed = completeTimer(state, config);
     await setTimerState(completed);
 
+    const endTime = Date.now();
+
     if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
       if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
         await browser.notifications.create({
           type: 'basic',
@@ -290,6 +297,11 @@ export default defineBackground(() => {
       await clearActiveAlarms();
     }
 
-    await refreshBadge();
+    // persistCompletedSession (writes session history) and refreshBadge (reads
+    // timer state for the badge) are independent — run them in parallel (#176).
+    await Promise.all([
+      state.phase === 'WORKING' ? persistCompletedSession(state, endTime) : Promise.resolve(),
+      refreshBadge(),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- **#142**: `recoverFromMissedAlarm` now reschedules the active `tomate-timer` alarm when the timer phase is still active but Chrome cleared the alarm during an extension update or service-worker restart. Previously, `recoverMissedAlarm` returned `null` (timer not yet missed) and the function only refreshed the badge, leaving the timer with no alarm.

- **#176**: `persistCompletedSession` (writes session history) and `refreshBadge` (reads timer state for the badge) are independent operations — they now run concurrently via `Promise.all` at the end of the `onAlarm` handler instead of sequentially.

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` — clean
- [ ] Tests: `npx vitest run` — 86/86 passed
- [ ] Manual: start a timer, force-reload the extension (simulate update), confirm the timer alarm fires at the correct time
- [ ] Manual: complete a work session, confirm badge updates and session is persisted

Closes #142
Closes #176