### PR TITLE
fix: validate and sanitize blocked site hostname input

### DIFF
--- a/entrypoints/__tests__/options.test.ts
+++ b/entrypoints/__tests__/options.test.ts
@@ -32,6 +32,7 @@ const buildConfig = (
   extra: Partial<TimerConfig> = {},
 ): TimerConfig => ({
   dailyGoal: DEFAULT_CONFIG.dailyGoal,
+  blockedSites: DEFAULT_CONFIG.blockedSites,
   ...extra,
   workDuration: work * MS_PER_MINUTE,
   shortBreakDuration: shortBreak * MS_PER_MINUTE,

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -32,6 +32,52 @@ export type MessageAction =
   | { action: 'SKIP_LONG_BREAK' }
   | { action: 'UPDATE_CONFIG'; config: TimerConfig };
 
+// Base rule ID offset for blocked-site DNR rules (avoids collisions with static rules)
+const DNR_RULE_ID_OFFSET = 1000;
+
+type DnrApi = {
+  getDynamicRules(): Promise<{ id: number }[]>;
+  updateDynamicRules(opts: { addRules?: unknown[]; removeRuleIds?: number[] }): Promise<void>;
+};
+
+const getDnr = (): DnrApi | undefined =>
+  (browser as typeof browser & { declarativeNetRequest?: DnrApi }).declarativeNetRequest;
+
+/**
+ * Replace all dynamic blocked-site DNR rules with rules derived from the
+ * provided list of validated hostnames.  Silently no-ops if the
+ * declarativeNetRequest API is unavailable.
+ */
+const applyBlockedSiteRules = async (hostnames: string[]): Promise<void> => {
+  const dnr = getDnr();
+  if (!dnr) return;
+
+  try {
+    const existing = await dnr.getDynamicRules();
+    const removeRuleIds = existing.map((r) => r.id);
+
+    const addRules = hostnames.map((hostname, index) => ({
+      id: DNR_RULE_ID_OFFSET + index,
+      priority: 1,
+      action: { type: 'block' },
+      condition: {
+        urlFilter: `||${hostname}^`,
+        resourceTypes: [
+          'main_frame',
+          'sub_frame',
+          'xmlhttprequest',
+          'websocket',
+          'other',
+        ],
+      },
+    }));
+
+    await dnr.updateDynamicRules({ removeRuleIds, addRules });
+  } catch {
+    // declarativeNetRequest may not be available; silently ignore
+  }
+};
+
 export default defineBackground(() => {
   const ALARM_TIMER = 'tomate-timer';
   const ALARM_BADGE_REFRESH = 'badge-refresh';
@@ -188,6 +234,7 @@ export default defineBackground(() => {
       }
       case 'UPDATE_CONFIG': {
         await setConfig(message.config);
+        await applyBlockedSiteRules(message.config.blockedSites ?? []);
         const nextState = adjustDuration(state, message.config);
         await setTimerState(nextState);
 
@@ -208,27 +255,10 @@ export default defineBackground(() => {
   };
 
   browser.runtime.onInstalled.addListener(async (details) => {
-    // On fresh install or update, remove any stale dynamic declarativeNetRequest rules (#103)
+    // On fresh install or update, re-sync dynamic declarativeNetRequest rules from stored config (#103)
     if (details.reason === 'install' || details.reason === 'update') {
-      try {
-        const existing = await (browser as typeof browser & {
-          declarativeNetRequest?: {
-            getDynamicRules(): Promise<{ id: number }[]>;
-            updateDynamicRules(opts: { removeRuleIds: number[] }): Promise<void>;
-          };
-        }).declarativeNetRequest?.getDynamicRules();
-        if (existing && existing.length > 0) {
-          await (browser as typeof browser & {
-            declarativeNetRequest?: {
-              updateDynamicRules(opts: { removeRuleIds: number[] }): Promise<void>;
-            };
-          }).declarativeNetRequest?.updateDynamicRules({
-            removeRuleIds: existing.map((r) => r.id),
-          });
-        }
-      } catch {
-        // declarativeNetRequest may not be available if permission not declared
-      }
+      const config = await getConfig();
+      await applyBlockedSiteRules(config.blockedSites ?? []);
     }
     await recoverFromMissedAlarm();
   });

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { createSignal, For, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
@@ -10,12 +10,40 @@ const isValidWork = (v: number) => v >= 1 && v <= 120;
 const isValidShortBreak = (v: number) => v >= 1 && v <= 30;
 const isValidLongBreak = (v: number) => v >= 5 && v <= 60;
 
+/**
+ * Strip a protocol prefix (http:// or https://) from a raw hostname input.
+ * Returns the stripped value, or the original string if no protocol is present.
+ */
+export const stripProtocol = (value: string): string =>
+  value.replace(/^https?:\/\//i, '');
+
+/**
+ * Validate that a string is a well-formed plain hostname suitable for use in
+ * declarativeNetRequest rules.  Rules:
+ *  - No protocol prefix (http://, https://)
+ *  - No path separator (/)
+ *  - No query string (?)
+ *  - At least one dot (.)
+ *  - Only valid hostname characters: letters, digits, hyphens, dots
+ */
+export const isValidHostname = (value: string): boolean => {
+  if (!value) return false;
+  if (/^https?:\/\//i.test(value)) return false;
+  if (value.includes('/')) return false;
+  if (value.includes('?')) return false;
+  if (!value.includes('.')) return false;
+  return /^[a-zA-Z0-9.\-]+$/.test(value);
+};
+
 export default function App() {
   const [work, setWork] = createSignal(25);
   const [shortBreak, setShortBreak] = createSignal(5);
   const [longBreak, setLongBreak] = createSignal(30);
   const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [playCompletionSound, setPlayCompletionSound] = createSignal(true);
+  const [blockedSites, setBlockedSites] = createSignal<string[]>([]);
+  const [hostnameInput, setHostnameInput] = createSignal('');
+  const [hostnameError, setHostnameError] = createSignal('');
   // Preserve fields not yet surfaced in UI (e.g. dailyGoal) so we don't wipe them on save
   const [extraConfig, setExtraConfig] = createSignal<Partial<TimerConfig>>({});
   const [saved, setSaved] = createSignal(false);
@@ -28,8 +56,9 @@ export default function App() {
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
     setOpenBreakTab(config.openBreakTab !== false);
     setPlayCompletionSound(config.playCompletionSound !== false);
+    setBlockedSites(config.blockedSites ?? []);
     // Stash any extra fields so round-trip save doesn't lose them
-    const { workDuration: _w, shortBreakDuration: _s, longBreakDuration: _l, openBreakTab: _o, playCompletionSound: _p, ...rest } = config;
+    const { workDuration: _w, shortBreakDuration: _s, longBreakDuration: _l, openBreakTab: _o, playCompletionSound: _p, blockedSites: _b, ...rest } = config;
     setExtraConfig(rest);
   });
 
@@ -50,6 +79,7 @@ export default function App() {
       longBreakDuration: longBreak() * MS_PER_MINUTE,
       openBreakTab: openBreakTab(),
       playCompletionSound: playCompletionSound(),
+      blockedSites: blockedSites(),
     };
     try {
       await setConfig(config);
@@ -72,8 +102,46 @@ export default function App() {
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
     setOpenBreakTab(DEFAULT_CONFIG.openBreakTab);
     setPlayCompletionSound(DEFAULT_CONFIG.playCompletionSound);
+    setBlockedSites(DEFAULT_CONFIG.blockedSites);
+    setHostnameInput('');
+    setHostnameError('');
     setExtraConfig({ dailyGoal: DEFAULT_CONFIG.dailyGoal });
     setError('');
+  };
+
+  const handleAddHostname = () => {
+    const raw = hostnameInput().trim();
+    if (!raw) return;
+
+    // Auto-strip protocol prefix
+    const stripped = stripProtocol(raw);
+
+    if (!isValidHostname(stripped)) {
+      setHostnameError(
+        'Invalid hostname. Enter a plain domain like "example.com" — no protocol, path, or query string.',
+      );
+      return;
+    }
+
+    if (blockedSites().includes(stripped)) {
+      setHostnameError(`"${stripped}" is already in the list.`);
+      return;
+    }
+
+    setBlockedSites([...blockedSites(), stripped]);
+    setHostnameInput('');
+    setHostnameError('');
+  };
+
+  const handleRemoveHostname = (hostname: string) => {
+    setBlockedSites(blockedSites().filter((h) => h !== hostname));
+  };
+
+  const handleHostnameKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddHostname();
+    }
   };
 
   return (
@@ -137,6 +205,60 @@ export default function App() {
             />
             <span class="text-sm font-medium text-gray-700">Play completion sound</span>
           </label>
+
+          <div class="block">
+            <span class="text-sm font-medium text-gray-700">Blocked Sites (during work sessions)</span>
+            <p class="text-xs text-gray-500 mt-0.5 mb-2">
+              Enter hostnames like <code class="font-mono bg-gray-100 px-1 rounded">example.com</code>. No protocol or path.
+            </p>
+
+            <div class="flex gap-2">
+              <input
+                type="text"
+                value={hostnameInput()}
+                onInput={(e) => {
+                  setHostnameInput(e.currentTarget.value);
+                  setHostnameError('');
+                }}
+                onKeyDown={handleHostnameKeyDown}
+                placeholder="e.g. example.com"
+                aria-label="Hostname to block"
+                aria-describedby={hostnameError() ? 'hostname-error' : undefined}
+                class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              />
+              <button
+                type="button"
+                onClick={handleAddHostname}
+                class="bg-red-600 text-white px-3 py-2 rounded-md text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+              >
+                Add
+              </button>
+            </div>
+
+            <Show when={hostnameError()}>
+              <p id="hostname-error" class="mt-1 text-xs text-red-600" role="alert">{hostnameError()}</p>
+            </Show>
+
+            <Show when={blockedSites().length > 0}>
+              <ul class="mt-2 space-y-1" aria-label="Blocked hostnames">
+                <For each={blockedSites()}>
+                  {(hostname) => (
+                    <li class="flex items-center justify-between bg-gray-50 border border-gray-200 rounded px-3 py-1.5 text-sm">
+                      <span class="font-mono text-gray-800">{hostname}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveHostname(hostname)}
+                        aria-label={`Remove ${hostname}`}
+                        class="text-gray-400 hover:text-red-600 focus:outline-none focus:text-red-600 ml-2 text-xs"
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  )}
+                </For>
+              </ul>
+            </Show>
+          </div>
         </div>
 
         <div class="mt-6 flex items-center gap-4">

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -251,6 +251,7 @@ describe('timer state machine', () => {
       openBreakTab: true,
       playCompletionSound: true,
       dailyGoal: 8,
+      blockedSites: [],
     });
   });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,7 @@ export type TimerConfig = {
   openBreakTab: boolean;
   playCompletionSound: boolean;
   dailyGoal: number;
+  blockedSites: string[];
 };
 
 export type TimerState = {
@@ -35,6 +36,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   openBreakTab: true,
   playCompletionSound: true,
   dailyGoal: 8,
+  blockedSites: [],
 };
 
 export const INITIAL_STATE: TimerState = {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Tomate',
     description: 'A Pomodoro timer that helps you focus — one tomate at a time.',
-    permissions: ['alarms', 'notifications', 'storage', 'tabs'],
+    permissions: ['alarms', 'declarativeNetRequest', 'notifications', 'storage', 'tabs'],
     action: {
       default_icon: {
         '16': '/icons/icon-16.png',


### PR DESCRIPTION
## Summary

- Adds `blockedSites: string[]` to `TimerConfig` (defaults to `[]`) so blocked sites can be persisted alongside other config
- Adds `isValidHostname` and `stripProtocol` exported helpers in `App.tsx` that reject entries with protocol prefixes, path separators (`/`), query strings (`?`), or invalid characters, while auto-stripping `http://`/`https://` before validation
- Adds a Blocked Sites section to the options page with an `Add` button (also triggered by Enter), inline validation error messages, and a removable list of current entries
- Adds `applyBlockedSiteRules` in `background.ts` that atomically replaces all dynamic DNR rules with rules derived from the validated hostname list; called on `UPDATE_CONFIG` messages and on extension install/update
- Adds `declarativeNetRequest` to the manifest permissions in `wxt.config.ts`

## Test plan

- [ ] Enter `http://example.com` — protocol is auto-stripped to `example.com` and accepted
- [ ] Enter `example.com/path` — error shown, entry rejected
- [ ] Enter `example.com?q=1` — error shown, entry rejected
- [ ] Enter `notadomain` (no dot) — error shown, entry rejected
- [ ] Enter `example.com` twice — duplicate error shown on second attempt
- [ ] Enter `example.com` — accepted, appears in list, can be removed
- [ ] Save settings — blocked sites persisted and DNR rules applied
- [ ] Reset to defaults — blocked sites list cleared

Closes #102