### PR TITLE
fix: clear label debounce timeout on popup component cleanup

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -104,6 +104,7 @@ export default function App() {
     setLabel(value);
     clearTimeout(labelTimeout);
     labelTimeout = setTimeout(() => setCurrentLabel(value), 300);
+    onCleanup(() => clearTimeout(labelTimeout));
   };
 
   return (


### PR DESCRIPTION
## Summary

- Adds `onCleanup(() => clearTimeout(labelTimeout))` inside `handleLabelChange` in `entrypoints/popup/App.tsx`
- Prevents the stale 300ms debounce timeout from firing `setCurrentLabel` on an already-unmounted popup component
- Follows the standard SolidJS cleanup pattern (`onCleanup` was already imported)

## Test plan

- [ ] Open the popup, type in the label input, then quickly close the popup before the 300ms debounce fires — no errors in the console
- [ ] Type a label and wait for it to persist normally — storage write still works as expected
- [ ] Type-check passes: `npx tsc --noEmit` exits with no errors

Closes #350