### PR TITLE
fix: wrap notifications.create in try/catch; add reconnecting state to popup

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -256,12 +256,16 @@ export default defineBackground(() => {
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
       if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
-        await browser.notifications.create({
-          type: 'basic',
-          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-          title: '🍅 Tomate Complete!',
-          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-        });
+        try {
+          await browser.notifications.create({
+            type: 'basic',
+            iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+            title: '🍅 Tomate Complete!',
+            message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+          });
+        } catch (err) {
+          console.error('[tomate] notifications.create failed:', err);
+        }
       }
       if (config.openBreakTab !== false) {
         try {
@@ -274,12 +278,16 @@ export default defineBackground(() => {
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
       if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
-        await browser.notifications.create({
-          type: 'basic',
-          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-        });
+        try {
+          await browser.notifications.create({
+            type: 'basic',
+            iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+            title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+            message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+          });
+        } catch (err) {
+          console.error('[tomate] notifications.create failed:', err);
+        }
       }
     }
 

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -27,6 +27,7 @@ export default function App() {
   const [todayCount, setTodayCount] = createSignal(0);
   const [dailyGoal, setDailyGoal] = createSignal<number | undefined>(undefined);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [isReconnecting, setIsReconnecting] = createSignal(false);
 
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
@@ -34,8 +35,20 @@ export default function App() {
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    let currentState: TimerState | undefined;
+    try {
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('GET_STATE timeout')), 3000),
+      );
+      currentState = (await Promise.race([
+        browser.runtime.sendMessage({ action: 'GET_STATE' }),
+        timeout,
+      ])) as TimerState;
+    } catch {
+      setIsReconnecting(true);
+      return;
+    }
+    setState(currentState);
 
     const config = await getConfig();
     setDailyGoal(config.dailyGoal);
@@ -120,28 +133,39 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+      <Switch>
+        <Match when={isReconnecting()}>
+          <div class="flex flex-col items-center justify-center py-10 gap-2" role="status" aria-live="polite">
+            <div class="text-gray-400 text-3xl animate-spin">↻</div>
+            <p class="text-sm text-gray-500 font-medium">Reconnecting…</p>
+            <p class="text-xs text-gray-400">Service is restarting, please wait.</p>
+          </div>
+        </Match>
+        <Match when={!isReconnecting()}>
+          <TimerRing progress={progress()} phase={state().phase} />
+          <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
-        <Switch>
-          <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
-          <Match when={state().phase === 'WORKING'}>Working</Match>
-          <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
-          <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
-          <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
-        </Switch>
-      </div>
+          <div class="text-sm text-gray-500 mt-1">
+            <Switch>
+              <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
+              <Match when={state().phase === 'WORKING'}>Working</Match>
+              <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
+              <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
+              <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
+            </Switch>
+          </div>
 
-      <TaskLabel value={label()} onChange={handleLabelChange} />
+          <TaskLabel value={label()} onChange={handleLabelChange} />
 
-      <Controls
-        phase={state().phase}
-        onStart={startTimer}
-        onAbandon={abandonTimer}
-        onAcceptLongBreak={acceptLongBreak}
-        onSkipLongBreak={skipLongBreak}
-      />
+          <Controls
+            phase={state().phase}
+            onStart={startTimer}
+            onAbandon={abandonTimer}
+            onAcceptLongBreak={acceptLongBreak}
+            onSkipLongBreak={skipLongBreak}
+          />
+        </Match>
+      </Switch>
 
       <TodayCount count={todayCount()} goal={dailyGoal()} />
 


### PR DESCRIPTION
## Summary

- **#152**: Both `browser.notifications.create()` calls in `entrypoints/background.ts` (WORKING phase and SHORT/LONG_BREAK phase) are now wrapped in `try/catch` with `console.error('[tomate] notifications.create failed:', err)` — minimal change, nothing else touched.
- **#117**: `entrypoints/popup/App.tsx` now uses a 3-second `Promise.race` timeout on `GET_STATE`. If the call fails or times out, a new `isReconnecting` signal flips to `true` and the timer UI is replaced with a "Reconnecting…" indicator (spinner + message + sub-text) that includes `role="status"` and `aria-live="polite"` for accessibility.

## Test plan

- [ ] `npx tsc --noEmit` — passes clean
- [ ] `npx vitest run` — 86 tests pass (6 suites)
- [ ] Manually kill service worker in `chrome://extensions` → open popup → confirm "Reconnecting…" message shows instead of stale timer
- [ ] Confirm notification errors no longer crash silently (check DevTools console for `[tomate] notifications.create failed:` if notifications permission is absent)

Closes #117
Closes #152