### PR TITLE
test: add break-phase alarm recovery and partial config merge coverage

### DIFF
--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -82,6 +82,20 @@ describe('storage helpers', () => {
     await expect(getConfig()).resolves.toEqual(config);
   });
 
+  it('merges a partially-stored config with DEFAULT_CONFIG defaults', async () => {
+    const partialConfig = { workDuration: 50 * 60 * 1000 } as Partial<TimerConfig>;
+    await fakeBrowser.storage.local.set({ config: partialConfig });
+
+    const result = await getConfig();
+
+    expect(result.workDuration).toBe(50 * 60 * 1000);
+    expect(result.shortBreakDuration).toBe(DEFAULT_CONFIG.shortBreakDuration);
+    expect(result.longBreakDuration).toBe(DEFAULT_CONFIG.longBreakDuration);
+    expect(result.openBreakTab).toBe(DEFAULT_CONFIG.openBreakTab);
+    expect(result.playCompletionSound).toBe(DEFAULT_CONFIG.playCompletionSound);
+    expect(result.dailyGoal).toBe(DEFAULT_CONFIG.dailyGoal);
+  });
+
   it('adds a completed session and returns it from history', async () => {
     const session = createSession(new Date(2026, 2, 15, 9, 0, 0).getTime());
 

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -232,6 +232,58 @@ describe('timer state machine', () => {
     });
   });
 
+  it('recovers a missed alarm for a completed short break — transitions to IDLE, increments cyclePosition', () => {
+    const state = createState({
+      phase: 'SHORT_BREAK',
+      startTime: 2_000,
+      endTime: 2_500,
+      duration: 500,
+      sessionCount: 2,
+      cyclePosition: 1,
+      completedToday: 2,
+    });
+
+    expect(recoverMissedAlarm(state, DEFAULT_CONFIG, 5_000)).toEqual(
+      createState({
+        sessionCount: 2,
+        cyclePosition: 2,
+        completedToday: 2,
+      }),
+    );
+  });
+
+  it('recovers a missed alarm for a completed long break — transitions to IDLE, resets cyclePosition to 0', () => {
+    const state = createState({
+      phase: 'LONG_BREAK',
+      startTime: 3_000,
+      endTime: 4_800_000,
+      duration: 4_797_000,
+      sessionCount: 4,
+      cyclePosition: 3,
+      completedToday: 4,
+    });
+
+    expect(recoverMissedAlarm(state, DEFAULT_CONFIG, 5_000_000)).toEqual(
+      createState({
+        sessionCount: 4,
+        cyclePosition: 0,
+        completedToday: 4,
+      }),
+    );
+  });
+
+  it('returns null when recovering a missed alarm on a non-expired active timer', () => {
+    const state = createState({
+      phase: 'WORKING',
+      startTime: 1_000,
+      endTime: 10_000,
+      duration: 9_000,
+    });
+
+    // endTime (10_000) is in the future relative to now (5_000)
+    expect(recoverMissedAlarm(state, DEFAULT_CONFIG, 5_000)).toBeNull();
+  });
+
   it('returns null when recovering a missed alarm from idle', () => {
     expect(recoverMissedAlarm(createState(), DEFAULT_CONFIG, 5_000)).toBeNull();
   });


### PR DESCRIPTION
## Summary

- Adds `recoverMissedAlarm` tests for SHORT_BREAK and LONG_BREAK expired phases, verifying correct IDLE transitions (cyclePosition increments for SHORT_BREAK, resets to 0 for LONG_BREAK)
- Adds a test confirming `recoverMissedAlarm` returns `null` for a non-expired active timer (endTime in the future)
- Adds a `getConfig()` test that writes only a partial config to storage and asserts the returned value has the stored field overriding DEFAULT_CONFIG while all other fields remain at their defaults — guards against spread-order bugs

## Test plan

- [x] `lib/__tests__/timer.test.ts` — 3 new cases for `recoverMissedAlarm`
- [x] `lib/__tests__/storage.test.ts` — 1 new case for partial config merge
- [x] All 87 tests pass (`npx vitest run`)

Closes #515
Closes #517