### PR TITLE
fix: surface refreshStats errors via console.error instead of swallowing

### DIFF
--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -47,10 +47,11 @@ export default function App() {
     }
 
     setLabel(await getCurrentLabel());
-    await refreshStats();
+    await refreshStats().catch(console.error);
 
-    browser.storage.onChanged.addListener(refreshStats);
-    onCleanup(() => browser.storage.onChanged.removeListener(refreshStats));
+    const onStorageChanged = () => refreshStats().catch(console.error);
+    browser.storage.onChanged.addListener(onStorageChanged);
+    onCleanup(() => browser.storage.onChanged.removeListener(onStorageChanged));
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary

- `refreshStats()` was passed directly as a `browser.storage.onChanged` listener, so any rejection from a storage error was silently swallowed
- The initial `await refreshStats()` call in `onMount` also lacked error handling — if it threw, the rejection propagated to the unhandled async `onMount` callback
- Introduced a named `onStorageChanged` wrapper that calls `refreshStats().catch(console.error)`, and applied `.catch(console.error)` to the inline call as well

## Test plan

- [ ] Open the popup — stats load normally, no console errors
- [ ] Simulate a storage read failure (e.g. stub `getTodayCount` to throw) and confirm the error appears in the console rather than being swallowed silently
- [ ] Confirm the cleanup in `onCleanup` correctly removes the new named listener

Closes #520