### PR TITLE
fix: sanitize label field in CSV export to prevent formula injection

### DIFF
--- a/entrypoints/stats/App.tsx
+++ b/entrypoints/stats/App.tsx
@@ -29,10 +29,18 @@ function StatCard(props: StatCardProps) {
   );
 }
 
+function sanitizeCsvCell(value: string): string {
+  if (/^[=+\-@]/.test(value)) {
+    return `'${value}`;
+  }
+  return value;
+}
+
 function exportCSV(sessions: import('@/lib/types').CompletedSession[]): void {
   const header = 'startTime,endTime,duration,label';
   const rows = sessions.map((s) => {
-    const label = `"${s.label.replace(/"/g, '""')}"`;
+    const safeLabel = sanitizeCsvCell(s.label);
+    const label = `"${safeLabel.replace(/"/g, '""')}"`;
     return `${s.startTime},${s.endTime},${s.duration},${label}`;
   });
   const csv = [header, ...rows].join('\n');


### PR DESCRIPTION
## Summary

- Adds a `sanitizeCsvCell()` helper that prefixes any cell value starting with `=`, `+`, `-`, or `@` with a single quote `'`
- Applies sanitization to the session label before quoting it in the CSV row
- This is the standard spreadsheet CSV injection defense (OWASP recommended)

## Test plan

- [ ] Export a CSV with a session whose label starts with `=HYPERLINK("evil.com","click")` — confirm the exported cell reads `'=HYPERLINK(...)` and does not execute as a formula in Excel/Google Sheets
- [ ] Export a CSV with labels starting with `+`, `-`, `@` — confirm each is prefixed with `'`
- [ ] Export a CSV with a normal label (e.g. `Focus`) — confirm it is unchanged
- [ ] TypeScript: `npx tsc --noEmit` passes with no errors

Closes #361