### PR TITLE
fix: correct computeWeekCount to include exactly 7 days

### DIFF
--- a/lib/__tests__/stats.test.ts
+++ b/lib/__tests__/stats.test.ts
@@ -70,6 +70,18 @@ describe('computeWeekCount', () => {
     ];
     expect(computeWeekCount(sessions)).toBe(3);
   });
+
+  it('counts exactly 7 days: one session per day for 7 days equals 7', () => {
+    // Sessions on each of the 7 days: today (0) through 6 days ago (6)
+    const sessions = [0, 1, 2, 3, 4, 5, 6].map((d) => makeSession(dateKey(d), `d${d}`));
+    expect(computeWeekCount(sessions)).toBe(7);
+  });
+
+  it('does not count an 8th session on day 7', () => {
+    // 8 sessions spanning 8 days — only 7 should be counted
+    const sessions = [0, 1, 2, 3, 4, 5, 6, 7].map((d) => makeSession(dateKey(d), `d${d}`));
+    expect(computeWeekCount(sessions)).toBe(7);
+  });
 });
 
 describe('computeBestDay', () => {

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -14,10 +14,11 @@ export const computeTotalCount = (sessions: CompletedSession[]): number => sessi
 export const computeWeekCount = (sessions: CompletedSession[]): number => {
   const today = new Date(Date.now());
   today.setHours(0, 0, 0, 0);
-  const weekAgo = new Date(today.getTime() - 7 * DAY_MS);
-  const cutoff = toDateKey(weekAgo);
+  // Subtract 6 days so the window is [today-6 .. today] = 7 full days inclusive.
+  const weekStart = new Date(today.getTime() - 6 * DAY_MS);
+  const cutoff = toDateKey(weekStart);
 
-  return sessions.filter((s) => s.date > cutoff).length;
+  return sessions.filter((s) => s.date >= cutoff).length;
 };
 
 export const computeBestDay = (


### PR DESCRIPTION
## Summary

- `computeWeekCount()` used `today - 7 * DAY_MS` with a strict `>` comparison, producing a 6-day window instead of 7
- Changed the offset to `- 6 * DAY_MS` and the comparison to `>=` so the window is `[today-6 .. today]` — exactly 7 days inclusive
- Added two new tests: one verifying 7 sessions across 7 days counts as 7, and one verifying a session on day 8 is excluded

## Test plan

- [x] `computeWeekCount` — session 6 days ago is included (existing test)
- [x] `computeWeekCount` — session 7 days ago is excluded (existing test)
- [x] `computeWeekCount` — one session per day for 7 days = 7 (new test)
- [x] `computeWeekCount` — 8 sessions spanning 8 days = 7 (new test)
- [x] All 86 tests pass (`npx vitest run`)

Closes #68