### PR TITLE
fix: respect playCompletionSound config and handle audio NotAllowedError

### DIFF
--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -29,7 +29,14 @@ export const playCelebration = (type: 'work' | 'milestone' | 'break', playSound 
     try {
       new Audio(browser.runtime.getURL('/sounds/completion.mp3' as '/popup.html'))
         .play()
-        .catch(() => {});
+        .catch((err: unknown) => {
+          // Autoplay policy or muted state blocks playback — not an error worth surfacing
+          if (err instanceof DOMException && (err.name === 'NotAllowedError' || err.name === 'AbortError')) {
+            console.debug('[tomate] completion sound blocked by browser policy:', err.name);
+            return;
+          }
+          console.warn('[tomate] completion sound failed to play:', err);
+        });
     } catch {
       // Audio constructor can throw in non-browser environments
     }


### PR DESCRIPTION
## Summary

- The `playCelebration` function in `lib/celebration.ts` was silently swallowing all audio play errors via `.catch(() => {})`, including `NotAllowedError` (autoplay policy / browser-muted state) and `AbortError`
- Replace with explicit error discrimination: `NotAllowedError` and `AbortError` are logged at `console.debug` level (expected, non-fatal); all other errors fall through to `console.warn`
- The `playCompletionSound` config flag, options-page toggle, and popup wiring were already fully in place — no changes needed there

## What was already correct
- `lib/types.ts`: `playCompletionSound: boolean` in `TimerConfig` and `DEFAULT_CONFIG`
- `entrypoints/options/App.tsx`: checkbox toggle wired to read/save `playCompletionSound`
- `entrypoints/popup/App.tsx`: passes `config.playCompletionSound` to `playCelebration`
- `lib/celebration.ts`: outer `if (playSound)` guard already present

## Test plan
- [ ] With `playCompletionSound: false` in options, complete a session — no sound plays
- [ ] With `playCompletionSound: true`, complete a session — sound plays (or is blocked silently if browser autoplay is restricted)
- [ ] With browser audio muted / system volume at 0, complete a session — no crash, `NotAllowedError` logged at debug level only
- [ ] `npx tsc --noEmit` passes with no errors

Closes #105