### PR TITLE
fix: guard goalProgress against division by zero; suppress empty state during load

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -52,7 +52,10 @@ export default function App() {
   const [config] = createResource(() => getConfig());
 
   const dailyGoal = () => config()?.dailyGoal ?? 8;
-  const goalProgress = () => Math.min(100, Math.round(((todayCount() ?? 0) / dailyGoal()) * 100));
+  const goalProgress = () => {
+    if (!dailyGoal() || dailyGoal() <= 0) return 0;
+    return Math.min(100, Math.round(((todayCount() ?? 0) / dailyGoal()) * 100));
+  };
 
   const total = () => computeTotalCount(sessions() ?? []);
   const week = () => computeWeekCount(sessions() ?? []);
@@ -74,7 +77,7 @@ export default function App() {
           </Show>
         </div>
 
-        <Show when={(sessions() ?? []).length === 0}>
+        <Show when={!sessions.loading && (sessions() ?? []).length === 0}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>
             <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>


### PR DESCRIPTION
## Summary

- **#522**: `goalProgress()` now guards against division by zero — if `dailyGoal()` is `0` or falsy the function returns `0` instead of `NaN`, preventing a `NaN%` width in the progress bar style.
- **#518**: The empty-state "No sessions yet" block now checks `!sessions.loading` in addition to `sessions.length === 0`, so the flash during initial resource load is suppressed.

## Test plan

- [ ] Open Stats page with sessions present — no empty-state flash before sessions render
- [ ] Open Stats page with zero sessions — empty state appears only after load completes
- [ ] Set `dailyGoal` to `0` in storage — progress bar renders at `0%` with no `NaN`
- [ ] Normal daily-goal flow still shows correct percentage and "Daily goal reached!" message

Closes #522
Closes #518