### PR TITLE
fix: reset all extraConfig fields to defaults on handleReset

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -72,7 +72,9 @@ export default function App() {
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
     setOpenBreakTab(DEFAULT_CONFIG.openBreakTab);
     setPlayCompletionSound(DEFAULT_CONFIG.playCompletionSound);
-    setExtraConfig({ dailyGoal: DEFAULT_CONFIG.dailyGoal });
+    // Reset all non-UI fields to their defaults so future config fields aren't silently wiped
+    const { workDuration: _w, shortBreakDuration: _s, longBreakDuration: _l, openBreakTab: _o, playCompletionSound: _p, ...restDefaults } = DEFAULT_CONFIG;
+    setExtraConfig(restDefaults);
     setError('');
   };
 


### PR DESCRIPTION
## Summary
- `handleReset` in `entrypoints/options/App.tsx` previously called `setExtraConfig({ dailyGoal: DEFAULT_CONFIG.dailyGoal })`, hard-coding only `dailyGoal` and silently wiping any other fields stored in `extraConfig` when the user clicked Reset
- Fixed by deriving the extra fields the same way `onMount` does: destructure the five UI-managed fields out of `DEFAULT_CONFIG` and spread the remainder into `setExtraConfig`
- This is forward-compatible — any new config field added to `TimerConfig` that isn't surfaced as a UI signal will automatically be reset to its default value

## Test plan
- [ ] Open options page, change settings, click Reset — all visible fields revert to defaults
- [ ] Verify `dailyGoal` (and any future non-UI config fields) are properly reset rather than preserved at their pre-reset values
- [ ] TypeScript `npx tsc --noEmit` passes with no errors

Closes #521