### PR TITLE
fix: use state.endTime as session timestamp in missed alarm recovery

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -128,7 +128,7 @@ export default defineBackground(() => {
     await setTimerState(recovered);
 
     if (state.phase === 'WORKING') {
-      await persistCompletedSession(state, Date.now());
+      await persistCompletedSession(state, state.endTime ?? Date.now());
     }
 
     if (recovered.phase === 'SHORT_BREAK' && recovered.endTime !== null) {


### PR DESCRIPTION
## Summary

- `recoverFromMissedAlarm` was calling `persistCompletedSession(state, Date.now())` — if Chrome was closed during a WORKING session, the recovered session's stored duration included all offline time (e.g. a 25-min session appeared as 2h25m if closed for 2 hours)
- Fix passes `state.endTime ?? Date.now()` instead, so the persisted duration matches the true intended session length
- The nullish fallback is a safety guard only; `state.endTime` is always non-null when `state.phase === 'WORKING'` and an alarm was missed (guaranteed by `recoverMissedAlarm`'s guard on `state.endTime === null`)

## Test plan

- [ ] TypeScript check clean (`npx tsc --noEmit`)
- [ ] All existing unit tests pass (`npx vitest run`)
- [ ] Manual: simulate a missed alarm by advancing system clock past endTime — verify recovered session duration equals `state.endTime - state.startTime`, not `Date.now() - state.startTime`

Closes #514