### PR TITLE
fix: validate GET_STATE response shape before using as TimerState

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -33,9 +33,14 @@ export default function App() {
     setHeatmapData(await getHeatmapData(120));
   };
 
+  const isValidTimerState = (value: unknown): value is TimerState =>
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as Record<string, unknown>).phase === 'string';
+
   onMount(async () => {
     const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
-    setState(currentState as TimerState);
+    setState(isValidTimerState(currentState) ? currentState : INITIAL_STATE);
 
     const config = await getConfig();
     setDailyGoal(config.dailyGoal);
@@ -81,22 +86,22 @@ export default function App() {
 
   const startTimer = async () => {
     const newState = await browser.runtime.sendMessage({ action: 'START_TIMER' });
-    setState(newState as TimerState);
+    setState(isValidTimerState(newState) ? newState : INITIAL_STATE);
   };
 
   const abandonTimer = async () => {
     const newState = await browser.runtime.sendMessage({ action: 'ABANDON_TIMER' });
-    setState(newState as TimerState);
+    setState(isValidTimerState(newState) ? newState : INITIAL_STATE);
   };
 
   const acceptLongBreak = async () => {
     const newState = await browser.runtime.sendMessage({ action: 'ACCEPT_LONG_BREAK' });
-    setState(newState as TimerState);
+    setState(isValidTimerState(newState) ? newState : INITIAL_STATE);
   };
 
   const skipLongBreak = async () => {
     const newState = await browser.runtime.sendMessage({ action: 'SKIP_LONG_BREAK' });
-    setState(newState as TimerState);
+    setState(isValidTimerState(newState) ? newState : INITIAL_STATE);
   };
 
   let labelTimeout: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
## Summary

- Adds an `isValidTimerState` type guard that checks the response is a non-null object with a `string`-typed `phase` field
- Replaces all five unsafe `as TimerState` casts in `entrypoints/popup/App.tsx` (`GET_STATE`, `START_TIMER`, `ABANDON_TIMER`, `ACCEPT_LONG_BREAK`, `SKIP_LONG_BREAK`) with guarded ternaries that fall back to `INITIAL_STATE`
- Prevents crashes or garbage renders when the background returns `undefined` or a partial object during a cold start

## Test plan

- [ ] Open popup immediately after installing the extension (cold start) — should show idle state, not crash
- [ ] Normal usage: start, abandon, accept/skip long break — state updates correctly
- [ ] Simulate background returning `undefined` (e.g. temporarily break the handler) — popup falls back to `INITIAL_STATE` gracefully
- [ ] `npx tsc --noEmit` passes with no errors

Closes #71