### PR TITLE
a11y: add aria-live countdown region to TimerRing

### DIFF
--- a/components/TimerRing.tsx
+++ b/components/TimerRing.tsx
@@ -3,6 +3,8 @@ import type { TimerPhase } from '@/lib/types';
 type TimerRingProps = {
   progress: number;
   phase: TimerPhase;
+  /** Remaining milliseconds; used for the screen-reader live region. */
+  remaining?: number;
 };
 
 const PHASE_COLORS: Record<TimerPhase, string> = {
@@ -18,34 +20,68 @@ const STROKE = 8;
 const RADIUS = (SIZE - STROKE) / 2;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
+/**
+ * Returns the remaining time rounded down to the nearest whole minute.
+ * The live region only changes once per minute, preventing per-second floods.
+ */
+function liveMinutes(ms: number): number {
+  return Math.floor(ms / 60_000);
+}
+
+/** Human-readable announcement, e.g. "23 minutes remaining" or "45 seconds remaining". */
+function liveLabel(ms: number, phase: TimerPhase): string {
+  const activePhases: TimerPhase[] = ['WORKING', 'SHORT_BREAK', 'LONG_BREAK'];
+  if (!activePhases.includes(phase) || ms <= 0) return '';
+  const minutes = liveMinutes(ms);
+  if (minutes >= 1) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'} remaining`;
+  const seconds = Math.floor(ms / 1000);
+  return `${seconds} ${seconds === 1 ? 'second' : 'seconds'} remaining`;
+}
+
 export default function TimerRing(props: TimerRingProps) {
   const offset = () => CIRCUMFERENCE * (1 - props.progress);
   const color = () => PHASE_COLORS[props.phase];
 
   return (
-    <svg width={SIZE} height={SIZE} class="timer-ring" viewBox={`0 0 ${SIZE} ${SIZE}`}>
-      <title>Timer progress</title>
-      <circle
-        cx={SIZE / 2}
-        cy={SIZE / 2}
-        r={RADIUS}
-        fill="none"
-        stroke="#E5E7EB"
-        stroke-width={STROKE}
-      />
-      <circle
-        cx={SIZE / 2}
-        cy={SIZE / 2}
-        r={RADIUS}
-        fill="none"
-        stroke={color()}
-        stroke-width={STROKE}
-        stroke-linecap="round"
-        stroke-dasharray={String(CIRCUMFERENCE)}
-        stroke-dashoffset={offset()}
-        transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
-        class="transition-[stroke-dashoffset] duration-500 ease-linear"
-      />
-    </svg>
+    <div class="relative inline-block">
+      <svg
+        width={SIZE}
+        height={SIZE}
+        class="timer-ring"
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        aria-hidden="true"
+      >
+        <title>Timer progress</title>
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          stroke="#E5E7EB"
+          stroke-width={STROKE}
+        />
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          stroke={color()}
+          stroke-width={STROKE}
+          stroke-linecap="round"
+          stroke-dasharray={String(CIRCUMFERENCE)}
+          stroke-dashoffset={offset()}
+          transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+          class="transition-[stroke-dashoffset] duration-500 ease-linear"
+        />
+      </svg>
+      {/* Screen-reader live region: announces remaining time once per minute */}
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        class="sr-only"
+      >
+        {liveLabel(props.remaining ?? 0, props.phase)}
+      </span>
+    </div>
   );
 }

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -120,7 +120,7 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
+      <TimerRing progress={progress()} phase={state().phase} remaining={remaining()} />
       <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
       <div class="text-sm text-gray-500 mt-1">


### PR DESCRIPTION
## Summary

- Adds an `aria-live="polite"` + `aria-atomic="true"` visually-hidden `<span>` adjacent to the SVG in `TimerRing`
- Screen readers now announce the remaining time as it counts down
- Announcements are coarsened to whole minutes to avoid per-second flooding; the final minute falls back to per-second announcements (e.g. "45 seconds remaining")
- The SVG itself gains `aria-hidden="true"` since it carries no additional information for AT
- Passes `remaining` ms from `popup/App.tsx` via a new optional prop on `TimerRing`

## Test plan

- [ ] Start a work session and confirm a screen reader (VoiceOver/NVDA) announces "X minutes remaining" once per minute
- [ ] Confirm announcements stop when the timer is idle (`IDLE` / `BREAK_SUGGESTION` phases)
- [ ] Confirm the last-minute fallback announces seconds (e.g. "30 seconds remaining", "1 second remaining")
- [ ] Confirm no visual layout change — the `sr-only` span is invisible
- [ ] `npx tsc --noEmit` exits cleanly

Closes #52