### PR TITLE
fix: catch unhandled rejection in popup storage change listener

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -49,8 +49,9 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const storageListener = () => { refreshStats().catch(console.error); };
+    browser.storage.onChanged.addListener(storageListener);
+    onCleanup(() => browser.storage.onChanged.removeListener(storageListener));
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary

- Chrome's extension API ignores the Promise returned by async storage change listeners, causing silent unhandled rejections when `getTodayCount` or `getHeatmapData` rejects
- Replaced the direct `refreshStats` listener reference with a wrapper that calls `.catch(console.error)`, ensuring errors surface in the console rather than silently leaving the popup with stale data

## Test plan

- [ ] Open the popup while offline or with storage unavailable — errors should now appear in the extension's background console instead of being swallowed
- [ ] Normal flow: storage changes still trigger UI updates as before
- [ ] `npx tsc --noEmit` passes with no errors

Closes #520