### PR TITLE
a11y: make TimerRing SVG title reflect current phase and remaining time

### DIFF
--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -3,7 +3,23 @@ import type { TimerPhase } from '@/lib/types';
 type TimerRingProps = {
   progress: number;
   phase: TimerPhase;
+  remaining: number;
 };
+
+const PHASE_LABELS: Record<TimerPhase, string> = {
+  IDLE: 'Idle',
+  WORKING: 'Working',
+  SHORT_BREAK: 'Short break',
+  LONG_BREAK: 'Long break',
+  BREAK_SUGGESTION: 'Break suggestion',
+};
+
+function formatRemaining(ms: number): string {
+  const totalSeconds = Math.ceil(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
 
 const PHASE_COLORS: Record<TimerPhase, string> = {
   IDLE: '#9CA3AF',
@@ -21,10 +37,21 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 export default function TimerRing(props: TimerRingProps) {
   const offset = () => CIRCUMFERENCE * (1 - props.progress);
   const color = () => PHASE_COLORS[props.phase];
+  const titleText = () => {
+    const label = PHASE_LABELS[props.phase];
+    if (props.phase === 'IDLE') return label;
+    return `${label} – ${formatRemaining(props.remaining)} remaining`;
+  };
 
   return (
-    <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      <title>Timer progress</title>
+    <svg
+      width={SIZE}
+      height={SIZE}
+      class="timer-ring"
+      viewBox={`0 0 ${SIZE} ${SIZE}`}
+      aria-labelledby="timer-ring-title"
+    >
+      <title id="timer-ring-title">{titleText()}</title>
       <circle
         cx={SIZE / 2}
         cy={SIZE / 2}

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -120,7 +120,7 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
+      <TimerRing progress={progress()} phase={state().phase} remaining={remaining()} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
       <div class="text-sm text-gray-500 mt-1">


### PR DESCRIPTION
## Summary

- Added a `remaining` prop (ms) to `TimerRing` so the SVG title can reflect live timer state
- Replaced the static `<title>Timer progress</title>` with a dynamic accessor: `"Idle"` when idle, or `"Working – 23:45 remaining"` / `"Short break – 04:12 remaining"` etc. when active
- Added `aria-labelledby="timer-ring-title"` to the `<svg>` element pointing to the `<title id>` for proper screen-reader association
- Updated `entrypoints/popup/App.tsx` to forward `remaining()` to `<TimerRing>`

## Test plan

- [ ] With a screen reader (VoiceOver / NVDA), focus the timer ring while the timer is running — it should announce e.g. "Working – 23:45 remaining"
- [ ] While idle, it should announce "Idle"
- [ ] During a break phase, it should announce "Short break – 04:12 remaining" (or Long break)
- [ ] The title text updates each second as the timer ticks
- [ ] `npx tsc --noEmit` passes with no errors

Closes #233