### PR TITLE
fix: use state.endTime instead of Date.now() for recovered sessions

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -218,7 +218,7 @@ describe('background service worker', () => {
         id: expect.any(String),
         label: 'Recovered work',
         startTime: 1_000,
-        endTime: 10_000,
+        endTime: 2_000,
         date: toDateKey(1_000),
         duration: 1_000,
       },

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -128,7 +128,7 @@ export default defineBackground(() => {
     await setTimerState(recovered);
 
     if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
+      await persistCompletedSession(state, state.endTime ?? Date.now());
     }
 
     if (recovered.phase === 'SHORT_BREAK' && recovered.endTime !== null) {


### PR DESCRIPTION
## Summary

- In `recoverFromMissedAlarm`, `persistCompletedSession` was called with `Date.now()` as the session `endTime`
- If Chrome was closed during a WORKING session, the recovered session's stored duration included all offline time (e.g. a 25-min session appeared as 2h25m if Chrome was closed for 2 hours)
- Fix uses `state.endTime` (the actual scheduled alarm time) instead, so the persisted duration matches the true intended session length

## Change

`entrypoints/background.ts` line 131: `Date.now()` → `state.endTime ?? Date.now()`

The nullish fallback is a safety guard only; `state.endTime` is always non-null when `state.phase === 'WORKING'` and the alarm was missed (guaranteed by `recoverMissedAlarm`'s guard on `state.endTime === null`).

## Test plan

- [ ] All 87 existing unit tests pass (`npx vitest run`)
- [ ] TypeScript check clean (`npx tsc --noEmit`)
- [ ] Manual: simulate a missed alarm by advancing system clock past endTime — verify recovered session duration equals `state.endTime - state.startTime`, not `Date.now() - state.startTime`

Closes #514