### PR TITLE
fix: stop previous audio before starting new in playCelebration

### DIFF
--- a/lib/celebration.ts
+++ b/lib/celebration.ts
@@ -22,16 +22,29 @@ const CONFETTI_CONFIGS: Record<string, confetti.Options> = {
   },
 };
 
+let currentAudio: HTMLAudioElement | null = null;
+
 export const playCelebration = (type: 'work' | 'milestone' | 'break', playSound = true): void => {
   confetti(CONFETTI_CONFIGS[type]);
 
   if (playSound) {
     try {
-      new Audio(browser.runtime.getURL('/sounds/completion.mp3' as '/popup.html'))
-        .play()
-        .catch(() => {});
+      if (currentAudio) {
+        currentAudio.pause();
+        currentAudio.currentTime = 0;
+        currentAudio = null;
+      }
+      const audio = new Audio(browser.runtime.getURL('/sounds/completion.mp3' as '/popup.html'));
+      currentAudio = audio;
+      audio.onended = () => {
+        currentAudio = null;
+      };
+      audio.play().catch(() => {
+        currentAudio = null;
+      });
     } catch {
       // Audio constructor can throw in non-browser environments
+      currentAudio = null;
     }
   }
 };


### PR DESCRIPTION
## Summary
- Adds a module-level `currentAudio: HTMLAudioElement | null` variable to track the active audio element
- Before playing a new sound, pauses and resets any currently playing audio, then nulls the reference
- Clears `currentAudio` in both the `onended` handler and the `.play()` rejection handler, so the reference is never stale

## Test plan
- [ ] Trigger multiple rapid session completions and confirm only one sound plays at a time with no audio overlap
- [ ] Confirm no TypeScript errors (`npx tsc --noEmit`)
- [ ] Confirm single session completion still plays the sound normally

Closes #70