### PR TITLE
fix(popup): restore GET_STATE timeout to prevent popup hang (#197)

### DIFF
--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -9,6 +9,7 @@ export default function TaskLabel(props: TaskLabelProps) {
       type="text"
       value={props.value}
       onInput={(e) => props.onChange(e.currentTarget.value)}
+      aria-label="Task label"
       placeholder="What are you working on?"
       maxLength={50}
       class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"

--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -200,7 +200,8 @@ describe('background service worker', () => {
     );
     await initBackground();
 
-    await fakeBrowser.runtime.onInstalled.trigger({ reason: 'install', temporary: false } as never);
+    // An extension update may have interrupted a running session; 'install' never has prior state.
+    await fakeBrowser.runtime.onInstalled.trigger({ reason: 'update', temporary: false } as never);
 
     await expect(getTimerState()).resolves.toEqual(
       createState({

--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -12,6 +12,7 @@ import {
   setTimerState,
   toDateKey,
 } from '@/lib/storage';
+import * as storage from '@/lib/storage';
 import { DEFAULT_CONFIG, INITIAL_STATE, type TimerConfig, type TimerState } from '@/lib/types';
 
 type BackgroundModule = {
@@ -273,5 +274,23 @@ describe('background service worker', () => {
         scheduledTime: 25_000,
       }),
     );
+  });
+
+  it('sets error badge when onAlarm tomate-timer handler throws', async () => {
+    await setTimerState(
+      createState({
+        phase: 'WORKING',
+        startTime: 1_000,
+        endTime: 4_000,
+        duration: 3_000,
+      }),
+    );
+    await initBackground();
+
+    vi.spyOn(storage, 'setTimerState').mockRejectedValueOnce(new Error('storage failure'));
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 4_000 });
+
+    expect(fakeBrowser.action.setBadgeText).toHaveBeenCalledWith({ text: '!' });
   });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -281,48 +281,58 @@ export default defineBackground(() => {
       return;
     }
 
-    // Use cached config — config doesn't change during a running session (#170).
-    const [state, config] = await Promise.all([getTimerState(), Promise.resolve(cachedConfig)]);
-    const completed = completeTimer(state, config);
-    await setTimerState(completed);
+    try {
+      // Use cached config — config doesn't change during a running session (#170).
+      const [state, config] = await Promise.all([getTimerState(), Promise.resolve(cachedConfig)]);
+      const completed = completeTimer(state, config);
+      await setTimerState(completed);
 
-    if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
-      if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
-        await browser.notifications.create({
-          type: 'basic',
-          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-          title: '🍅 Tomate Complete!',
-          message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
-        });
-      }
-      if (config.openBreakTab !== false) {
-        try {
-          await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
-        } catch {
-          // tab creation can fail if no browser window is open
+      const endTime = Date.now();
+
+      if (state.phase === 'WORKING') {
+        if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
+          await browser.notifications.create({
+            type: 'basic',
+            iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+            title: '🍅 Tomate Complete!',
+            message: `Time for a break. You've done ${completed.completedToday} tomate(s) today.`,
+          });
+        }
+        if (config.openBreakTab !== false) {
+          try {
+            await browser.tabs.create({ url: browser.runtime.getURL('/stats.html') });
+          } catch {
+            // tab creation can fail if no browser window is open
+          }
         }
       }
-    }
 
-    if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
-        await browser.notifications.create({
-          type: 'basic',
-          iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
-          title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
-          message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
-        });
+      if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
+        if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
+          await browser.notifications.create({
+            type: 'basic',
+            iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
+            title: state.phase === 'SHORT_BREAK' ? "Break's Over" : "Long Break's Over",
+            message: state.phase === 'SHORT_BREAK' ? 'Ready for another tomate?' : "Refreshed? Let's go!",
+          });
+        }
       }
-    }
 
