### PR TITLE
fix: guard notifications.create() with permission check

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -48,6 +48,8 @@ describe('background service worker', () => {
 
     fakeBrowser.action.setBadgeText = vi.fn().mockResolvedValue(undefined);
     fakeBrowser.action.setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+    // fake-browser does not implement permissions.contains — stub it to grant all permissions
+    fakeBrowser.permissions.contains = vi.fn().mockResolvedValue(true);
   });
 
   it('starts a timer, persists working state, and creates the timer alarm', async () => {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -255,7 +255,8 @@ export default defineBackground(() => {
 
     if (state.phase === 'WORKING') {
       await persistCompletedSession(state, Date.now());
-      if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
+      const hasNotifPermission = await browser.permissions.contains({ permissions: ['notifications'] });
+      if (hasNotifPermission) {
         await browser.notifications.create({
           type: 'basic',
           iconUrl: browser.runtime.getURL('/icons/icon-128.png'),
@@ -273,7 +274,8 @@ export default defineBackground(() => {
     }
 
     if (state.phase === 'SHORT_BREAK' || state.phase === 'LONG_BREAK') {
-      if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
+      const hasNotifPermission = await browser.permissions.contains({ permissions: ['notifications'] });
+      if (hasNotifPermission) {
         await browser.notifications.create({
           type: 'basic',
           iconUrl: browser.runtime.getURL('/icons/icon-128.png'),


### PR DESCRIPTION
## Summary

- Replaces the previous `typeof browser.notifications !== 'undefined'` runtime duck-type checks with `browser.permissions.contains({ permissions: ['notifications'] })`, which correctly reflects whether the user has actually granted the permission
- Both notification sites (WORKING session complete and SHORT/LONG break complete) are guarded by this check
- If the permission is not granted, the notification is silently skipped — no errors thrown

## Test plan

- [ ] Verify all existing tests pass (`npx vitest run`)
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)
- [ ] Manually test with notifications permission granted: notifications should appear on timer completion and break end
- [ ] Manually test with notifications permission denied: timer still completes, no notification, no errors in background console

Closes #137