### PR TITLE
fix: add schema version tracking to config storage with migration support

### DIFF
--- a/entrypoints/__tests__/options.test.ts
+++ b/entrypoints/__tests__/options.test.ts
@@ -31,6 +31,7 @@ const buildConfig = (
   playCompletionSound: boolean,
   extra: Partial<TimerConfig> = {},
 ): TimerConfig => ({
+  configVersion: DEFAULT_CONFIG.configVersion,
   dailyGoal: DEFAULT_CONFIG.dailyGoal,
   ...extra,
   workDuration: work * MS_PER_MINUTE,

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -101,7 +101,7 @@ describe('storage helpers', () => {
     expect(result.dailyGoal).toBe(DEFAULT_CONFIG.dailyGoal);
     expect(result.openBreakTab).toBe(DEFAULT_CONFIG.openBreakTab);
     // Version bumped to current
-    expect(result.configVersion).toBe(2);
+    expect(result.configVersion).toBe(DEFAULT_CONFIG.configVersion);
   });
 
   it('fills defaults for configs with an explicit configVersion of 1', async () => {
@@ -117,7 +117,7 @@ describe('storage helpers', () => {
 
     expect(result.dailyGoal).toBe(DEFAULT_CONFIG.dailyGoal);
     expect(result.openBreakTab).toBe(DEFAULT_CONFIG.openBreakTab);
-    expect(result.configVersion).toBe(2);
+    expect(result.configVersion).toBe(DEFAULT_CONFIG.configVersion);
   });
 
   it('returns a v2 config unchanged', async () => {

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -82,6 +82,51 @@ describe('storage helpers', () => {
     await expect(getConfig()).resolves.toEqual(config);
   });
 
+  it('fills defaults for v1 configs that are missing new fields', async () => {
+    // Simulate a stored v1 config (only the original 3 fields, no configVersion)
+    const v1Config = {
+      workDuration: 30 * 60 * 1000,
+      shortBreakDuration: 5 * 60 * 1000,
+      longBreakDuration: 20 * 60 * 1000,
+    };
+    await fakeBrowser.storage.local.set({ config: v1Config });
+
+    const result = await getConfig();
+
+    // Preserved v1 user-customised values
+    expect(result.workDuration).toBe(30 * 60 * 1000);
+    expect(result.shortBreakDuration).toBe(5 * 60 * 1000);
+    expect(result.longBreakDuration).toBe(20 * 60 * 1000);
+    // New v2 fields filled with defaults
+    expect(result.dailyGoal).toBe(DEFAULT_CONFIG.dailyGoal);
+    expect(result.openBreakTab).toBe(DEFAULT_CONFIG.openBreakTab);
+    // Version bumped to current
+    expect(result.configVersion).toBe(2);
+  });
+
+  it('fills defaults for configs with an explicit configVersion of 1', async () => {
+    const v1Config = {
+      configVersion: 1,
+      workDuration: 25 * 60 * 1000,
+      shortBreakDuration: 5 * 60 * 1000,
+      longBreakDuration: 30 * 60 * 1000,
+    };
+    await fakeBrowser.storage.local.set({ config: v1Config });
+
+    const result = await getConfig();
+
+    expect(result.dailyGoal).toBe(DEFAULT_CONFIG.dailyGoal);
+    expect(result.openBreakTab).toBe(DEFAULT_CONFIG.openBreakTab);
+    expect(result.configVersion).toBe(2);
+  });
+
+  it('returns a v2 config unchanged', async () => {
+    const v2Config = createConfig({ dailyGoal: 10, openBreakTab: false });
+    await setConfig(v2Config);
+
+    await expect(getConfig()).resolves.toEqual(v2Config);
+  });
+
   it('adds a completed session and returns it from history', async () => {
     const session = createSession(new Date(2026, 2, 15, 9, 0, 0).getTime());
 

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -245,6 +245,7 @@ describe('timer state machine', () => {
 
   it('uses the default 25/5/30 minute config values', () => {
     expect(DEFAULT_CONFIG).toEqual({
+      configVersion: 2,
       workDuration: 25 * 60 * 1000,
       shortBreakDuration: 5 * 60 * 1000,
       longBreakDuration: 30 * 60 * 1000,

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -47,7 +47,19 @@ export const setTimerState = async (state: TimerState): Promise<void> => {
 
 export const getConfig = async (): Promise<TimerConfig> => {
   const stored = await getStoredValue<Partial<TimerConfig>>(KEYS.CONFIG);
-  return stored ? { ...DEFAULT_CONFIG, ...stored } : DEFAULT_CONFIG;
+
+  if (!stored) {
+    return DEFAULT_CONFIG;
+  }
+
+  // v1 configs are missing configVersion (and any fields added in v2+).
+  // Merge stored values on top of DEFAULT_CONFIG so every new field gets its
+  // default while any value the user already customised is preserved.
+  if (!stored.configVersion || stored.configVersion < DEFAULT_CONFIG.configVersion) {
+    return { ...DEFAULT_CONFIG, ...stored, configVersion: DEFAULT_CONFIG.configVersion };
+  }
+
+  return { ...DEFAULT_CONFIG, ...stored };
 };
 
 export const setConfig = async (config: TimerConfig): Promise<void> => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,7 @@
 export type TimerPhase = 'IDLE' | 'WORKING' | 'SHORT_BREAK' | 'LONG_BREAK' | 'BREAK_SUGGESTION';
 
 export type TimerConfig = {
+  configVersion: number;
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;
@@ -29,6 +30,7 @@ export type CompletedSession = {
 };
 
 export const DEFAULT_CONFIG: TimerConfig = {
+  configVersion: 2,
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
   longBreakDuration: 30 * 60 * 1000,


### PR DESCRIPTION
## Summary

- Adds `configVersion: number` to `TimerConfig` and `DEFAULT_CONFIG` (current version is `2`)
- `getConfig()` detects legacy stored configs (missing or outdated `configVersion`) and fills in missing fields from `DEFAULT_CONFIG` before returning
- Migration uses `DEFAULT_CONFIG.configVersion` as the single source of truth — no hardcoded version literals in migration logic
- Tests cover: no-version legacy config migration, explicit v1 config migration, and v2 pass-through

## Test plan

- [ ] `npx vitest run lib/__tests__/storage.test.ts` — 13 tests pass
- [ ] Install an older build, upgrade, open extension — new config fields default correctly
- [ ] Existing custom settings (work duration, break duration) are preserved after upgrade

Closes #126