### PR TITLE
fix: reset config to full DEFAULT_CONFIG to preserve all fields on reset

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -72,7 +72,10 @@ export default function App() {
     setLongBreak(Math.round(DEFAULT_CONFIG.longBreakDuration / MS_PER_MINUTE));
     setOpenBreakTab(DEFAULT_CONFIG.openBreakTab);
     setPlayCompletionSound(DEFAULT_CONFIG.playCompletionSound);
-    setExtraConfig({ dailyGoal: DEFAULT_CONFIG.dailyGoal });
+    // Derive extraConfig from DEFAULT_CONFIG by stripping the fields surfaced in UI,
+    // so any future config fields are automatically reset to their defaults too.
+    const { workDuration: _w, shortBreakDuration: _s, longBreakDuration: _l, openBreakTab: _o, playCompletionSound: _p, ...defaultRest } = DEFAULT_CONFIG;
+    setExtraConfig(defaultRest);
     setError('');
   };
 


### PR DESCRIPTION
## Summary

- `handleReset` in `entrypoints/options/App.tsx` was calling `setExtraConfig({ dailyGoal: DEFAULT_CONFIG.dailyGoal })`, hardcoding only the `dailyGoal` field
- Any future config fields added to `TimerConfig`/`DEFAULT_CONFIG` (e.g. `blockedSites`, `configVersion`) would be silently dropped to `undefined` after a reset
- Fix mirrors the pattern already used in `onMount`: destructure the known UI fields out of `DEFAULT_CONFIG` and stash the remainder as `extraConfig`, so all current and future fields get their correct default values

## Test plan

- [ ] Open the options page, change work/break durations, click "Reset to defaults" — values should snap back to 25/5/30
- [ ] Confirm `openBreakTab` and `playCompletionSound` also reset correctly
- [ ] Add a new field to `DEFAULT_CONFIG` in `lib/types.ts`, verify it appears in storage after a reset (not wiped)
- [ ] `npx tsc --noEmit` passes with no errors

Closes #521