### PR TITLE
a11y: hide arrow glyph from screen readers in stats link

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -154,7 +154,7 @@ export default function App() {
         onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
         class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
       >
-        View all stats →
+        View all stats <span aria-hidden="true">→</span>
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary

- Wraps the `→` decorative arrow in `<span aria-hidden="true">` in the "View all stats" button in `entrypoints/popup/App.tsx`
- Screen readers will now announce "View all stats" instead of "View all stats right arrow" or similar confusing output
- Visual appearance is unchanged

## Test plan

- [ ] Open the popup with a screen reader (VoiceOver / NVDA / JAWS) and navigate to the "View all stats" button — confirm it announces "View all stats" with no arrow character
- [ ] Visually confirm the `→` arrow still appears next to the button text
- [ ] Run `npx tsc --noEmit` — no new type errors

Closes #234