### PR TITLE
a11y: make heatmap cells keyboard-focusable and add legend text alternatives

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -22,6 +22,15 @@ const INTENSITY_COLORS = [
 
 const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', ''] as const;
 
+const FULL_DAY_NAMES = [
+  'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
+] as const;
+
+const FULL_MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+] as const;
+
 const MONTH_NAMES = [
   'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
@@ -125,6 +134,16 @@ export default function Heatmap(props: HeatmapProps) {
     return `${label} on ${cell.date}`;
   };
 
+  const ariaLabel = (cell: HeatmapCell) => {
+    const [year, month, day] = cell.date.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+    const dayName = FULL_DAY_NAMES[date.getDay()];
+    const monthName = FULL_MONTH_NAMES[month - 1];
+    const count = cell.count;
+    const sessionLabel = count === 0 ? 'no sessions' : `${count} session${count !== 1 ? 's' : ''}`;
+    return `${dayName} ${monthName} ${day} ${year}: ${sessionLabel}`;
+  };
+
   const labelWidth = 24;
 
   return (
@@ -175,6 +194,8 @@ export default function Heatmap(props: HeatmapProps) {
 
         {/* Heatmap cells - CSS Grid: 7 rows, auto columns */}
         <div
+          role="grid"
+          aria-label="Activity heatmap"
           class="grid"
           style={{
             "grid-template-rows": `repeat(7, ${cellSize()}px)`,
@@ -189,13 +210,16 @@ export default function Heatmap(props: HeatmapProps) {
                 {(cell) =>
                   cell ? (
                     <div
-                      class="rounded-sm"
+                      class="rounded-sm focus:outline focus:outline-2 focus:outline-offset-1 focus:outline-red-500"
                       style={{
                         width: `${cellSize()}px`,
                         height: `${cellSize()}px`,
                         "background-color": getIntensityColor(cell.count),
                       }}
+                      role="gridcell"
+                      tabIndex={0}
                       title={tooltipText(cell)}
+                      aria-label={ariaLabel(cell)}
                     />
                   ) : (
                     <div

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -120,13 +120,18 @@ export default function App() {
             <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
             <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
 
-            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
+            <div
+              class="flex items-center gap-1 mt-3 text-[10px] text-gray-400"
+              role="group"
+              aria-label="Session intensity legend: Less to More"
+            >
               <span>Less</span>
               <For each={INTENSITY_LEGEND}>
                 {(item) => (
                   <div
                     class="w-3 h-3 rounded-sm"
                     style={{ "background-color": item.color }}
+                    aria-hidden="true"
                     title={item.label}
                   />
                 )}


### PR DESCRIPTION
## Summary

- **#229**: Day cells in `components/Heatmap.tsx` now have `tabIndex={0}`, `role="gridcell"`, and a descriptive `aria-label` (e.g. "Monday April 7 2026: 3 sessions"). The wrapping grid div has `role="grid"` and `aria-label="Activity heatmap"`. A visible focus ring (`focus:outline-red-500`) is also added.
- **#230**: The color intensity legend swatches in `entrypoints/stats/App.tsx` now have `aria-hidden="true"` (they are purely decorative). The surrounding container has `role="group"` and `aria-label="Session intensity legend: Less to More"`, so screen readers announce the legend context once using the visible "Less" / "More" text labels already present.

## Test plan

- [ ] Tab through the heatmap — each day cell receives focus and a screen reader announces e.g. "Wednesday April 12 2026: 5 sessions"
- [ ] The focused cell shows a red outline ring
- [ ] Navigate to the stats page with a screen reader — the legend group is announced as "Session intensity legend: Less to More"; the colored swatches are skipped
- [ ] `npx tsc --noEmit` passes with no errors

Closes #229
Closes #230