### PR TITLE
fix(stats): prevent empty-state flash during resource loading (#518)

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -74,7 +74,7 @@ export default function App() {
           </Show>
         </div>
 
-        <Show when={(sessions() ?? []).length === 0}>
+        <Show when={sessions.state === 'ready' && (sessions() ?? []).length === 0}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>
             <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>


### PR DESCRIPTION
## Summary
- Guards the \"No sessions yet\" `<Show>` with `sessions.state === 'ready'` so it only renders after the `createResource` has resolved
- Previously, `sessions()` returned `undefined` during loading; the `?? []` fallback made `[].length === 0` evaluate to `true`, causing a \"No sessions yet\" flash for every user on every page load
- Users with actual sessions now see no empty state at all until data is confirmed empty

## Test plan
- [ ] Open the stats page with existing sessions — no \"No sessions yet\" flash occurs
- [ ] Open the stats page with no sessions — empty state renders after load (not before)
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes (86 tests)

Closes #518