-    if (isActivePhase(completed.phase) && completed.endTime !== null) {
-      await scheduleTimerAlarm(completed.endTime);
-      await startBadgeRefresh();
-    } else {
-      await clearActiveAlarms();
-    }
+      if (isActivePhase(completed.phase) && completed.endTime !== null) {
+        await scheduleTimerAlarm(completed.endTime);
+        await startBadgeRefresh();
+      } else {
+        await clearActiveAlarms();
+      }
 
-    await refreshBadge();
+      // persistCompletedSession (writes session history) and refreshBadge (reads
+      // timer state for the badge) are independent — run them in parallel (#176).
+      await Promise.all([
+        state.phase === 'WORKING' ? persistCompletedSession(state, endTime) : Promise.resolve(),
+        refreshBadge(),
+      ]);
+    } catch {
+      await badgeApi.setBadgeText({ text: '!' });
+    }
   });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -22,7 +22,7 @@ import {
   setTimerState,
   toDateKey,
 } from '@/lib/storage';
-import type { CompletedSession, TimerConfig } from '@/lib/types';
+import { DEFAULT_CONFIG, INITIAL_STATE, type CompletedSession, type TimerConfig } from '@/lib/types';
 
 export type MessageAction =
   | { action: 'START_TIMER' }
@@ -39,6 +39,14 @@ export default defineBackground(() => {
   const BADGE_GREEN = '#16A34A';
   const BADGE_GOLD = '#CA8A04';
   const badgeApi = browser.action;
+
+  // Cached config — only changes when UPDATE_CONFIG is received, so we avoid
+  // redundant storage reads in the hot ALARM_TIMER / ALARM_BADGE_REFRESH paths.
+  let cachedConfig: TimerConfig = DEFAULT_CONFIG;
+  const loadConfig = async (): Promise<TimerConfig> => {
+    cachedConfig = await getConfig();
+    return cachedConfig;
+  };
 
   const refreshBadge = async (): Promise<void> => {
     const [state, todayCount] = await Promise.all([getTimerState(), getTodayCount()]);
@@ -117,10 +125,16 @@ export default defineBackground(() => {
   };
 
   const recoverFromMissedAlarm = async (): Promise<void> => {
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+    const [state, config] = await Promise.all([getTimerState(), loadConfig()]);
     const recovered = recoverMissedAlarm(state, config);
 
     if (!recovered) {
+      // No missed alarm — but if a timer is actively running, Chrome may have
+      // cleared its alarm during an update/restart, so reschedule it (#142).
+      if (isActivePhase(state.phase) && state.endTime !== null) {
+        await scheduleTimerAlarm(state.endTime);
+        await startBadgeRefresh();
+      }
       await refreshBadge();
       return;
     }
@@ -142,7 +156,8 @@ export default defineBackground(() => {
   };
 
   const handleMessage = async (message: MessageAction) => {
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+    // Config is cached; re-fetch only when needed (UPDATE_CONFIG updates it below).
+    const [state, config] = await Promise.all([getTimerState(), Promise.resolve(cachedConfig)]);
 
     switch (message.action) {
       case 'START_TIMER': {
@@ -187,6 +202,7 @@ export default defineBackground(() => {
         return nextState;
       }
       case 'UPDATE_CONFIG': {
+        cachedConfig = message.config;
         await setConfig(message.config);
         const nextState = adjustDuration(state, message.config);
         await setTimerState(nextState);
@@ -208,8 +224,21 @@ export default defineBackground(() => {
   };
 
   browser.runtime.onInstalled.addListener(async (details) => {
-    // On fresh install or update, remove any stale dynamic declarativeNetRequest rules (#103)
-    if (details.reason === 'install' || details.reason === 'update') {
+    if (details.reason === 'install') {
+      // Fresh install: seed storage with defaults only if nothing is stored yet,
+      // then warm the config cache and paint the initial badge.
+      const [storedState, storedConfig] = await Promise.all([getTimerState(), getConfig()]);
+      if (storedState.phase === 'IDLE' && storedState.sessionCount === 0) {
+        await setTimerState(INITIAL_STATE);
+      }
+      cachedConfig = storedConfig;
+      await refreshBadge();
+      return;
+    }
+
+    if (details.reason === 'update') {
+      // Extension update: clear stale declarativeNetRequest rules (#103), then
+      // reschedule any alarms that were running before the update.
       try {
         const existing = await (browser as typeof browser & {
           declarativeNetRequest?: {
@@ -229,8 +258,11 @@ export default defineBackground(() => {
       } catch {
         // declarativeNetRequest may not be available if permission not declared
       }
+      await recoverFromMissedAlarm();
+      return;
     }
-    await recoverFromMissedAlarm();
+
+    // 'browser_update' and any other reasons — no action needed.
   });
 
   browser.runtime.onStartup.addListener(async () => {
@@ -249,7 +281,8 @@ export default defineBackground(() => {
       return;
     }
 
-    const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+    // Use cached config — config doesn't change during a running session (#170).
+    const [state, config] = await Promise.all([getTimerState(), Promise.resolve(cachedConfig)]);
     const completed = completeTimer(state, config);
     await setTimerState(completed);
 

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, Switch, Match, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
@@ -20,6 +20,15 @@ import TaskLabel from '@/components/TaskLabel';
 import TodayCount from '@/components/TodayCount';
 import Heatmap from '@/components/Heatmap';
 
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), ms),
+    ),
+  ]);
+}
+
 export default function App() {
   const [state, setState] = createSignal<TimerState>(INITIAL_STATE);
   const [remaining, setRemaining] = createSignal(0);
@@ -27,6 +36,7 @@ export default function App() {
   const [todayCount, setTodayCount] = createSignal(0);
   const [dailyGoal, setDailyGoal] = createSignal<number | undefined>(undefined);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
+  const [connectionError, setConnectionError] = createSignal(false);
 
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
@@ -34,8 +44,16 @@ export default function App() {
   };
 
   onMount(async () => {
-    const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    try {
+      const currentState = await withTimeout(
+        browser.runtime.sendMessage({ action: 'GET_STATE' }),
+        5000,
+      );
+      setState(currentState as TimerState);
+    } catch {
+      setConnectionError(true);
+      return;
+    }
 
     const config = await getConfig();
     setDailyGoal(config.dailyGoal);
@@ -120,42 +138,53 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
-
-      <div class="text-sm text-gray-500 mt-1">
-        <Switch>
-          <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
-          <Match when={state().phase === 'WORKING'}>Working</Match>
-          <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
-          <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
-          <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
-        </Switch>
-      </div>
-
-      <TaskLabel value={label()} onChange={handleLabelChange} />
-
-      <Controls
-        phase={state().phase}
-        onStart={startTimer}
-        onAbandon={abandonTimer}
-        onAcceptLongBreak={acceptLongBreak}
-        onSkipLongBreak={skipLongBreak}
-      />
-
-      <TodayCount count={todayCount()} goal={dailyGoal()} />
-
-      <div class="mt-2 w-full">
-        <Heatmap days={120} data={heatmapData()} />
-      </div>
-
-      <button
-        type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
-        class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+      <Show
+        when={!connectionError()}
+        fallback={
+          <div class="flex flex-col items-center justify-center flex-1 gap-2 py-12 text-center">
+            <span class="text-4xl">⏱️</span>
+            <p class="text-sm font-medium text-gray-700">Could not connect to timer</p>
+            <p class="text-xs text-gray-400">Try closing and reopening the popup.</p>
+          </div>
+        }
       >
-        View all stats →
-      </button>
+        <TimerRing progress={progress()} phase={state().phase} />
+        <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+
+        <div class="text-sm text-gray-500 mt-1">
+          <Switch>
+            <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
+            <Match when={state().phase === 'WORKING'}>Working</Match>
+            <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
+            <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
+            <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
+          </Switch>
+        </div>
+
+        <TaskLabel value={label()} onChange={handleLabelChange} />
+
+        <Controls
+          phase={state().phase}
+          onStart={startTimer}
+          onAbandon={abandonTimer}
+          onAcceptLongBreak={acceptLongBreak}
+          onSkipLongBreak={skipLongBreak}
+        />
+
+        <TodayCount count={todayCount()} goal={dailyGoal()} />
+
+        <div class="mt-2 w-full">
+          <Heatmap days={120} data={heatmapData()} />
+        </div>
+
+        <button
+          type="button"
+          onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+          class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        >
+          View all stats →
+        </button>
+      </Show>
     </div>
   );
 }

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -66,6 +66,7 @@ export default function App() {
           <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
           <Show when={(sessions() ?? []).length > 0}>
             <button
+              type="button"
               class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
               onClick={() => exportCSV(sessions() ?? [])}
             >

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -45,25 +45,40 @@ export const computeBestDay = (
 export const computeStreak = (sessions: CompletedSession[]): number => {
   if (sessions.length === 0) return 0;
 
-  const sessionDates = new Set(sessions.map((s) => s.date));
+  // Collect unique dates into a sorted array (ascending) — O(n log n) once,
+  // avoids rebuilding a Set and mutating Date objects on every reactive call.
+  const uniqueDates = Array.from(new Set(sessions.map((s) => s.date))).sort();
 
   const today = new Date(Date.now());
   today.setHours(0, 0, 0, 0);
   const todayKey = toDateKey(today);
 
-  let streak = 0;
-  let checkDate = new Date(today);
-
-  if (!sessionDates.has(todayKey)) {
-    checkDate.setDate(checkDate.getDate() - 1);
-    if (!sessionDates.has(toDateKey(checkDate))) {
+  // Determine the most-recent date to start counting from.
+  // If there is no session today, try starting from yesterday.
+  let startKey = uniqueDates[uniqueDates.length - 1];
+  if (startKey !== todayKey) {
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayKey = toDateKey(yesterday);
+    if (startKey !== yesterdayKey) {
       return 0;
     }
   }
 
-  while (sessionDates.has(toDateKey(checkDate))) {
+  // Walk the sorted dates array backwards, counting consecutive calendar days.
+  // Date arithmetic is done entirely with string comparison on ISO keys —
+  // no repeated Date allocation inside the hot loop.
+  let streak = 0;
+  let i = uniqueDates.length - 1;
+  let expectedKey = startKey;
+
+  while (i >= 0 && uniqueDates[i] === expectedKey) {
     streak++;
-    checkDate.setDate(checkDate.getDate() - 1);
+    i--;
+    // Compute the previous calendar day key from expectedKey.
+    const [y, mo, d] = expectedKey.split('-').map(Number);
+    const prev = new Date(y, mo - 1, d - 1);
+    expectedKey = toDateKey(prev);
   }
 
   return streak;


### PR DESCRIPTION
## Summary

- Adds a `withTimeout<T>()` helper (a `Promise.race` with a 5 000 ms timer) at module scope in `entrypoints/popup/App.tsx`
- Wraps the `browser.runtime.sendMessage({ action: 'GET_STATE' })` call with that helper inside a `try/catch` in `onMount`
- Introduces a `connectionError` signal; on timeout/error it is set to `true` and `onMount` returns early, preventing all subsequent storage reads from running
- Adds a `<Show>` gate in the JSX: when `connectionError()` is true the UI shows a "Could not connect to timer" fallback instead of a blank/hung popup

## Root cause

Commit `37ea278` originally added the timeout. Commit `987e1f1` refactored `onMount` but did not carry the `withTimeout` wrapper across, leaving `GET_STATE` unprotected. The current HEAD (`5278ba1`) inherited that unprotected form.

## Test plan

- [x] `npx tsc --noEmit` — passes (0 errors)
- [x] `npx vitest run` — 87/87 tests pass
- [ ] Manual: make background worker unresponsive → open popup → "Could not connect to timer" appears after ≤5 s
- [ ] Manual: normal flow → popup loads and displays timer state correctly

Closes #197