### PR TITLE
fix: delay URL.revokeObjectURL to after async download starts

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -41,8 +41,10 @@ function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
   const a = document.createElement('a');
   a.href = url;
   a.download = `tomate-sessions-${new Date().toISOString().slice(0, 10)}.csv`;
+  document.body.appendChild(a);
   a.click();
-  URL.revokeObjectURL(url);
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 export default function App() {


### PR DESCRIPTION
## Summary

- Wraps `URL.revokeObjectURL(url)` in `setTimeout(..., 100)` so the browser has time to initiate the download before the blob is released
- Also appends the anchor element to `document.body` before clicking and removes it after, which is required in some browsers for programmatic downloads to work reliably

## Root cause

`URL.revokeObjectURL()` was called synchronously immediately after `a.click()`. Since the browser download is asynchronous, the blob URL was revoked before the browser could read the blob data, causing downloads to fail or produce empty files.

## Test plan

- [ ] Click "Export CSV" on the stats page with at least one session recorded
- [ ] Verify the file downloads successfully and contains the expected CSV data
- [ ] Verify the file is not empty or corrupted

Closes #282