### PR TITLE
fix: add dark mode color variants to options page

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -77,44 +77,44 @@ export default function App() {
   };
 
   return (
-    <div class="min-h-screen bg-red-50 flex items-start justify-center pt-16">
-      <div class="w-full max-w-[400px] bg-white rounded-lg shadow-sm p-6">
+    <div class="min-h-screen bg-red-50 dark:bg-gray-900 flex items-start justify-center pt-16">
+      <div class="w-full max-w-[400px] bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
         <h1 class="text-xl font-bold text-red-600 mb-6">Tomate Settings</h1>
 
         <div class="space-y-4">
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Work Duration (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Work Duration (minutes)</span>
             <input
               type="number"
               min={1}
               max={120}
               value={work()}
               onInput={(e) => setWork(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Short Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Short Break (minutes)</span>
             <input
               type="number"
               min={1}
               max={30}
               value={shortBreak()}
               onInput={(e) => setShortBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
 
           <label class="block">
-            <span class="text-sm font-medium text-gray-700">Long Break (minutes)</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Long Break (minutes)</span>
             <input
               type="number"
               min={5}
               max={60}
               value={longBreak()}
               onInput={(e) => setLongBreak(Number(e.currentTarget.value))}
-              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
             />
           </label>
 
@@ -123,9 +123,9 @@ export default function App() {
               type="checkbox"
               checked={openBreakTab()}
               onChange={(e) => setOpenBreakTab(e.currentTarget.checked)}
-              class="w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500"
             />
-            <span class="text-sm font-medium text-gray-700">Open stats tab when session completes</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Open stats tab when session completes</span>
           </label>
 
           <label class="flex items-center gap-3 cursor-pointer">
@@ -133,9 +133,9 @@ export default function App() {
               type="checkbox"
               checked={playCompletionSound()}
               onChange={(e) => setPlayCompletionSound(e.currentTarget.checked)}
-              class="w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+              class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500"
             />
-            <span class="text-sm font-medium text-gray-700">Play completion sound</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Play completion sound</span>
           </label>
         </div>
 
@@ -152,7 +152,7 @@ export default function App() {
           <button
             type="button"
             onClick={handleReset}
-            class="text-sm text-gray-500 hover:text-gray-700 underline"
+            class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline"
           >
             Reset to defaults
           </button>


### PR DESCRIPTION
## Summary

- Added `dark:` Tailwind variants to all hardcoded light-mode color classes in `entrypoints/options/App.tsx`
- Page background: `bg-red-50` → `dark:bg-gray-900`
- Card background: `bg-white` → `dark:bg-gray-800`
- Label text: `text-gray-700` → `dark:text-gray-300`
- Input borders: `border-gray-300` → `dark:border-gray-600`
- Input backgrounds: added `bg-white dark:bg-gray-900`
- Input text: added `text-gray-900 dark:text-gray-100`
- Checkbox borders: `border-gray-300` → `dark:border-gray-600`
- Reset button: `text-gray-500` → `dark:text-gray-400`, hover `dark:hover:text-gray-200`
- Accent/brand colors (`bg-red-*`, `text-red-*`, `focus:ring-red-*`, `text-green-600`) left unchanged

## Test plan

- [ ] Open options page in a browser with dark mode enabled; verify all text, inputs, and backgrounds render correctly
- [ ] Open options page in light mode; verify no visual regressions
- [ ] Save and reset still function correctly in both modes

Closes #206