### PR TITLE
fix: add dark mode color variants to stats page

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -141,7 +141,7 @@ export default function Heatmap(props: HeatmapProps) {
             const width = () => (nextCol() - ml.column) * (cellSize() + gap);
             return (
               <span
-                class="text-[9px] text-gray-400 inline-block overflow-hidden"
+                class="text-[9px] text-gray-400 dark:text-gray-500 inline-block overflow-hidden"
                 style={{ width: `${width()}px`, "min-width": `${width()}px` }}
               >
                 {ml.label}
@@ -164,7 +164,7 @@ export default function Heatmap(props: HeatmapProps) {
           <For each={DAY_LABELS}>
             {(label) => (
               <span
-                class="text-[9px] text-gray-400 leading-none flex items-center"
+                class="text-[9px] text-gray-400 dark:text-gray-500 leading-none flex items-center"
                 style={{ height: `${cellSize()}px` }}
               >
                 {label}

--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -21,10 +21,10 @@ type StatCardProps = {
 
 function StatCard(props: StatCardProps) {
   return (
-    <div class="bg-white rounded-xl p-4 shadow-sm border border-red-100 flex flex-col items-center gap-1">
+    <div class="bg-white dark:bg-gray-900 rounded-xl p-4 shadow-sm border border-red-100 dark:border-red-900 flex flex-col items-center gap-1">
       <span class="text-2xl font-bold text-red-600">{props.value}</span>
-      <span class="text-xs text-gray-500 font-medium">{props.label}</span>
-      {props.sublabel && <span class="text-[10px] text-gray-400">{props.sublabel}</span>}
+      <span class="text-xs text-gray-500 dark:text-gray-400 font-medium">{props.label}</span>
+      {props.sublabel && <span class="text-[10px] text-gray-400 dark:text-gray-500">{props.sublabel}</span>}
     </div>
   );
 }
@@ -60,7 +60,7 @@ export default function App() {
   const streak = () => computeStreak(sessions() ?? []);
 
   return (
-    <div class="min-h-screen bg-red-50 py-10 px-4">
+    <div class="min-h-screen bg-red-50 dark:bg-gray-950 py-10 px-4">
       <div class="max-w-[800px] mx-auto">
         <div class="flex items-center justify-between mb-6">
           <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
@@ -97,12 +97,12 @@ export default function App() {
             />
           </div>
 
-          <div class="bg-white rounded-xl p-4 shadow-sm border border-red-100 mb-6">
+          <div class="bg-white dark:bg-gray-900 rounded-xl p-4 shadow-sm border border-red-100 dark:border-red-900 mb-6">
             <div class="flex items-center justify-between mb-2">
-              <span class="text-sm font-semibold text-gray-700">Daily Goal</span>
-              <span class="text-xs text-gray-500">{todayCount() ?? 0} / {dailyGoal()}</span>
+              <span class="text-sm font-semibold text-gray-700 dark:text-gray-300">Daily Goal</span>
+              <span class="text-xs text-gray-500 dark:text-gray-400">{todayCount() ?? 0} / {dailyGoal()}</span>
             </div>
-            <div class="w-full bg-gray-200 rounded-full h-2.5">
+            <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5">
               <div
                 class="h-2.5 rounded-full transition-all duration-300"
                 style={{
@@ -116,11 +116,11 @@ export default function App() {
             </Show>
           </div>
 
-          <div class="bg-white rounded-xl p-5 shadow-sm border border-red-100">
-            <h2 class="text-sm font-semibold text-gray-700 mb-3">365-day activity</h2>
+          <div class="bg-white dark:bg-gray-900 rounded-xl p-5 shadow-sm border border-red-100 dark:border-red-900">
+            <h2 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">365-day activity</h2>
             <Heatmap days={365} cellSize={14} data={yearData() ?? {}} />
 
-            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400">
+            <div class="flex items-center gap-1 mt-3 text-[10px] text-gray-400 dark:text-gray-500">
               <span>Less</span>
               <For each={INTENSITY_LEGEND}>
                 {(item) => (


### PR DESCRIPTION
## Summary

- Added `dark:` Tailwind variants to all hardcoded light-mode color classes in `entrypoints/stats/App.tsx`
- Added `dark:` variants to label text colors in `components/Heatmap.tsx`

## Changes

**`entrypoints/stats/App.tsx`:**
- Page background: `bg-red-50` → `dark:bg-gray-950`
- StatCard background: `bg-white` → `dark:bg-gray-900`
- StatCard border: `border-red-100` → `dark:border-red-900`
- StatCard label: `text-gray-500` → `dark:text-gray-400`
- StatCard sublabel: `text-gray-400` → `dark:text-gray-500`
- Daily Goal card: same `bg-white`/`border` dark variants as StatCard
- Daily Goal label: `text-gray-700` → `dark:text-gray-300`
- Daily Goal count: `text-gray-500` → `dark:text-gray-400`
- Progress bar track: `bg-gray-200` → `dark:bg-gray-700`
- Activity card: same `bg-white`/`border` dark variants
- Activity heading: `text-gray-700` → `dark:text-gray-300`
- Legend text: `text-gray-400` → `dark:text-gray-500`

**`components/Heatmap.tsx`:**
- Month labels: `text-gray-400` → `dark:text-gray-500`
- Day labels: `text-gray-400` → `dark:text-gray-500`

## Test plan

- [ ] Build extension and open stats page in a browser with dark mode enabled — all text, backgrounds, borders, and progress bar should render correctly
- [ ] Verify light mode is unchanged
- [ ] Confirm `npx tsc --noEmit` passes (no TypeScript errors)

Closes #208