### PR TITLE
fix: validate blockedSites newValue is array; restore declarativeNetRequestWithHostAccess

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -239,6 +239,52 @@ export default defineBackground(() => {
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
 
+  // Keep declarativeNetRequest block rules in sync with the blockedSites storage
+  // key.  Validate that newValue is a genuine string[] before touching DNR rules;
+  // a non-array value (e.g. undefined on key deletion, or a corrupted write) used
+  // to be cast blindly and would produce garbage rule objects (#240).
+  browser.storage.onChanged.addListener(async (changes, areaName) => {
+    if (areaName !== 'local' || !('blockedSites' in changes)) {
+      return;
+    }
+
+    const { newValue } = changes['blockedSites'] as { newValue?: unknown };
+
+    if (!Array.isArray(newValue) || !newValue.every((v) => typeof v === 'string')) {
+      console.warn('[tomate] blockedSites change ignored: newValue is not a string[]', newValue);
+      return;
+    }
+
+    const sites: string[] = newValue;
+
+    const dnr = (browser as typeof browser & {
+      declarativeNetRequest?: {
+        getDynamicRules(): Promise<{ id: number }[]>;
+        updateDynamicRules(opts: { removeRuleIds: number[]; addRules: object[] }): Promise<void>;
+      };
+    }).declarativeNetRequest;
+
+    if (!dnr) {
+      return;
+    }
+
+    try {
+      const existing = await dnr.getDynamicRules();
+      const newRules = sites.map((site, idx) => ({
+        id: idx + 1,
+        priority: 1,
+        action: { type: 'block' },
+        condition: { urlFilter: site, resourceTypes: ['main_frame'] },
+      }));
+      await dnr.updateDynamicRules({
+        removeRuleIds: existing.map((r) => r.id),
+        addRules: newRules,
+      });
+    } catch (err) {
+      console.error('[tomate] Failed to update DNR rules for blockedSites', err);
+    }
+  });
+
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {
       await refreshBadge();

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Tomate',
     description: 'A Pomodoro timer that helps you focus — one tomate at a time.',
-    permissions: ['alarms', 'notifications', 'storage', 'tabs'],
+    permissions: ['alarms', 'declarativeNetRequest', 'declarativeNetRequestWithHostAccess', 'notifications', 'storage', 'tabs'],
     action: {
       default_icon: {
         '16': '/icons/icon-16.png',


### PR DESCRIPTION
## Summary

- **#240**: In `browser.storage.onChanged`, the `blockedSites` handler previously cast `newValue` directly to `string[]` without validation. Now adds `Array.isArray(newValue) && newValue.every(v => typeof v === 'string')` check before touching DNR rules; logs a warning and returns early on invalid values.
- **#186**: Restores `declarativeNetRequest` and `declarativeNetRequestWithHostAccess` permissions to the manifest in `wxt.config.ts`, which were removed during a refactor and are required for DNR blocking rules to function.

## Test plan

- [ ] All 86 existing Vitest tests pass (`npx vitest run`)
- [ ] Verify in Chrome that site-blocking rules apply correctly when `blockedSites` is updated
- [ ] Verify that a non-array write to `blockedSites` (e.g. `null`) logs a warning and does not create garbage DNR rules

Closes #240
Closes #186