### PR TITLE
a11y: add border to zero-intensity heatmap cells for WCAG contrast

### DIFF
--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -189,7 +189,7 @@ export default function Heatmap(props: HeatmapProps) {
                 {(cell) =>
                   cell ? (
                     <div
-                      class="rounded-sm"
+                      class={`rounded-sm${cell.count === 0 ? ' ring-1 ring-gray-200 dark:ring-gray-700' : ''}`}
                       style={{
                         width: `${cellSize()}px`,
                         height: `${cellSize()}px`,


### PR DESCRIPTION
## Summary

- Zero-intensity heatmap cells (days with no sessions) previously had only a light `#F3F4F6` background with no border, making them nearly invisible against a white page background and failing WCAG 2.1 AA contrast requirements for low-vision users
- Added `ring-1 ring-gray-200 dark:ring-gray-700` Tailwind classes conditionally to cells where `count === 0`, giving them a visible 1px inset ring boundary without altering the colour of active cells
- Dark mode is handled via the `dark:ring-gray-700` variant so the border remains appropriately subtle on dark backgrounds

## Test plan

- [ ] Open the Stats page and verify zero-session cells display a faint but visible border around each cell
- [ ] Toggle OS dark mode and confirm the border uses the darker `gray-700` tone
- [ ] Verify non-zero cells (red shades) have no ring applied
- [ ] Run `npx tsc --noEmit` — no errors

Closes #55