### PR TITLE
fix: dark-mode-aware colors in TimerRing and Heatmap (#182)

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -12,12 +12,20 @@ type HeatmapCell = {
   dayOfWeek: number;
 };
 
-const INTENSITY_COLORS = [
-  '#F3F4F6',
-  '#FCA5A5',
-  '#EF4444',
-  '#DC2626',
-  '#991B1B',
+/**
+ * Tailwind background-color classes for each intensity level.
+ * Each entry pairs a light-mode color with a dark-mode equivalent so the
+ * heatmap remains legible regardless of the user's color-scheme preference.
+ *
+ * Light:  gray-100 / red-300 / red-500 / red-600 / red-900
+ * Dark:   gray-700 / red-900 / red-800 / red-700 / red-600
+ */
+const INTENSITY_CLASSES = [
+  'bg-gray-100 dark:bg-gray-700',
+  'bg-red-300  dark:bg-red-900',
+  'bg-red-500  dark:bg-red-800',
+  'bg-red-600  dark:bg-red-700',
+  'bg-red-900  dark:bg-red-600',
 ] as const;
 
 const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', ''] as const;
@@ -27,12 +35,12 @@ const MONTH_NAMES = [
   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
 ] as const;
 
-const getIntensityColor = (count: number): string => {
-  if (count === 0) return INTENSITY_COLORS[0];
-  if (count === 1) return INTENSITY_COLORS[1];
-  if (count <= 3) return INTENSITY_COLORS[2];
-  if (count <= 5) return INTENSITY_COLORS[3];
-  return INTENSITY_COLORS[4];
+const getIntensityClass = (count: number): string => {
+  if (count === 0) return INTENSITY_CLASSES[0];
+  if (count === 1) return INTENSITY_CLASSES[1];
+  if (count <= 3) return INTENSITY_CLASSES[2];
+  if (count <= 5) return INTENSITY_CLASSES[3];
+  return INTENSITY_CLASSES[4];
 };
 
 const toDateKey = (date: Date): string => {
@@ -189,11 +197,10 @@ export default function Heatmap(props: HeatmapProps) {
                 {(cell) =>
                   cell ? (
                     <div
-                      class="rounded-sm"
+                      class={`rounded-sm ${getIntensityClass(cell.count)}`}
                       style={{
                         width: `${cellSize()}px`,
                         height: `${cellSize()}px`,
-                        "background-color": getIntensityColor(cell.count),
                       }}
                       title={tooltipText(cell)}
                     />

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -5,12 +5,18 @@ type TimerRingProps = {
   phase: TimerPhase;
 };
 
-const PHASE_COLORS: Record<TimerPhase, string> = {
-  IDLE: '#9CA3AF',
-  WORKING: '#DC2626',
-  SHORT_BREAK: '#16A34A',
-  LONG_BREAK: '#16A34A',
-  BREAK_SUGGESTION: '#CA8A04',
+/**
+ * Tailwind color classes for each phase.
+ * `text-*` sets `currentColor` which is used as the SVG `stroke` on the
+ * progress arc.  Each pair includes a `dark:` variant so the ring is
+ * legible in both light and dark mode.
+ */
+const PHASE_CLASSES: Record<TimerPhase, string> = {
+  IDLE: 'text-gray-400 dark:text-gray-500',
+  WORKING: 'text-red-600 dark:text-red-500',
+  SHORT_BREAK: 'text-green-600 dark:text-green-500',
+  LONG_BREAK: 'text-green-600 dark:text-green-500',
+  BREAK_SUGGESTION: 'text-yellow-600 dark:text-yellow-500',
 };
 
 const SIZE = 160;
@@ -20,25 +26,32 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 export default function TimerRing(props: TimerRingProps) {
   const offset = () => CIRCUMFERENCE * (1 - props.progress);
-  const color = () => PHASE_COLORS[props.phase];
+  const colorClass = () => PHASE_CLASSES[props.phase];
 
   return (
-    <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
+    <svg
+      width={SIZE}
+      height={SIZE}
+      class={`timer-ring ${colorClass()}`}
+      viewBox={`0 0 ${SIZE} ${SIZE}`}
+    >
       <title>Timer progress</title>
+      {/* Track ring — uses a neutral color in both light and dark mode */}
       <circle
         cx={SIZE / 2}
         cy={SIZE / 2}
         r={RADIUS}
         fill="none"
-        stroke="#E5E7EB"
+        class="stroke-gray-200 dark:stroke-gray-700"
         stroke-width={STROKE}
       />
+      {/* Progress arc — inherits `currentColor` from the parent SVG class */}
       <circle
         cx={SIZE / 2}
         cy={SIZE / 2}
         r={RADIUS}
         fill="none"
-        stroke={color()}
+        stroke="currentColor"
         stroke-width={STROKE}
         stroke-linecap="round"
         stroke-dasharray={String(CIRCUMFERENCE)}

--- a/lib/__tests__/heatmap.test.ts
+++ b/lib/__tests__/heatmap.test.ts
@@ -5,20 +5,20 @@ import { describe, expect, it } from 'vitest';
 
 type HeatmapCell = { date: string; count: number; dayOfWeek: number };
 
-const INTENSITY_COLORS = [
-  '#F3F4F6',
-  '#FCA5A5',
-  '#EF4444',
-  '#DC2626',
-  '#991B1B',
+const INTENSITY_CLASSES = [
+  'bg-gray-100 dark:bg-gray-700',
+  'bg-red-300  dark:bg-red-900',
+  'bg-red-500  dark:bg-red-800',
+  'bg-red-600  dark:bg-red-700',
+  'bg-red-900  dark:bg-red-600',
 ] as const;
 
-const getIntensityColor = (count: number): string => {
-  if (count === 0) return INTENSITY_COLORS[0];
-  if (count === 1) return INTENSITY_COLORS[1];
-  if (count <= 3) return INTENSITY_COLORS[2];
-  if (count <= 5) return INTENSITY_COLORS[3];
-  return INTENSITY_COLORS[4];
+const getIntensityClass = (count: number): string => {
+  if (count === 0) return INTENSITY_CLASSES[0];
+  if (count === 1) return INTENSITY_CLASSES[1];
+  if (count <= 3) return INTENSITY_CLASSES[2];
+  if (count <= 5) return INTENSITY_CLASSES[3];
+  return INTENSITY_CLASSES[4];
 };
 
 const toDateKey = (date: Date): string => {
@@ -44,37 +44,37 @@ const generateHeatmapGrid = (data: Record<string, number>, days: number): Heatma
   return cells;
 };
 
-describe('getIntensityColor', () => {
-  it('returns the empty colour for count 0', () => {
-    expect(getIntensityColor(0)).toBe('#F3F4F6');
+describe('getIntensityClass', () => {
+  it('returns the empty class for count 0', () => {
+    expect(getIntensityClass(0)).toBe('bg-gray-100 dark:bg-gray-700');
   });
 
-  it('returns the lightest red for count 1', () => {
-    expect(getIntensityColor(1)).toBe('#FCA5A5');
+  it('returns the lightest red class for count 1', () => {
+    expect(getIntensityClass(1)).toBe('bg-red-300  dark:bg-red-900');
   });
 
-  it('returns the second tier for count 2', () => {
-    expect(getIntensityColor(2)).toBe('#EF4444');
+  it('returns the second tier class for count 2', () => {
+    expect(getIntensityClass(2)).toBe('bg-red-500  dark:bg-red-800');
   });
 
-  it('returns the second tier for count 3', () => {
-    expect(getIntensityColor(3)).toBe('#EF4444');
+  it('returns the second tier class for count 3', () => {
+    expect(getIntensityClass(3)).toBe('bg-red-500  dark:bg-red-800');
   });
 
-  it('returns the third tier for count 4', () => {
-    expect(getIntensityColor(4)).toBe('#DC2626');
+  it('returns the third tier class for count 4', () => {
+    expect(getIntensityClass(4)).toBe('bg-red-600  dark:bg-red-700');
   });
 
-  it('returns the third tier for count 5', () => {
-    expect(getIntensityColor(5)).toBe('#DC2626');
+  it('returns the third tier class for count 5', () => {
+    expect(getIntensityClass(5)).toBe('bg-red-600  dark:bg-red-700');
   });
 
-  it('returns the darkest red for count 6', () => {
-    expect(getIntensityColor(6)).toBe('#991B1B');
+  it('returns the darkest red class for count 6', () => {
+    expect(getIntensityClass(6)).toBe('bg-red-900  dark:bg-red-600');
   });
 
-  it('returns the darkest red for high counts', () => {
-    expect(getIntensityColor(100)).toBe('#991B1B');
+  it('returns the darkest red class for high counts', () => {
+    expect(getIntensityClass(100)).toBe('bg-red-900  dark:bg-red-600');
   });
 });
 


### PR DESCRIPTION
## Summary

- **TimerRing**: Replaced the `PHASE_COLORS` map (inline `#hex` strings) with `PHASE_CLASSES` — Tailwind `text-*` classes with `dark:` variants. The SVG progress arc now uses `stroke="currentColor"`, inheriting color from the parent `<svg>` element's text color class. The track ring uses `stroke-gray-200 dark:stroke-gray-700` directly.
- **Heatmap**: Replaced the `INTENSITY_COLORS` hex array and `getIntensityColor` inline-style function with `INTENSITY_CLASSES` — Tailwind `bg-*` class strings with `dark:` variants. Cells now receive a `class` attribute rather than an inline `background-color` style.
- Updated `lib/__tests__/heatmap.test.ts` to mirror the new class-string API (`getIntensityClass` / `INTENSITY_CLASSES`).

Color mapping (light → dark):

| Level    | Light         | Dark          |
|----------|---------------|---------------|
| empty    | `gray-100` (`#F3F4F6`) | `gray-700` (`#374151`) |
| 1 tomate | `red-300` (`#FCA5A5`)  | `red-900` (`#7F1D1D`)  |
| 2–3      | `red-500` (`#EF4444`)  | `red-800` (`#991B1B`)  |
| 4–5      | `red-600` (`#DC2626`)  | `red-700` (`#B91C1C`)  |
| 6+       | `red-900` (`#991B1B`)  | `red-600` (`#DC2626`)  |

## Test plan

- [ ] `npx tsc --noEmit` — passes (0 errors)
- [ ] `npx vitest run` — 86 tests pass across 6 test files
- [ ] Visual check: popup timer ring shows correct phase color in light and dark mode
- [ ] Visual check: stats page heatmap cells use muted gray (empty) and red-scale (activity) in dark mode

Closes #182