### PR TITLE
fix: atomic timer state + session persistence on alarm completion

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -251,10 +251,24 @@ export default defineBackground(() => {
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
     const completed = completeTimer(state, config);
-    await setTimerState(completed);
+    const endTime = Date.now();
 
     if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
+      try {
+        await Promise.all([
+          setTimerState(completed),
+          persistCompletedSession(state, endTime),
+        ]);
+      } catch (err) {
+        console.error('[tomate] Failed to persist session completion:', err);
+        try { await setTimerState(state); } catch {}
+        throw err;
+      }
+    } else {
+      await setTimerState(completed);
+    }
+
+    if (state.phase === 'WORKING') {
       if (typeof browser.notifications !== 'undefined' && browser.notifications.create) {
         await browser.notifications.create({
           type: 'basic',


### PR DESCRIPTION
## Summary

- Wraps `setTimerState(completed)` and `persistCompletedSession(state, endTime)` in `Promise.all` so both storage writes are attempted together on WORKING session completion
- Adds a `try/catch` around the combined write; on failure, attempts to rollback the timer state back to `prevState` to avoid the session counter advancing without a persisted record
- Non-WORKING phases (break completions) keep a plain `await setTimerState(completed)` — no session to persist there

## Test plan

- [ ] All 86 existing unit tests pass (`npx vitest run`)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Manual: complete a WORKING timer → session appears in stats, phase transitions to break
- [ ] Manual: simulate quota error on `addCompletedSession` → timer stays in WORKING phase (rollback succeeds), error logged to console

Closes #43