### PR TITLE
perf: skip storage change listener when no relevant keys changed

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -49,8 +49,12 @@ export default function App() {
     setLabel(await getCurrentLabel());
     await refreshStats();
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const onStorageChanged = (changes: Record<string, unknown>) => {
+      if (!changes.timerState && !changes.sessions) return;
+      void refreshStats();
+    };
+    browser.storage.onChanged.addListener(onStorageChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onStorageChanged));
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary
- In `entrypoints/popup/App.tsx`, the `browser.storage.onChanged` listener previously fired `refreshStats` on every storage write, regardless of which key changed
- Added an early-return guard that checks for `timerState` or `sessions` keys before doing work — these are the only keys that affect the stats displayed in the popup (today's count and heatmap data)
- `background.ts` and `options/App.tsx` had no `storage.onChanged` listeners and required no changes

## Test plan
- [ ] Open the popup — today count and heatmap still update when a session completes
- [ ] Verify that writing unrelated keys (e.g. `currentLabel`, `pendingCelebration`, `config`) no longer triggers unnecessary `getTodayCount` / `getHeatmapData` reads
- [ ] TypeScript passes with `npx tsc --noEmit`

Closes #48