### PR TITLE
feat: add session history list to stats page

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -1,9 +1,21 @@
-import { createResource, For, Show } from 'solid-js';
+import { createResource, createSignal, createMemo, For, Show } from 'solid-js';
 
 import { getConfig, getSessionHistory, getHeatmapData, getTodayCount } from '@/lib/storage';
 import { computeTotalCount, computeWeekCount, computeBestDay, computeStreak } from '@/lib/stats';
 
 import Heatmap from '@/components/Heatmap';
+
+const SESSION_PAGE_SIZE = 50;
+
+function formatDuration(ms: number): string {
+  const mins = Math.round(ms / 60000);
+  return `${mins} min`;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
 
 const INTENSITY_LEGEND = [
   { color: '#F3F4F6', label: '0' },
@@ -58,6 +70,17 @@ export default function App() {
   const week = () => computeWeekCount(sessions() ?? []);
   const bestDay = () => computeBestDay(sessions() ?? []);
   const streak = () => computeStreak(sessions() ?? []);
+
+  const [showAll, setShowAll] = createSignal(false);
+
+  const sortedSessions = createMemo(() =>
+    [...(sessions() ?? [])].sort((a, b) => b.startTime - a.startTime),
+  );
+
+  const visibleSessions = createMemo(() => {
+    const all = sortedSessions();
+    return showAll() ? all : all.slice(0, SESSION_PAGE_SIZE);
+  });
 
   return (
     <div class="min-h-screen bg-red-50 py-10 px-4">
@@ -133,6 +156,49 @@ export default function App() {
               </For>
               <span>More</span>
             </div>
+          </div>
+
+          <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100 mt-6">
+            <h2 class="text-sm font-semibold text-gray-700 mb-3">Session history</h2>
+            <Show
+              when={sortedSessions().length > 0}
+              fallback={
+                <p class="text-sm text-gray-400 text-center py-4">No sessions to display.</p>
+              }
+            >
+              <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                  <thead>
+                    <tr class="border-b border-red-100">
+                      <th class="text-left py-2 pr-4 text-xs font-semibold text-gray-500 uppercase tracking-wide">Date</th>
+                      <th class="text-left py-2 pr-4 text-xs font-semibold text-gray-500 uppercase tracking-wide">Label</th>
+                      <th class="text-right py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">Duration</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <For each={visibleSessions()}>
+                      {(session) => (
+                        <tr class="border-b border-red-50 last:border-0 hover:bg-red-50 transition-colors">
+                          <td class="py-2 pr-4 text-gray-700 whitespace-nowrap">{formatDate(session.date)}</td>
+                          <td class="py-2 pr-4 text-gray-700 truncate max-w-[200px]">{session.label || '—'}</td>
+                          <td class="py-2 text-right text-red-600 font-medium whitespace-nowrap">{formatDuration(session.duration)}</td>
+                        </tr>
+                      )}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+              <Show when={sortedSessions().length > SESSION_PAGE_SIZE && !showAll()}>
+                <div class="mt-3 text-center">
+                  <button
+                    class="text-sm px-4 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
+                    onClick={() => setShowAll(true)}
+                  >
+                    Show all {sortedSessions().length} sessions
+                  </button>
+                </div>
+              </Show>
+            </Show>
           </div>
         </Show>
       </div>


### PR DESCRIPTION
## Summary

- Adds a **Session history** table below the heatmap on the stats page
- Columns: Date, Label, Duration (formatted as "N min")
- Sessions are sorted newest-first using `createMemo`
- Shows at most 50 sessions by default with a "Show all N sessions" button to expand
- Empty state message shown when no sessions exist
- Matches existing red-100/white/red-600 color scheme

## Details

- Added `formatDuration(ms)` and `formatDate(dateStr)` helpers at module level
- Added `createSignal(false)` for `showAll` toggle and two `createMemo`s: `sortedSessions` (newest-first) and `visibleSessions` (paginated)
- Uses SolidJS `For` component for row rendering and `Show` for the empty state and "show more" button
- Only `entrypoints/stats/App.tsx` was modified

## Test plan

- [ ] `npx tsc --noEmit` — passes with no errors
- [ ] `npx vitest run` — all 86 tests pass
- [ ] Stats page shows session table with Date / Label / Duration columns when sessions exist
- [ ] "Show all N sessions" button appears when there are more than 50 sessions and expands the list
- [ ] Empty state fallback shown when no sessions exist
- [ ] Sessions are ordered newest-first

Closes #193