### PR TITLE
test: add playCelebration sound and addCompletedSession quota retry coverage

### DIFF
--- a/lib/__tests__/celebration.test.ts
+++ b/lib/__tests__/celebration.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+
+vi.mock('wxt/browser', () => ({ browser: fakeBrowser }));
+vi.mock('canvas-confetti', () => ({ default: vi.fn() }));
+
+import confetti from 'canvas-confetti';
+import { playCelebration } from '../celebration';
+
+const mockConfetti = vi.mocked(confetti);
+
+describe('playCelebration', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fakeBrowser.reset();
+    mockConfetti.mockReset();
+  });
+
+  it('fires confetti with the work config', () => {
+    playCelebration('work', false);
+    expect(mockConfetti).toHaveBeenCalledOnce();
+    const opts = mockConfetti.mock.calls[0][0] as confetti.Options;
+    expect(opts?.particleCount).toBe(150);
+  });
+
+  it('fires confetti with the milestone config', () => {
+    playCelebration('milestone', false);
+    expect(mockConfetti).toHaveBeenCalledOnce();
+    const opts = mockConfetti.mock.calls[0][0] as confetti.Options;
+    expect(opts?.particleCount).toBe(300);
+  });
+
+  it('fires confetti with the break config', () => {
+    playCelebration('break', false);
+    expect(mockConfetti).toHaveBeenCalledOnce();
+    const opts = mockConfetti.mock.calls[0][0] as confetti.Options;
+    expect(opts?.particleCount).toBe(50);
+  });
+
+  it('does not create an Audio instance when playSound is false', () => {
+    const AudioSpy = vi.fn(() => ({ play: vi.fn().mockResolvedValue(undefined) }));
+    vi.stubGlobal('Audio', AudioSpy);
+
+    playCelebration('work', false);
+
+    expect(AudioSpy).not.toHaveBeenCalled();
+  });
+
+  it('creates an Audio instance and calls play() when playSound is true', () => {
+    const playSpy = vi.fn().mockResolvedValue(undefined);
+    const AudioSpy = vi.fn(() => ({ play: playSpy }));
+    vi.stubGlobal('Audio', AudioSpy);
+    fakeBrowser.runtime.getURL = vi.fn(() => 'chrome-extension://abc/sounds/completion.mp3');
+
+    playCelebration('work', true);
+
+    expect(AudioSpy).toHaveBeenCalledOnce();
+    expect(AudioSpy).toHaveBeenCalledWith('chrome-extension://abc/sounds/completion.mp3');
+    expect(playSpy).toHaveBeenCalledOnce();
+  });
+
+  it('defaults playSound to true', () => {
+    const playSpy = vi.fn().mockResolvedValue(undefined);
+    const AudioSpy = vi.fn(() => ({ play: playSpy }));
+    vi.stubGlobal('Audio', AudioSpy);
+    fakeBrowser.runtime.getURL = vi.fn(() => 'chrome-extension://abc/sounds/completion.mp3');
+
+    playCelebration('break');
+
+    expect(AudioSpy).toHaveBeenCalledOnce();
+    expect(playSpy).toHaveBeenCalledOnce();
+  });
+
+  it('silently absorbs a rejected play() promise', async () => {
+    const playSpy = vi.fn().mockRejectedValue(new Error('NotAllowedError'));
+    const AudioSpy = vi.fn(() => ({ play: playSpy }));
+    vi.stubGlobal('Audio', AudioSpy);
+    fakeBrowser.runtime.getURL = vi.fn(() => 'chrome-extension://abc/sounds/completion.mp3');
+
+    // Should not throw — the .catch(() => {}) in playCelebration eats the rejection
+    expect(() => playCelebration('work', true)).not.toThrow();
+
+    // Give the microtask queue a chance to process the rejection
+    await Promise.resolve();
+    expect(playSpy).toHaveBeenCalledOnce();
+  });
+
+  it('silently absorbs an Audio constructor error when playSound is true', () => {
+    vi.stubGlobal('Audio', () => {
+      throw new Error('Audio not available');
+    });
+    fakeBrowser.runtime.getURL = vi.fn(() => 'chrome-extension://abc/sounds/completion.mp3');
+
+    // The try/catch around the Audio constructor should prevent this from throwing
+    expect(() => playCelebration('work', true)).not.toThrow();
+
+    // Confetti should still have fired despite the Audio failure
+    expect(mockConfetti).toHaveBeenCalledOnce();
+  });
+});

