### PR TITLE
fix: show loading state while fetching initial timer state in popup

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, onMount, onCleanup, Switch, Match } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, Switch, Match, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { isActivePhase } from '@/lib/timer';
@@ -21,6 +21,7 @@ import TodayCount from '@/components/TodayCount';
 import Heatmap from '@/components/Heatmap';
 
 export default function App() {
+  const [isLoading, setIsLoading] = createSignal(true);
   const [state, setState] = createSignal<TimerState>(INITIAL_STATE);
   const [remaining, setRemaining] = createSignal(0);
   const [label, setLabel] = createSignal('');
@@ -36,6 +37,7 @@ export default function App() {
   onMount(async () => {
     const currentState = await browser.runtime.sendMessage({ action: 'GET_STATE' });
     setState(currentState as TimerState);
+    setIsLoading(false);
 
     const config = await getConfig();
     setDailyGoal(config.dailyGoal);
@@ -120,42 +122,44 @@ export default function App() {
         </button>
       </div>
 
-      <TimerRing progress={progress()} phase={state().phase} />
-      <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
+      <Show when={!isLoading()} fallback={<div class="flex-1" />}>
+        <TimerRing progress={progress()} phase={state().phase} />
+        <div class="text-4xl font-mono font-bold text-gray-800 mt-2">{formatTime()}</div>
 
-      <div class="text-sm text-gray-500 mt-1">
-        <Switch>
-          <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
-          <Match when={state().phase === 'WORKING'}>Working</Match>
-          <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
-          <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
-          <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
-        </Switch>
-      </div>
+        <div class="text-sm text-gray-500 mt-1">
+          <Switch>
+            <Match when={state().phase === 'IDLE'}>Ready to focus</Match>
+            <Match when={state().phase === 'WORKING'}>Working</Match>
+            <Match when={state().phase === 'SHORT_BREAK'}>Short Break</Match>
+            <Match when={state().phase === 'LONG_BREAK'}>Long Break</Match>
+            <Match when={state().phase === 'BREAK_SUGGESTION'}>Time for a long break!</Match>
+          </Switch>
+        </div>
 
-      <TaskLabel value={label()} onChange={handleLabelChange} />
+        <TaskLabel value={label()} onChange={handleLabelChange} />
 
-      <Controls
-        phase={state().phase}
-        onStart={startTimer}
-        onAbandon={abandonTimer}
-        onAcceptLongBreak={acceptLongBreak}
-        onSkipLongBreak={skipLongBreak}
-      />
+        <Controls
+          phase={state().phase}
+          onStart={startTimer}
+          onAbandon={abandonTimer}
+          onAcceptLongBreak={acceptLongBreak}
+          onSkipLongBreak={skipLongBreak}
+        />
 
-      <TodayCount count={todayCount()} goal={dailyGoal()} />
+        <TodayCount count={todayCount()} goal={dailyGoal()} />
 
-      <div class="mt-2 w-full">
-        <Heatmap days={120} data={heatmapData()} />
-      </div>
+        <div class="mt-2 w-full">
+          <Heatmap days={120} data={heatmapData()} />
+        </div>
 
-      <button
-        type="button"
-        onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
-        class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
-      >
-        View all stats →
-      </button>
+        <button
+          type="button"
+          onClick={() => browser.tabs.create({ url: browser.runtime.getURL('/stats.html' as '/popup.html') })}
+          class="mt-2 text-xs text-red-400 hover:text-red-600 underline"
+        >
+          View all stats →
+        </button>
+      </Show>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds an `isLoading` signal (initialized to `true`) in the popup `App` component
- Sets `isLoading` to `false` immediately after the `GET_STATE` response is received in `onMount`, before the remaining async setup work
- Wraps the entire timer UI (ring, countdown, phase label, controls, stats, heatmap) in `<Show when={!isLoading()}>` with an empty flex spacer as the fallback, so nothing renders until the real state is known
- The header bar (title + settings button) remains always visible to avoid layout shift

## Test plan

- [ ] Open the popup while a timer is actively running — confirm no "Idle / 00:00" flash before the correct state appears
- [ ] Open the popup when idle — confirm the UI renders normally after the brief load
- [ ] `npx tsc --noEmit` passes with zero errors

Closes #50