### PR TITLE
fix: clear existing badge refresh alarm before creating a new one

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -85,6 +85,8 @@ export default defineBackground(() => {
   };
 
   const startBadgeRefresh = async (): Promise<void> => {
+    // Clear any existing alarm first to avoid silent duplicate alarms (#97)
+    await browser.alarms.clear(ALARM_BADGE_REFRESH);
     await browser.alarms.create(ALARM_BADGE_REFRESH, { periodInMinutes: 1 });
   };
 


### PR DESCRIPTION
## Summary

- `startBadgeRefresh()` was calling `browser.alarms.create('badge-refresh', ...)` without first clearing any existing alarm with the same name
- If called multiple times (e.g. on each timer start or config update), duplicate periodic alarms would accumulate and cause the badge to refresh at an ever-increasing rate
- Fix adds `await browser.alarms.clear(ALARM_BADGE_REFRESH)` before each `create()` call, making `startBadgeRefresh()` idempotent

## Test plan

- [ ] Type-check passes: `npx tsc --noEmit` (no errors)
- [ ] Verify in browser: start a timer, pause and restart multiple times — badge refresh rate stays consistent at ~1/min
- [ ] `browser.alarms.getAll()` in devtools shows only a single `badge-refresh` alarm regardless of how many times the timer is started

Closes #97