--- a/lib/__tests__/storage-quota.test.ts
+++ b/lib/__tests__/storage-quota.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+
+vi.mock('wxt/browser', () => ({ browser: fakeBrowser }));
+
+import { addCompletedSession, getSessionHistory, toDateKey } from '../storage';
+import type { CompletedSession } from '../types';
+
+const makeSession = (id: string, timestamp = 1_000_000): CompletedSession => ({
+  id,
+  label: 'Deep work',
+  startTime: timestamp,
+  endTime: timestamp + 1_500_000,
+  date: toDateKey(timestamp),
+  duration: 1_500_000,
+});
+
+describe('addCompletedSession — quota exceeded retry', () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    fakeBrowser.reset();
+    await fakeBrowser.storage.local.clear();
+  });
+
+  it('succeeds normally when storage.set does not throw', async () => {
+    const session = makeSession('s1');
+    await addCompletedSession(session);
+    await expect(getSessionHistory()).resolves.toEqual([session]);
+  });
+
+  it('retries with pruned sessions when storage.set throws a quota error', async () => {
+    // Seed storage with 10 existing sessions
+    const existing: CompletedSession[] = Array.from({ length: 10 }, (_, i) =>
+      makeSession(`existing-${i}`, 1_000_000 + i * 1_000),
+    );
+    await fakeBrowser.storage.local.set({ sessions: existing });
+
+    const newSession = makeSession('new-session', 2_000_000);
+
+    // Make the first set call throw a quota error, then succeed on the second call
+    let callCount = 0;
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items: Record<string, unknown>) => {
+      if ('sessions' in items && callCount === 0) {
+        callCount++;
+        const quotaError = new Error('QUOTA_BYTES_PER_ITEM quota exceeded');
+        throw quotaError;
+      }
+      return originalSet(items);
+    });
+
+    await addCompletedSession(newSession);
+
+    const stored = await getSessionHistory();
+    // The new session should be present after the retry
+    expect(stored.some((s) => s.id === 'new-session')).toBe(true);
+    // The pruned result should have fewer sessions than 11 (10 + 1 = 11 before pruning)
+    expect(stored.length).toBeLessThan(11);
+  });
+
+  it('does not prune when a non-quota error is thrown', async () => {
+    const existing: CompletedSession[] = [makeSession('s-existing', 1_000_000)];
+    await fakeBrowser.storage.local.set({ sessions: existing });
+
+    const nonQuotaError = new Error('Unknown storage error');
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValue(nonQuotaError);
+
+    await expect(addCompletedSession(makeSession('s-new'))).rejects.toThrow('Unknown storage error');
+  });
+
+  it('prunes 10% of existing sessions on a quota error', async () => {
+    // Seed storage with exactly 100 sessions
+    const existing: CompletedSession[] = Array.from({ length: 100 }, (_, i) =>
+      makeSession(`old-${i}`, 1_000_000 + i * 1_000),
+    );
+    await fakeBrowser.storage.local.set({ sessions: existing });
+
+    const newSession = makeSession('trigger', 2_000_000);
+
+    let callCount = 0;
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items: Record<string, unknown>) => {
+      if ('sessions' in items && callCount === 0) {
+        callCount++;
+        throw new Error('QuotaExceededError: quota exceeded');
+      }
+      return originalSet(items);
+    });
+
+    await addCompletedSession(newSession);
+
+    const stored = await getSessionHistory();
+    // 100 existing, prune 10% (10), add 1 new = 91 total
+    expect(stored.length).toBe(91);
+    expect(stored[stored.length - 1].id).toBe('trigger');
+    // The oldest 10 sessions should be pruned
+    expect(stored.some((s) => s.id === 'old-0')).toBe(false);
+    expect(stored.some((s) => s.id === 'old-9')).toBe(false);
+    expect(stored.some((s) => s.id === 'old-10')).toBe(true);
+  });
+
+  it('prunes at least 1 session when there is only 1 existing session', async () => {
+    const existing: CompletedSession[] = [makeSession('only-one', 1_000_000)];
+    await fakeBrowser.storage.local.set({ sessions: existing });
+
+    const newSession = makeSession('after-prune', 2_000_000);
+
+    let callCount = 0;
+    const originalSet = fakeBrowser.storage.local.set.bind(fakeBrowser.storage.local);
+    vi.spyOn(fakeBrowser.storage.local, 'set').mockImplementation(async (items: Record<string, unknown>) => {
+      if ('sessions' in items && callCount === 0) {
+        callCount++;
+        throw new Error('quota exceeded');
+      }
+      return originalSet(items);
+    });
+
+    await addCompletedSession(newSession);
+
+    const stored = await getSessionHistory();
+    // 1 existing pruned (Math.max(1, floor(1*0.1)) = 1), then new session added = 1 total
+    expect(stored.length).toBe(1);
+    expect(stored[0].id).toBe('after-prune');
+  });
+});

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -18,6 +18,7 @@ const KEYS = {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_LABEL_LENGTH = 50;
+const MAX_SESSIONS = 10_000;
 
 const startOfLocalDay = (timestamp: number): Date => {
   const date = new Date(timestamp);
@@ -54,9 +55,25 @@ export const setConfig = async (config: TimerConfig): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CONFIG]: config });
 };
 
