### PR TITLE
fix: verify sender.id in onMessage to reject cross-extension mutations

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -237,7 +237,14 @@ export default defineBackground(() => {
     await recoverFromMissedAlarm();
   });
 
-  browser.runtime.onMessage.addListener((message) => handleMessage(message as MessageAction));
+  browser.runtime.onMessage.addListener((message, sender) => {
+    // Reject messages from other extensions; allow own pages/content-scripts
+    // (which carry a matching sender.id) and internal calls (sender.id undefined).
+    if (sender.id !== undefined && sender.id !== browser.runtime.id) {
+      return;
+    }
+    return handleMessage(message as MessageAction);
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === ALARM_BADGE_REFRESH) {


### PR DESCRIPTION
## Summary

- Adds a sender origin check to `browser.runtime.onMessage.addListener` in `entrypoints/background.ts`
- Rejects messages where `sender.id` is set but does not match `browser.runtime.id` (i.e. messages from foreign extensions)
- Messages from this extension's own pages/content-scripts (matching `sender.id`) and internal browser calls (`sender.id` undefined) continue to work normally

## Test plan

- [ ] All 86 existing vitest tests pass (`npx vitest run`)
- [ ] `npx tsc --noEmit` reports no errors
- [ ] Install a second extension in a dev browser and confirm it cannot trigger `START_TIMER` / `ABANDON_TIMER` / `UPDATE_CONFIG` on this extension

Closes #236