### PR TITLE
fix: ensure heatmap always renders at least 12 weeks of cells

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -12,6 +12,8 @@ type HeatmapCell = {
   dayOfWeek: number;
 };
 
+const MIN_DISPLAY_DAYS = 12 * 7; // always show at least 12 weeks
+
 const INTENSITY_COLORS = [
   '#F3F4F6',
   '#FCA5A5',
@@ -50,7 +52,9 @@ const generateHeatmapGrid = (
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  for (let i = days - 1; i >= 0; i--) {
+  const effectiveDays = Math.max(days, MIN_DISPLAY_DAYS);
+
+  for (let i = effectiveDays - 1; i >= 0; i--) {
     const date = new Date(today);
     date.setDate(date.getDate() - i);
     const key = toDateKey(date);


### PR DESCRIPTION
## Summary

- Adds `MIN_DISPLAY_DAYS = 84` (12 × 7) constant to `components/Heatmap.tsx`
- `generateHeatmapGrid` now uses `Math.max(days, MIN_DISPLAY_DAYS)` so the grid always spans at least 12 weeks regardless of how little data exists
- New users with only a few days of sessions will see a full-width, consistently laid-out heatmap instead of a narrow/broken grid
- Month and day labels continue to render correctly because the column structure is identical — only the date range is extended with empty (count = 0) cells on the left

## Test plan

- [ ] Existing `lib/__tests__/heatmap.test.ts` tests the `generateHeatmapGrid` minimum-days behaviour — run `npx vitest run lib/__tests__/heatmap.test.ts`
- [ ] Visually verify the stats page with a fresh profile (< 7 days of data) shows a full-width heatmap
- [ ] Verify that passing `days=365` still renders 365 cells (larger value is respected)

Closes #104