### PR TITLE
feat: add empty state to stats page for first-time users

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -75,9 +75,12 @@ export default function App() {
         </div>
 
         <Show when={(sessions() ?? []).length === 0}>
-          <div class="text-center py-8 text-gray-500 dark:text-gray-400">
-            <p class="text-lg">No sessions yet</p>
-            <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
+          <div class="flex flex-col items-center justify-center py-20 text-center">
+            <span class="text-6xl mb-4" role="img" aria-label="tomato">🍅</span>
+            <h2 class="text-xl font-semibold text-gray-700 mb-2">No sessions yet</h2>
+            <p class="text-sm text-gray-500 max-w-xs">
+              Complete your first Pomodoro to see your stats here.
+            </p>
           </div>
         </Show>
 


### PR DESCRIPTION
## Summary
- Replaces the bare plain-text empty state on the stats page with a styled panel featuring a tomato emoji, a bold heading, and descriptive sub-text
- Charts, stat cards, and the daily goal bar remain hidden when there are 0 sessions (existing behaviour preserved)
- No TypeScript errors; no logic changes, purely presentational

## Test plan
- [ ] Open the stats page with no completed sessions — confirm the tomato emoji, "No sessions yet" heading, and sub-text are visible
- [ ] Complete a Pomodoro session and reload stats — confirm the empty state is gone and all charts/counters appear normally
- [ ] Export CSV button should still be hidden when sessions === 0

Closes #107