### PR TITLE
fix: skip alarm processing when timer phase is not active

### DIFF
--- a/entrypoints/__tests__/background.test.ts
+++ b/entrypoints/__tests__/background.test.ts
@@ -243,6 +243,36 @@ describe('background service worker', () => {
     await expect(fakeBrowser.runtime.sendMessage({ action: 'GET_STATE' })).resolves.toEqual(storedState);
   });
 
+  it('ignores a stale tomate-timer alarm when the phase is IDLE and clears the alarm', async () => {
+    await setTimerState(createState({ phase: 'IDLE' }));
+    await initBackground();
+    await fakeBrowser.alarms.create('tomate-timer', { when: 1_000 });
+
+    const stateBefore = await getTimerState();
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 1_000 });
+    const stateAfter = await getTimerState();
+
+    expect(stateAfter).toEqual(stateBefore);
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toBeUndefined();
+  });
+
+  it('ignores a stale tomate-timer alarm when the phase is BREAK_SUGGESTION and clears the alarm', async () => {
+    const storedState = createState({
+      phase: 'BREAK_SUGGESTION',
+      sessionCount: 4,
+      cyclePosition: 3,
+      completedToday: 4,
+    });
+    await setTimerState(storedState);
+    await initBackground();
+    await fakeBrowser.alarms.create('tomate-timer', { when: 1_000 });
+
+    await fakeBrowser.alarms.onAlarm.trigger({ name: 'tomate-timer', scheduledTime: 1_000 });
+
+    await expect(getTimerState()).resolves.toEqual(storedState);
+    await expect(fakeBrowser.alarms.get('tomate-timer')).resolves.toBeUndefined();
+  });
+
   it('updates config during an active timer and recreates the timer alarm', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000);
     const updatedConfig = createConfig({ workDuration: 20_000, shortBreakDuration: 1_000 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -250,6 +250,12 @@ export default defineBackground(() => {
     }
 
     const [state, config] = await Promise.all([getTimerState(), getConfig()]);
+
+    if (!isActivePhase(state.phase)) {
+      await browser.alarms.clear('tomate-timer');
+      return;
+    }
+
     const completed = completeTimer(state, config);
     await setTimerState(completed);
 


### PR DESCRIPTION
## Summary

- Guards the `onAlarm` handler for `'tomate-timer'` against firing when the timer phase is not active (IDLE or BREAK_SUGGESTION)
- After loading state, checks `isActivePhase(state.phase)` — if false, clears the stale alarm and returns early without modifying state
- Adds two regression tests covering IDLE and BREAK_SUGGESTION stale-alarm scenarios

## Test plan

- [ ] Run `npx vitest run entrypoints/__tests__/background.test.ts` — 9 tests pass
- [ ] Manually verify: start a timer, let it complete naturally to BREAK_SUGGESTION, confirm no further state changes occur if a leftover alarm fires
- [ ] Manually verify: with timer in IDLE, confirm a stale `tomate-timer` alarm is cleared without advancing state

Closes #45