### PR TITLE
fix: use state.endTime for recovered session instead of Date.now() (#514)

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -213,12 +213,14 @@ describe('background service worker', () => {
       }),
     );
     await expect(getPendingCelebration()).resolves.toBe(true);
+    // endTime should be state.endTime (the originally scheduled alarm time),
+    // not Date.now(), so recovered sessions don't get an inflated duration (#514).
     await expect(getSessionHistory()).resolves.toEqual([
       {
         id: expect.any(String),
         label: 'Recovered work',
         startTime: 1_000,
-        endTime: 10_000,
+        endTime: 2_000,
         date: toDateKey(1_000),
         duration: 1_000,
       },

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -128,7 +128,9 @@ export default defineBackground(() => {
     await setTimerState(recovered);
 
     if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
+      // Use the originally scheduled end time, not Date.now(), so that
+      // recovered sessions don't get an inflated duration (#514).
+      await persistCompletedSession(state, state.endTime ?? Date.now());
     }
 
     if (recovered.phase === 'SHORT_BREAK' && recovered.endTime !== null) {


### PR DESCRIPTION
## Summary
- In `recoverFromMissedAlarm()`, the session was persisted with `Date.now()` as `endTime` rather than the originally scheduled `state.endTime`
- Since recovery runs when Chrome restarts (potentially hours after the alarm fired), this inflated session durations in the CSV export and any future session-length analytics
- Fixed to use `state.endTime ?? Date.now()` so the recorded end time matches when the alarm was actually scheduled to fire

## Test plan
- [ ] Updated the existing background test to expect `endTime: 2_000` (state.endTime) instead of `endTime: 10_000` (Date.now mock) for a recovered session
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes (86 tests)

Closes #514