### PR TITLE
a11y: add contextual aria-labels to Controls and label TaskLabel input

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -16,6 +16,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'IDLE'}>
           <button
             type="button"
+            aria-label="Start work session"
             onClick={props.onStart}
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
           >
@@ -25,6 +26,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'WORKING'}>
           <button
             type="button"
+            aria-label="Abandon current work session"
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
@@ -34,6 +36,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'SHORT_BREAK' || props.phase === 'LONG_BREAK'}>
           <button
             type="button"
+            aria-label="Skip current break and return to work"
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >
@@ -43,6 +46,7 @@ export default function Controls(props: ControlsProps) {
         <Match when={props.phase === 'BREAK_SUGGESTION'}>
           <button
             type="button"
+            aria-label="Start a long break"
             onClick={props.onAcceptLongBreak}
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"
           >
@@ -50,6 +54,7 @@ export default function Controls(props: ControlsProps) {
           </button>
           <button
             type="button"
+            aria-label="Skip long break and start next work session"
             onClick={props.onSkipLongBreak}
             class="px-5 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
           >

--- a/components/TaskLabel.tsx
+++ b/components/TaskLabel.tsx
@@ -7,6 +7,7 @@ export default function TaskLabel(props: TaskLabelProps) {
   return (
     <input
       type="text"
+      aria-label="Task name"
       value={props.value}
       onInput={(e) => props.onChange(e.currentTarget.value)}
       placeholder="What are you working on?"


### PR DESCRIPTION
## Summary

- **#53**: Added descriptive `aria-label` attributes to all timer control buttons in `Controls.tsx`, giving each button phase-specific context (e.g. "Start work session", "Abandon current work session", "Skip current break and return to work", "Start a long break", "Skip long break and start next work session")
- **#54**: Added `aria-label="Task name"` to the task name input in `TaskLabel.tsx`, making it accessible to screen readers that previously only saw the placeholder text

## Test plan

- [ ] Verify screen reader announces "Start work session" when focused on the Start button in IDLE phase
- [ ] Verify screen reader announces "Abandon current work session" when focused on the Abandon button in WORKING phase
- [ ] Verify screen reader announces "Skip current break and return to work" during SHORT_BREAK and LONG_BREAK phases
- [ ] Verify screen reader announces "Start a long break" / "Skip long break and start next work session" during BREAK_SUGGESTION phase
- [ ] Verify screen reader announces "Task name" when focused on the task input field
- [ ] Confirm TypeScript check passes: `npx tsc --noEmit`

Closes #53
Closes #54