### PR TITLE
fix: consolidate toDateKey into lib/storage.ts to prevent divergence

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -1,5 +1,7 @@
 import { For, createMemo } from 'solid-js';
 
+import { toDateKey } from '@/lib/storage';
+
 type HeatmapProps = {
   data: Record<string, number>;
   days: number;
@@ -35,13 +37,6 @@ const getIntensityColor = (count: number): string => {
   return INTENSITY_COLORS[4];
 };
 
-const toDateKey = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
 const generateHeatmapGrid = (
   data: Record<string, number>,
   days: number,
@@ -53,7 +48,7 @@ const generateHeatmapGrid = (
   for (let i = days - 1; i >= 0; i--) {
     const date = new Date(today);
     date.setDate(date.getDate() - i);
-    const key = toDateKey(date);
+    const key = toDateKey(date.getTime());
     cells.push({
       date: key,
       count: data[key] ?? 0,

--- a/lib/__tests__/heatmap.test.ts
+++ b/lib/__tests__/heatmap.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { toDateKey } from '../storage';
+
 // We test the pure heatmap utilities without importing the SolidJS component.
 // The logic we need is inlined here to mirror the implementation.
 
@@ -21,13 +23,6 @@ const getIntensityColor = (count: number): string => {
   return INTENSITY_COLORS[4];
 };
 
-const toDateKey = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
 const MIN_DISPLAY_DAYS = 12 * 7;
 
 const generateHeatmapGrid = (data: Record<string, number>, days: number): HeatmapCell[] => {
@@ -38,7 +33,7 @@ const generateHeatmapGrid = (data: Record<string, number>, days: number): Heatma
   for (let i = effectiveDays - 1; i >= 0; i--) {
     const date = new Date(today);
     date.setDate(date.getDate() - i);
-    const key = toDateKey(date);
+    const key = toDateKey(date.getTime());
     cells.push({ date: key, count: data[key] ?? 0, dayOfWeek: date.getDay() });
   }
   return cells;
@@ -102,7 +97,7 @@ describe('generateHeatmapGrid — minimum display days (#104)', () => {
   it('fills count from data keyed by date string', () => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const key = toDateKey(today);
+    const key = toDateKey(today.getTime());
     const cells = generateHeatmapGrid({ [key]: 3 }, MIN_DISPLAY_DAYS);
     const todayCell = cells.find((c) => c.date === key);
     expect(todayCell?.count).toBe(3);
@@ -116,10 +111,10 @@ describe('generateHeatmapGrid — minimum display days (#104)', () => {
 
 describe('toDateKey', () => {
   it('formats a date as YYYY-MM-DD', () => {
-    expect(toDateKey(new Date(2026, 3, 5))).toBe('2026-04-05');
+    expect(toDateKey(new Date(2026, 3, 5).getTime())).toBe('2026-04-05');
   });
 
   it('pads single-digit month and day', () => {
-    expect(toDateKey(new Date(2026, 0, 1))).toBe('2026-01-01');
+    expect(toDateKey(new Date(2026, 0, 1).getTime())).toBe('2026-01-01');
   });
 });

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,13 +1,7 @@
 import type { CompletedSession } from './types';
+import { toDateKey } from './storage';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-
-const toDateKey = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
 
 export const computeTotalCount = (sessions: CompletedSession[]): number => sessions.length;
 
@@ -15,7 +9,7 @@ export const computeWeekCount = (sessions: CompletedSession[]): number => {
   const today = new Date(Date.now());
   today.setHours(0, 0, 0, 0);
   const weekAgo = new Date(today.getTime() - 7 * DAY_MS);
-  const cutoff = toDateKey(weekAgo);
+  const cutoff = toDateKey(weekAgo.getTime());
 
   return sessions.filter((s) => s.date > cutoff).length;
 };
@@ -49,19 +43,19 @@ export const computeStreak = (sessions: CompletedSession[]): number => {
 
   const today = new Date(Date.now());
   today.setHours(0, 0, 0, 0);
-  const todayKey = toDateKey(today);
+  const todayKey = toDateKey(today.getTime());
 
   let streak = 0;
   let checkDate = new Date(today);
 
   if (!sessionDates.has(todayKey)) {
     checkDate.setDate(checkDate.getDate() - 1);
-    if (!sessionDates.has(toDateKey(checkDate))) {
+    if (!sessionDates.has(toDateKey(checkDate.getTime()))) {
       return 0;
     }
   }
 
-  while (sessionDates.has(toDateKey(checkDate))) {
+  while (sessionDates.has(toDateKey(checkDate.getTime()))) {
     streak++;
     checkDate.setDate(checkDate.getDate() - 1);
   }


### PR DESCRIPTION
## Summary

- Removes duplicate `toDateKey()` implementations from `lib/stats.ts` and `components/Heatmap.tsx`
- Both files now import the canonical `toDateKey` export from `lib/storage.ts`
- Updates `lib/__tests__/heatmap.test.ts` to use the shared import instead of an inline copy
- All call sites updated from `toDateKey(date: Date)` to `toDateKey(date.getTime())` to match the `number`-based signature in `storage.ts`

## Test plan

- [ ] Verify `lib/__tests__/storage.test.ts` passes (toDateKey unit tests live here)
- [ ] Verify `lib/__tests__/stats.test.ts` passes (computeStreak, computeWeekCount use toDateKey indirectly)
- [ ] Verify `lib/__tests__/heatmap.test.ts` passes (toDateKey describe block now tests the shared import)
- [ ] Confirm no TypeScript errors in `lib/stats.ts`, `components/Heatmap.tsx`

Closes #67