### PR TITLE
fix: show error state when stats resource fails to load

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -64,7 +64,7 @@ export default function App() {
       <div class="max-w-[800px] mx-auto">
         <div class="flex items-center justify-between mb-6">
           <h1 class="text-2xl font-bold text-red-600">Tomate Stats</h1>
-          <Show when={(sessions() ?? []).length > 0}>
+          <Show when={!sessions.error && (sessions() ?? []).length > 0}>
             <button
               class="text-sm px-3 py-1.5 rounded-lg border border-red-200 text-red-600 hover:bg-red-100 transition-colors"
               onClick={() => exportCSV(sessions() ?? [])}
@@ -74,14 +74,21 @@ export default function App() {
           </Show>
         </div>
 
-        <Show when={(sessions() ?? []).length === 0}>
+        <Show when={sessions.error}>
+          <div class="text-center py-8 text-red-600">
+            <p class="text-lg font-semibold">Failed to load stats</p>
+            <p class="text-sm mt-1 text-gray-500">Please try refreshing.</p>
+          </div>
+        </Show>
+
+        <Show when={!sessions.error && (sessions() ?? []).length === 0}>
           <div class="text-center py-8 text-gray-500 dark:text-gray-400">
             <p class="text-lg">No sessions yet</p>
             <p class="text-sm mt-1">Complete your first Pomodoro to see your stats here.</p>
           </div>
         </Show>
 
-        <Show when={(sessions() ?? []).length > 0}>
+        <Show when={!sessions.error && (sessions() ?? []).length > 0}>
           <div class="grid grid-cols-5 gap-3 mb-6">
             <StatCard label="Total tomates" value={total()} />
             <StatCard label="Today" value={todayCount() ?? 0} />


### PR DESCRIPTION
## Summary

- Checks `sessions.error` from the `createResource` signal in the stats page
- Renders a "Failed to load stats. Please try refreshing." error panel when the resource enters an error state
- Guards both the empty state and the data/charts behind `!sessions.error` so the error panel is shown exclusively
- The Export CSV button is also hidden when in error state

Closes #47