+const isQuotaError = (err: unknown): boolean =>
+  err instanceof Error && err.message.toLowerCase().includes('quota');
+
 export const addCompletedSession = async (session: CompletedSession): Promise<void> => {
   const sessions = (await getStoredValue<CompletedSession[]>(KEYS.SESSIONS)) ?? [];
-  await browser.storage.local.set({ [KEYS.SESSIONS]: [...sessions, session] });
+  const updated = [...sessions, session];
+  const capped = updated.slice(-MAX_SESSIONS);
+
+  try {
+    await browser.storage.local.set({ [KEYS.SESSIONS]: capped });
+  } catch (err) {
+    if (!isQuotaError(err)) throw err;
+
+    const pruneCount = Math.max(1, Math.floor(sessions.length * 0.1));
+    const pruned = sessions.slice(pruneCount);
+    await browser.storage.local.set({
+      [KEYS.SESSIONS]: [...pruned, session].slice(-MAX_SESSIONS),
+    });
+  }
 };
 
 export const getSessionHistory = async (days?: number): Promise<CompletedSession[]> => {


### PR DESCRIPTION
## Summary

- Adds quota-exceeded retry logic to `addCompletedSession()` in `lib/storage.ts`: on a quota error, prune 10% of oldest sessions and retry the write
- Creates `lib/__tests__/celebration.test.ts` with 8 tests covering all sound-playback code paths in `playCelebration()` (playSound=false, playSound=true, default, rejected promise, constructor throw)
- Creates `lib/__tests__/storage-quota.test.ts` with 5 tests covering the quota retry path: normal success, quota error with retry, non-quota error re-throw, 10% pruning math, and minimum-prune-of-1 guard

## Test plan

- [ ] `npx tsc --noEmit` — no errors
- [ ] `npx vitest run` — all 99 tests pass
- [ ] `celebration.test.ts` — 8 tests, covers both `playSound=true` and `playSound=false` branches
- [ ] `storage-quota.test.ts` — 5 tests, covers quota retry, non-quota rethrow, pruning math

Closes #195
Closes #180