### PR TITLE
a11y: move focus to action button on timer phase transitions

### DIFF
--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -7,6 +7,7 @@ type ControlsProps = {
   onAbandon: () => void;
   onAcceptLongBreak: () => void;
   onSkipLongBreak: () => void;
+  primaryButtonRef?: (el: HTMLButtonElement) => void;
 };
 
 export default function Controls(props: ControlsProps) {
@@ -15,6 +16,7 @@ export default function Controls(props: ControlsProps) {
       <Switch>
         <Match when={props.phase === 'IDLE'}>
           <button
+            ref={props.primaryButtonRef}
             type="button"
             onClick={props.onStart}
             class="px-6 py-2.5 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 active:bg-red-800 transition-colors"
@@ -24,6 +26,7 @@ export default function Controls(props: ControlsProps) {
         </Match>
         <Match when={props.phase === 'WORKING'}>
           <button
+            ref={props.primaryButtonRef}
             type="button"
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
@@ -33,6 +36,7 @@ export default function Controls(props: ControlsProps) {
         </Match>
         <Match when={props.phase === 'SHORT_BREAK' || props.phase === 'LONG_BREAK'}>
           <button
+            ref={props.primaryButtonRef}
             type="button"
             onClick={props.onAbandon}
             class="px-6 py-2.5 bg-gray-200 text-gray-700 font-semibold rounded-lg hover:bg-gray-300 active:bg-gray-400 transition-colors"
@@ -42,6 +46,7 @@ export default function Controls(props: ControlsProps) {
         </Match>
         <Match when={props.phase === 'BREAK_SUGGESTION'}>
           <button
+            ref={props.primaryButtonRef}
             type="button"
             onClick={props.onAcceptLongBreak}
             class="px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors"

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -28,6 +28,9 @@ export default function App() {
   const [dailyGoal, setDailyGoal] = createSignal<number | undefined>(undefined);
   const [heatmapData, setHeatmapData] = createSignal<Record<string, number>>({});
 
+  let primaryButtonRef: HTMLButtonElement | undefined;
+  let prevPhase = INITIAL_STATE.phase;
+
   const refreshStats = async () => {
     setTodayCount(await getTodayCount());
     setHeatmapData(await getHeatmapData(120));
@@ -62,6 +65,14 @@ export default function App() {
       onCleanup(() => clearInterval(id));
     } else {
       setRemaining(0);
+    }
+  });
+
+  createEffect(() => {
+    const currentPhase = state().phase;
+    if (currentPhase !== prevPhase) {
+      prevPhase = currentPhase;
+      primaryButtonRef?.focus();
     }
   });
 
@@ -141,6 +152,7 @@ export default function App() {
         onAbandon={abandonTimer}
         onAcceptLongBreak={acceptLongBreak}
         onSkipLongBreak={skipLongBreak}
+        primaryButtonRef={(el) => { primaryButtonRef = el; }}
       />
 
       <TodayCount count={todayCount()} goal={dailyGoal()} />


### PR DESCRIPTION
## Summary

- Adds a `primaryButtonRef` callback prop to `Controls` so the primary action button for each phase (Start / Abandon / Skip Break / Long Break) can be referenced from the parent
- In `App.tsx`, a `createEffect` watches `state().phase` and calls `.focus()` on the primary button whenever the phase changes, but skips the initial mount by comparing against `prevPhase`
- Keyboard users are no longer left with focus on a button that has been removed from the DOM after a phase transition

## Test plan

- [ ] Open popup, press Tab to focus the Start button, press Enter to start a working session — focus should move to the Abandon button automatically
- [ ] Let a working session complete (or trigger it via background) — focus should move to the appropriate button for the new phase (Skip Break or Long Break)
- [ ] Verify that on initial popup open, focus is NOT stolen (focus stays at document level / first tabbable element, not forced onto the button)
- [ ] `npx tsc --noEmit` passes with no errors

Closes #49