### PR TITLE
fix: guard against Chrome's 5000 dynamic DNR rule limit

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -48,6 +48,8 @@ describe('background service worker', () => {
 
     fakeBrowser.action.setBadgeText = vi.fn().mockResolvedValue(undefined);
     fakeBrowser.action.setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+    fakeBrowser.declarativeNetRequest.getDynamicRules = vi.fn().mockResolvedValue([]);
+    fakeBrowser.declarativeNetRequest.updateDynamicRules = vi.fn().mockResolvedValue(undefined);
   });
 
   it('starts a timer, persists working state, and creates the timer alarm', async () => {

--- a/entrypoints/__tests__/options.test.ts
+++ b/entrypoints/__tests__/options.test.ts
@@ -32,6 +32,7 @@ const buildConfig = (
   extra: Partial<TimerConfig> = {},
 ): TimerConfig => ({
   dailyGoal: DEFAULT_CONFIG.dailyGoal,
+  blockedSites: DEFAULT_CONFIG.blockedSites,
   ...extra,
   workDuration: work * MS_PER_MINUTE,
   shortBreakDuration: shortBreak * MS_PER_MINUTE,

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -24,6 +24,67 @@ import {
 } from '@/lib/storage';
 import type { CompletedSession, TimerConfig } from '@/lib/types';
 
+/**
+ * Chrome limits extensions to 5 000 dynamic declarativeNetRequest rules.
+ * We leave a small buffer so other rules (e.g. static ruleset) are never crowded out.
+ */
+const MAX_DNR_RULES = 4990;
+
+type DnrApi = {
+  getDynamicRules(): Promise<{ id: number }[]>;
+  updateDynamicRules(opts: {
+    addRules?: chrome.declarativeNetRequest.Rule[];
+    removeRuleIds?: number[];
+  }): Promise<void>;
+};
+
+/**
+ * Replace all dynamic blocking rules with one BLOCK rule per hostname in `sites`.
+ * Each hostname produces two rules (apex + www subdomain), so the effective
+ * per-site cost is 2 rule slots.
+ *
+ * If the total would exceed MAX_DNR_RULES the list is silently truncated so
+ * that `updateDynamicRules` never throws a quota error.
+ */
+const applyBlockingRules = async (sites: string[]): Promise<void> => {
+  const dnr = (browser as typeof browser & { declarativeNetRequest?: DnrApi }).declarativeNetRequest;
+  if (!dnr) return;
+
+  // Each site generates up to 2 rules (apex + www). Calculate how many fit.
+  const maxSites = Math.floor(MAX_DNR_RULES / 2);
+  let sanitised = sites.map((s) => s.trim().toLowerCase()).filter(Boolean);
+  if (sanitised.length > maxSites) {
+    console.warn('[tomate] Too many blocked sites — truncating to fit DNR limit');
+    sanitised = sanitised.slice(0, maxSites);
+  }
+
+  // Remove all existing dynamic rules first.
+  const existing = await dnr.getDynamicRules();
+  const removeRuleIds = existing.map((r) => r.id);
+
+  // Build new rules: one for the apex domain, one for *.domain
+  const addRules: chrome.declarativeNetRequest.Rule[] = [];
+  sanitised.forEach((host, i) => {
+    const baseId = i * 2 + 1; // 1-based, step 2
+    addRules.push(
+      {
+        id: baseId,
+        priority: 1,
+        action: { type: 'block' as const },
+        condition: { urlFilter: `||${host}^`, resourceTypes: ['main_frame'] as const },
+      },
+      {
+        id: baseId + 1,
+        priority: 1,
+        action: { type: 'block' as const },
+        condition: { urlFilter: `||www.${host}^`, resourceTypes: ['main_frame'] as const },
+      },
+    );
+  });
+
+  await dnr.updateDynamicRules({ removeRuleIds, addRules });
+};
+
 export type MessageAction =
   | { action: 'START_TIMER' }
   | { action: 'ABANDON_TIMER' }
@@ -149,6 +210,10 @@ export default defineBackground(() => {
         const nextState = startTimer(state, config);
         await setTimerState(nextState);
 
+        if (nextState.phase === 'WORKING') {
+          await applyBlockingRules(config.blockedSites ?? []);
+        }
+
         if (nextState.endTime !== null) {
           await scheduleTimerAlarm(nextState.endTime);
           await startBadgeRefresh();
@@ -160,6 +225,7 @@ export default defineBackground(() => {
       case 'ABANDON_TIMER': {
         const nextState = abandonTimer(state);
         await setTimerState(nextState);
+        await applyBlockingRules([]);
         await clearActiveAlarms();
         await refreshBadge();
         return nextState;
@@ -254,6 +320,8 @@ export default defineBackground(() => {
     await setTimerState(completed);
 
     if (state.phase === 'WORKING') {
+      // Session ended — unblock sites regardless of what the next phase is
+      await applyBlockingRules([]);
       await persistCompletedSession(state, Date.now());
       if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
         await browser.notifications.create({

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -30,10 +30,17 @@ import type { CompletedSession, TimerConfig } from '@/lib/types';
  */
 const MAX_DNR_RULES = 4990;
 
+type DnrRule = {
+  id: number;
+  priority: number;
+  action: { type: string };
+  condition: { urlFilter: string; resourceTypes: string[] };
+};
+
 type DnrApi = {
   getDynamicRules(): Promise<{ id: number }[]>;
   updateDynamicRules(opts: {
-    addRules?: chrome.declarativeNetRequest.Rule[];
+    addRules?: DnrRule[];
     removeRuleIds?: number[];
   }): Promise<void>;
 };
@@ -63,7 +70,7 @@ const applyBlockingRules = async (sites: string[]): Promise<void> => {
   const removeRuleIds = existing.map((r) => r.id);
 
   // Build new rules: one for the apex domain, one for *.domain
-  const addRules: chrome.declarativeNetRequest.Rule[] = [];
+  const addRules: DnrRule[] = [];
   sanitised.forEach((host, i) => {
     const baseId = i * 2 + 1; // 1-based, step 2
     addRules.push(

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -2,7 +2,7 @@ import { createSignal, onMount, Show } from 'solid-js';
 import { browser } from 'wxt/browser';
 
 import { getConfig, setConfig } from '@/lib/storage';
-import { DEFAULT_CONFIG, type TimerConfig } from '@/lib/types';
+import { DEFAULT_CONFIG, MAX_BLOCKED_SITES, type TimerConfig } from '@/lib/types';
 
 const MS_PER_MINUTE = 60_000;
 
@@ -16,6 +16,7 @@ export default function App() {
   const [longBreak, setLongBreak] = createSignal(30);
   const [openBreakTab, setOpenBreakTab] = createSignal(true);
   const [playCompletionSound, setPlayCompletionSound] = createSignal(true);
+  const [blockedSites, setBlockedSites] = createSignal('');
   // Preserve fields not yet surfaced in UI (e.g. dailyGoal) so we don't wipe them on save
   const [extraConfig, setExtraConfig] = createSignal<Partial<TimerConfig>>({});
   const [saved, setSaved] = createSignal(false);
@@ -28,8 +29,9 @@ export default function App() {
     setLongBreak(Math.round(config.longBreakDuration / MS_PER_MINUTE));
     setOpenBreakTab(config.openBreakTab !== false);
     setPlayCompletionSound(config.playCompletionSound !== false);
+    setBlockedSites((config.blockedSites ?? []).join('\n'));
     // Stash any extra fields so round-trip save doesn't lose them
-    const { workDuration: _w, shortBreakDuration: _s, longBreakDuration: _l, openBreakTab: _o, playCompletionSound: _p, ...rest } = config;
+    const { workDuration: _w, shortBreakDuration: _s, longBreakDuration: _l, openBreakTab: _o, playCompletionSound: _p, blockedSites: _b, ...rest } = config;
     setExtraConfig(rest);
   });
 
@@ -42,6 +44,11 @@ export default function App() {
       setError('Please check the duration values — work must be 1–120 min, short break 1–30 min, long break 5–60 min.');
       return;
     }
+    const parsedSites = blockedSites()
+      .split('\n')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean)
+      .slice(0, MAX_BLOCKED_SITES);
     const config: TimerConfig = {
       ...DEFAULT_CONFIG,
       ...extraConfig(),
@@ -50,6 +57,7 @@ export default function App() {
       longBreakDuration: longBreak() * MS_PER_MINUTE,
       openBreakTab: openBreakTab(),
       playCompletionSound: playCompletionSound(),
+      blockedSites: parsedSites,
     };
     try {
       await setConfig(config);
@@ -72,6 +80,7 @@ export default function App() {
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
     setOpenBreakTab(DEFAULT_CONFIG.openBreakTab);
     setPlayCompletionSound(DEFAULT_CONFIG.playCompletionSound);
+    setBlockedSites(DEFAULT_CONFIG.blockedSites.join('\n'));
     setExtraConfig({ dailyGoal: DEFAULT_CONFIG.dailyGoal });
     setError('');
   };
@@ -136,6 +145,19 @@ export default function App() {
               class="w-4 h-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
             />
             <span class="text-sm font-medium text-gray-700">Play completion sound</span>
+          </label>
+
+          <label class="block">
+            <span class="text-sm font-medium text-gray-700">
+              Block sites during work sessions (one per line, max {MAX_BLOCKED_SITES})
+            </span>
+            <textarea
+              rows={4}
+              placeholder={'twitter.com\nyoutube.com'}
+              value={blockedSites()}
+              onInput={(e) => setBlockedSites(e.currentTarget.value)}
+              class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm font-mono focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+            />
           </label>
         </div>
 

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -251,6 +251,7 @@ describe('timer state machine', () => {
       openBreakTab: true,
       playCompletionSound: true,
       dailyGoal: 8,
+      blockedSites: [],
     });
   });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,8 @@ export type TimerConfig = {
   openBreakTab: boolean;
   playCompletionSound: boolean;
   dailyGoal: number;
+  /** Hostnames to block during WORKING sessions (e.g. "twitter.com"). Max 100 entries. */
+  blockedSites: string[];
 };
 
 export type TimerState = {
@@ -28,6 +30,9 @@ export type CompletedSession = {
   duration: number;
 };
 
+/** Maximum number of sites that can be blocked (enforced in the options UI). */
+export const MAX_BLOCKED_SITES = 100;
+
 export const DEFAULT_CONFIG: TimerConfig = {
   workDuration: 25 * 60 * 1000,
   shortBreakDuration: 5 * 60 * 1000,
@@ -35,6 +40,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   openBreakTab: true,
   playCompletionSound: true,
   dailyGoal: 8,
+  blockedSites: [],
 };
 
 export const INITIAL_STATE: TimerState = {


### PR DESCRIPTION
## Summary

- Adds `MAX_DNR_RULES = 4990` constant in `background.ts` (10-rule buffer below Chrome's hard 5000 limit)
- Adds `applyBlockingRules(sites)` helper that truncates the rule list and emits `console.warn('[tomate] Too many blocked sites — truncating to fit DNR limit')` before calling `updateDynamicRules`, so the extension never throws a quota error that silently breaks all blocking
- Wires blocking on/off in `START_TIMER` (enable when entering WORKING phase), `ABANDON_TIMER`, and when the WORKING alarm fires (disable when session ends)
- Adds `blockedSites: string[]` field to `TimerConfig` / `DEFAULT_CONFIG`
- Exports `MAX_BLOCKED_SITES = 100` from `lib/types.ts` and enforces it in the options page textarea (`slice(0, MAX_BLOCKED_SITES)` on save)
- Adds a "Block sites during work sessions" textarea to `options/App.tsx`

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` passes (verified locally)
- [ ] Add 1–3 sites in options, start a WORKING session — verify `getDynamicRules()` returns the expected rule pairs
- [ ] Abandon timer mid-session — verify rules are cleared
- [ ] Complete a WORKING session — verify rules are cleared before break phase
- [ ] Paste > 100 lines into the textarea, save — verify only 100 are stored
- [ ] Simulate > 2495 sites (unit test) — verify `applyBlockingRules` truncates and warns rather than throwing

Closes #101