### PR TITLE
fix: clear stale DNR rules on extension install/update

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -205,7 +205,26 @@ export default defineBackground(() => {
     }
   };
 
-  browser.runtime.onInstalled.addListener(async () => {
+  browser.runtime.onInstalled.addListener(async (details) => {
+    // On fresh install or update, remove any stale dynamic declarativeNetRequest rules (#103)
+    if (details.reason === 'install' || details.reason === 'update') {
+      try {
+        const dnr = (browser as typeof browser & {
+          declarativeNetRequest?: {
+            getDynamicRules(): Promise<{ id: number }[]>;
+            updateDynamicRules(opts: { removeRuleIds: number[] }): Promise<void>;
+          };
+        }).declarativeNetRequest;
+        if (dnr) {
+          const existing = await dnr.getDynamicRules();
+          if (existing.length > 0) {
+            await dnr.updateDynamicRules({ removeRuleIds: existing.map((r) => r.id) });
+          }
+        }
+      } catch {
+        // declarativeNetRequest may not be available if the permission is not declared
+      }
+    }
     await recoverFromMissedAlarm();
   });
 


### PR DESCRIPTION
## Summary

- On `install` or `update`, iterate all existing dynamic `declarativeNetRequest` rules and remove them before re-applying config
- Guards with optional chaining (`declarativeNetRequest?.getDynamicRules`) so the code is safe if the permission is absent
- Error is silently swallowed in a `try/catch` since the API may be unavailable in some environments

## Test plan

- [ ] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] No vitest regressions introduced by this change
- [ ] Manual: install extension, set a blocking rule, update extension — confirm rule is cleared on startup

Closes #103