### PR TITLE
fix: match both apex domain and subdomains in blocking rules

### DIFF
--- a/entrypoints/__tests__/options.test.ts
+++ b/entrypoints/__tests__/options.test.ts
@@ -32,6 +32,7 @@ const buildConfig = (
   extra: Partial<TimerConfig> = {},
 ): TimerConfig => ({
   dailyGoal: DEFAULT_CONFIG.dailyGoal,
+  blockedSites: DEFAULT_CONFIG.blockedSites,
   ...extra,
   workDuration: work * MS_PER_MINUTE,
   shortBreakDuration: shortBreak * MS_PER_MINUTE,

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -32,6 +32,65 @@ export type MessageAction =
   | { action: 'SKIP_LONG_BREAK' }
   | { action: 'UPDATE_CONFIG'; config: TimerConfig };
 
+// Base rule ID for dynamic declarativeNetRequest blocking rules.
+// Each blocked hostname occupies two consecutive IDs:
+//   DNR_RULE_ID_BASE + index * 2     → apex domain  (*://hostname/*)
+//   DNR_RULE_ID_BASE + index * 2 + 1 → all subdomains (*://*.hostname/*)
+const DNR_RULE_ID_BASE = 1000;
+
+type DnrApi = {
+  getDynamicRules(): Promise<{ id: number }[]>;
+  updateDynamicRules(opts: {
+    removeRuleIds?: number[];
+    addRules?: {
+      id: number;
+      priority: number;
+      action: { type: string };
+      condition: { urlFilter: string; resourceTypes: string[] };
+    }[];
+  }): Promise<void>;
+};
+
+const getDnr = (): DnrApi | undefined =>
+  (browser as typeof browser & { declarativeNetRequest?: DnrApi }).declarativeNetRequest;
+
+const syncBlockingRules = async (blockedSites: string[]): Promise<void> => {
+  const dnr = getDnr();
+  if (!dnr) return;
+
+  try {
+    // Remove all existing dynamic rules managed by this extension
+    const existing = await dnr.getDynamicRules();
+    const removeRuleIds = existing.map((r) => r.id);
+
+    // Build two rules per hostname: apex + wildcard subdomains
+    const addRules = blockedSites.flatMap((hostname, index) => [
+      {
+        id: DNR_RULE_ID_BASE + index * 2,
+        priority: 1,
+        action: { type: 'block' },
+        condition: {
+          urlFilter: `*://${hostname}/*`,
+          resourceTypes: ['main_frame'],
+        },
+      },
+      {
+        id: DNR_RULE_ID_BASE + index * 2 + 1,
+        priority: 1,
+        action: { type: 'block' },
+        condition: {
+          urlFilter: `*://*.${hostname}/*`,
+          resourceTypes: ['main_frame'],
+        },
+      },
+    ]);
+
+    await dnr.updateDynamicRules({ removeRuleIds, addRules });
+  } catch {
+    // declarativeNetRequest may not be available in all environments
+  }
+};
+
 export default defineBackground(() => {
   const ALARM_TIMER = 'tomate-timer';
   const ALARM_BADGE_REFRESH = 'badge-refresh';
@@ -198,6 +257,7 @@ export default defineBackground(() => {
           await clearActiveAlarms();
         }
 
+        await syncBlockingRules(message.config.blockedSites ?? []);
         await refreshBadge();
         return nextState;
       }
@@ -208,27 +268,10 @@ export default defineBackground(() => {
   };
 
   browser.runtime.onInstalled.addListener(async (details) => {
-    // On fresh install or update, remove any stale dynamic declarativeNetRequest rules (#103)
+    // On fresh install or update, re-sync blocking rules from stored config (#100, #103)
     if (details.reason === 'install' || details.reason === 'update') {
-      try {
-        const existing = await (browser as typeof browser & {
-          declarativeNetRequest?: {
-            getDynamicRules(): Promise<{ id: number }[]>;
-            updateDynamicRules(opts: { removeRuleIds: number[] }): Promise<void>;
-          };
-        }).declarativeNetRequest?.getDynamicRules();
-        if (existing && existing.length > 0) {
-          await (browser as typeof browser & {
-            declarativeNetRequest?: {
-              updateDynamicRules(opts: { removeRuleIds: number[] }): Promise<void>;
-            };
-          }).declarativeNetRequest?.updateDynamicRules({
-            removeRuleIds: existing.map((r) => r.id),
-          });
-        }
-      } catch {
-        // declarativeNetRequest may not be available if permission not declared
-      }
+      const config = await getConfig();
+      await syncBlockingRules(config.blockedSites ?? []);
     }
     await recoverFromMissedAlarm();
   });

--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -251,6 +251,7 @@ describe('timer state machine', () => {
       openBreakTab: true,
       playCompletionSound: true,
       dailyGoal: 8,
+      blockedSites: [],
     });
   });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,7 @@ export type TimerConfig = {
   openBreakTab: boolean;
   playCompletionSound: boolean;
   dailyGoal: number;
+  blockedSites: string[];
 };
 
 export type TimerState = {
@@ -35,6 +36,7 @@ export const DEFAULT_CONFIG: TimerConfig = {
   openBreakTab: true,
   playCompletionSound: true,
   dailyGoal: 8,
+  blockedSites: [],
 };
 
 export const INITIAL_STATE: TimerState = {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   manifest: {
     name: 'Tomate',
     description: 'A Pomodoro timer that helps you focus — one tomate at a time.',
-    permissions: ['alarms', 'notifications', 'storage', 'tabs'],
+    permissions: ['alarms', 'notifications', 'storage', 'tabs', 'declarativeNetRequest'],
     action: {
       default_icon: {
         '16': '/icons/icon-16.png',


### PR DESCRIPTION
## Summary

- Creates two `declarativeNetRequest` rules per blocked hostname: `*://hostname/*` (apex) and `*://*.hostname/*` (all subdomains), so e.g. `www.example.com` and `app.example.com` are blocked in addition to the bare domain
- Rule IDs use `DNR_RULE_ID_BASE + index * 2` and `+ 1` to keep each pair contiguous and collision-free
- Extracts a shared `syncBlockingRules()` helper used by both `UPDATE_CONFIG` and `onInstalled`, replacing the previous ad-hoc cleanup-only code
- Adds `blockedSites: string[]` to `TimerConfig` / `DEFAULT_CONFIG` (defaults to `[]`) and adds `declarativeNetRequest` to the extension manifest permissions

## Test plan

- [ ] All existing tests pass (`npx vitest run entrypoints/__tests__/background.test.ts lib/__tests__/timer.test.ts lib/__tests__/stats.test.ts`)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] Manual: add `example.com` to blocked sites, verify `example.com`, `www.example.com`, and `app.example.com` are all blocked during a work session
- [ ] Manual: remove all blocked sites, verify no DNR rules remain

Closes #100