### PR TITLE
test: add applyBlockingRules and blockedSites listener coverage

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -8,6 +8,7 @@ import {
   getPendingCelebration,
   getSessionHistory,
   getTimerState,
+  setBlockedSites,
   setCurrentLabel,
   setTimerState,
   toDateKey,
@@ -48,6 +49,14 @@ describe('background service worker', () => {
 
     fakeBrowser.action.setBadgeText = vi.fn().mockResolvedValue(undefined);
     fakeBrowser.action.setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+
+    // Provide a chrome.declarativeNetRequest stub so applyBlockingRules doesn't throw
+    (globalThis as typeof globalThis & { chrome: unknown }).chrome = {
+      declarativeNetRequest: {
+        getDynamicRules: vi.fn().mockResolvedValue([]),
+        updateDynamicRules: vi.fn().mockResolvedValue(undefined),
+      },
+    };
   });
 
   it('starts a timer, persists working state, and creates the timer alarm', async () => {
@@ -241,6 +250,122 @@ describe('background service worker', () => {
     await initBackground();
 
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
+  });
+
+  it('applyBlockingRules during WORKING phase applies DNR rules for each site', async () => {
+    const globalChrome = (globalThis as typeof globalThis & {
+      chrome: { declarativeNetRequest: { getDynamicRules: ReturnType<typeof vi.fn>; updateDynamicRules: ReturnType<typeof vi.fn> } };
+    }).chrome;
+
+    await setTimerState(
+      createState({ phase: 'WORKING', startTime: 1_000, endTime: 60_001_000, duration: 60_000_000 }),
+    );
+    await initBackground();
+
+    const bg = (await import(`../background?dnrTest=${testId++}`)) as {
+      applyBlockingRules?: (sites: string[]) => Promise<void>;
+    };
+
+    await bg.applyBlockingRules?.(['example.com', 'reddit.com']);
+
+    expect(globalChrome.declarativeNetRequest.updateDynamicRules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addRules: [
+          expect.objectContaining({
+            id: 1,
+            priority: 1,
+            action: { type: 'block' },
+            condition: expect.objectContaining({ urlFilter: 'example.com', resourceTypes: ['main_frame'] }),
+          }),
+          expect.objectContaining({
+            id: 2,
+            priority: 1,
+            action: { type: 'block' },
+            condition: expect.objectContaining({ urlFilter: 'reddit.com', resourceTypes: ['main_frame'] }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('applyBlockingRules with empty sites array clears all existing DNR rules', async () => {
+    const globalChrome = (globalThis as typeof globalThis & {
+      chrome: { declarativeNetRequest: { getDynamicRules: ReturnType<typeof vi.fn>; updateDynamicRules: ReturnType<typeof vi.fn> } };
+    }).chrome;
+
+    // Simulate two existing rules already present
+    globalChrome.declarativeNetRequest.getDynamicRules.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+    await initBackground();
+
+    const bg = (await import(`../background?dnrClear=${testId++}`)) as {
+      applyBlockingRules?: (sites: string[]) => Promise<void>;
+    };
+
+    await bg.applyBlockingRules?.([]);
+
+    expect(globalChrome.declarativeNetRequest.updateDynamicRules).toHaveBeenCalledWith({
+      removeRuleIds: [1, 2],
+      addRules: [],
+    });
+  });
+
+  it('blockedSites storage listener applies rules when phase is WORKING', async () => {
+    const globalChrome = (globalThis as typeof globalThis & {
+      chrome: { declarativeNetRequest: { updateDynamicRules: ReturnType<typeof vi.fn> } };
+    }).chrome;
+
+    await setTimerState(
+      createState({ phase: 'WORKING', startTime: 1_000, endTime: 60_001_000, duration: 60_000_000 }),
+    );
+    await initBackground();
+
+    await setBlockedSites(['reddit.com']);
+
+    // Allow the listener's .then() microtasks to settle
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(globalChrome.declarativeNetRequest.updateDynamicRules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addRules: [
+          expect.objectContaining({ condition: expect.objectContaining({ urlFilter: 'reddit.com' }) }),
+        ],
+      }),
+    );
+  });
+
+  it('blockedSites storage listener clears rules when phase is not WORKING', async () => {
+    const globalChrome = (globalThis as typeof globalThis & {
+      chrome: { declarativeNetRequest: { updateDynamicRules: ReturnType<typeof vi.fn> } };
+    }).chrome;
+
+    await setTimerState(createState({ phase: 'IDLE' }));
+    await initBackground();
+
+    await setBlockedSites(['reddit.com']);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Should call updateDynamicRules with empty addRules (clear mode)
+    expect(globalChrome.declarativeNetRequest.updateDynamicRules).toHaveBeenCalledWith(
+      expect.objectContaining({ addRules: [] }),
+    );
+  });
+
+  it('blockedSites storage listener ignores changes to other storage keys', async () => {
+    const globalChrome = (globalThis as typeof globalThis & {
+      chrome: { declarativeNetRequest: { updateDynamicRules: ReturnType<typeof vi.fn> } };
+    }).chrome;
+
+    await setTimerState(
+      createState({ phase: 'WORKING', startTime: 1_000, endTime: 60_001_000, duration: 60_000_000 }),
+    );
+    await initBackground();
+
+    // Trigger storage change on a different key
+    await fakeBrowser.storage.onChanged.trigger({ someOtherKey: { newValue: 'foo' } }, 'local');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(globalChrome.declarativeNetRequest.updateDynamicRules).not.toHaveBeenCalled();
   });
 
   it('updates config during an active timer and recreates the timer alarm', async () => {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -24,6 +24,48 @@ import {
 } from '@/lib/storage';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
 
+const MAX_BLOCKED_SITES = 100;
+
+type DnrRule = {
+  id: number;
+  priority: number;
+  action: { type: string };
+  condition: { urlFilter: string; resourceTypes: string[] };
+};
+
+declare const chrome: {
+  declarativeNetRequest: {
+    getDynamicRules(): Promise<DnrRule[]>;
+    updateDynamicRules(options: { removeRuleIds: number[]; addRules: DnrRule[] }): Promise<void>;
+  };
+};
+
+export const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const sitesToBlock = sites.slice(0, MAX_BLOCKED_SITES);
+
+  const newRules: DnrRule[] = sitesToBlock.map((site, index) => ({
+    id: index + 1,
+    priority: 1,
+    action: { type: 'block' },
+    condition: {
+      urlFilter: site,
+      resourceTypes: ['main_frame'],
+    },
+  }));
+
+  const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+  const existingIds = existingRules.map((r) => r.id);
+
+  try {
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      removeRuleIds: existingIds,
+      addRules: newRules,
+    });
+  } catch (e) {
+    console.error('[tomate] Failed to update blocking rules:', e);
+  }
+};
+
 export type MessageAction =
   | { action: 'START_TIMER' }
   | { action: 'ABANDON_TIMER' }
@@ -235,6 +277,22 @@ export default defineBackground(() => {
 
   browser.runtime.onStartup.addListener(async () => {
     await recoverFromMissedAlarm();
+  });
+
+  browser.storage.onChanged.addListener((changes: Record<string, { newValue?: unknown }>, area: string) => {
+    if (area !== 'local' || !('blockedSites' in changes)) {
+      return;
+    }
+
+    getTimerState()
+      .then((state) => {
+        if (state.phase === 'WORKING') {
+          const sites = (changes['blockedSites'].newValue as string[]) ?? [];
+          return applyBlockingRules(sites);
+        }
+        return applyBlockingRules([]);
+      })
+      .catch((e) => console.error('[tomate] Failed to apply blocking rules on storage change:', e));
   });
 
   browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -105,3 +105,10 @@ export const getCurrentLabel = async (): Promise<string> =>
 export const setCurrentLabel = async (label: string): Promise<void> => {
   await browser.storage.local.set({ [KEYS.CURRENT_LABEL]: label.slice(0, MAX_LABEL_LENGTH) });
 };
+
+export const getBlockedSites = async (): Promise<string[]> =>
+  (await getStoredValue<string[]>('blockedSites')) ?? [];
+
+export const setBlockedSites = async (sites: string[]): Promise<void> => {
+  await browser.storage.local.set({ blockedSites: sites });
+};


### PR DESCRIPTION
## Summary

- Add `applyBlockingRules` function and `storage.onChanged` blockedSites listener to `entrypoints/background.ts` (the blocking feature code referenced in issue #192)
- Add `getBlockedSites` / `setBlockedSites` helpers to `lib/storage.ts`
- Add 5 new test cases to `entrypoints/__tests__/background.test.ts` covering the critical blocking path

## New tests

- `applyBlockingRules during WORKING phase applies DNR rules for each site` — verifies rule id, priority, action, urlFilter, and resourceTypes
- `applyBlockingRules with empty sites array clears all existing DNR rules` — verifies removeRuleIds are passed and addRules is empty
- `blockedSites storage listener applies rules when phase is WORKING` — fires setBlockedSites, confirms updateDynamicRules called with correct site
- `blockedSites storage listener clears rules when phase is not WORKING` — IDLE phase, confirms addRules: []
- `blockedSites storage listener ignores changes to other storage keys` — confirms updateDynamicRules not called for unrelated storage changes

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — 91 tests pass across 6 files (background.test.ts: 12 tests, up from 7)

Closes #192