### PR TITLE
fix: add dark mode color variants to popup

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -26,7 +26,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-6 py-2.5 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 font-semibold rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 transition-colors"
           >
             Abandon
           </button>
@@ -35,7 +35,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onAbandon}
-            class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-6 py-2.5 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 font-semibold rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 transition-colors"
           >
             Skip Break
           </button>
@@ -51,7 +51,7 @@ export default function Controls(props: ControlsProps) {
           <button
             type="button"
             onClick={props.onSkipLongBreak}
-            class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
+            class="px-5 py-2.5 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 font-semibold rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 transition-colors"
           >
             Skip
           </button>

--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -11,7 +11,7 @@ export default function TaskLabel(props: TaskLabelProps) {
       onInput={(e) => props.onChange(e.currentTarget.value)}
       placeholder="What are you working on?"
       maxLength={50}
-      class="w-full mt-4 px-3 py-2 text-sm border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-red-300 placeholder:text-gray-400"
+      class="w-full mt-4 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-red-300 dark:focus:ring-red-700 placeholder:text-gray-400 dark:placeholder:text-gray-500"
     />
   );
 }

--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -30,8 +30,8 @@ export default function TimerRing(props: TimerRingProps) {
         cy={SIZE / 2}
         r={RADIUS}
         fill="none"
-        stroke="#E5E7EB"
         stroke-width={STROKE}
+        class="stroke-gray-200 dark:stroke-gray-700"
       />
       <circle
         cx={SIZE / 2}

--- a/components/TodayCount.tsx
+++ b/components/TodayCount.tsx
@@ -10,7 +10,7 @@ export default function TodayCount(props: TodayCountProps) {
     props.goal != null ? ` / ${props.goal}` : '';
 
   return (
-    <div class="mt-4 text-sm text-gray-500">
+    <div class="mt-4 text-sm text-gray-500 dark:text-gray-400">
       <span>
         🍅 {props.count}{goalText()} tomate{props.count !== 1 ? 's' : ''} today
       </span>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -107,13 +107,13 @@ export default function App() {
   };
 
   return (
-    <div class="w-[360px] min-h-[400px] bg-red-50 p-4 flex flex-col items-center">
+    <div class="w-[360px] min-h-[400px] bg-red-50 dark:bg-gray-900 p-4 flex flex-col items-center">
       <div class="w-full flex justify-between items-center mb-4">
         <h1 class="text-xl font-bold text-red-600">Tomate</h1>
         <button
           type="button"
           onClick={() => browser.runtime.openOptionsPage()}
-          class="text-gray-400 hover:text-gray-600 text-lg"
+          class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 text-lg"
           aria-label="Settings"
         >
           ⚙️
@@ -121,9 +121,9 @@ export default function App() {
       </div>
 
       <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+      <div class="text-4xl font-mono font-bold text-gray-800 dark:text-gray-100 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
+      <div class="text-sm text-gray-500 dark:text-gray-400 mt-1">
         <Switch>
           <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
           <Match when={state().phase === 'WORKING'}>Working</Match>


### PR DESCRIPTION
## Summary

- Add `dark:` Tailwind variants to `entrypoints/popup/App.tsx`: root background (`bg-red-50` → `dark:bg-gray-900`), timer digits, phase label, and settings gear icon
- Add `dark:` variants to `components/TaskLabel.tsx`: input background, border, text, placeholder, and focus ring
- Add `dark:` variants to `components/Controls.tsx`: all three gray secondary buttons (Abandon, Skip Break, Skip)
- Add `dark:` variant to `components/TodayCount.tsx`: count text color
- Replace hardcoded `stroke="#E5E7EB"` in `components/TimerRing.tsx` with Tailwind `stroke-gray-200 dark:stroke-gray-700` class

## Test plan

- [ ] Enable OS dark mode and open the extension popup — background should be `gray-900`, text should be light, no white-on-white or dark-on-dark contrast issues
- [ ] Verify the task label input is readable in dark mode (dark background, light text, visible focus ring)
- [ ] Verify the Abandon/Skip Break/Skip buttons render correctly in dark mode
- [ ] Verify the timer ring track circle is visible in dark mode
- [ ] Toggle OS back to light mode and confirm all light-mode colors are unchanged

Closes #210