### PR TITLE
test: add recoverMissedAlarm coverage for SHORT_BREAK and LONG_BREAK phases

### DIFF
--- a/lib/__tests__/timer.test.ts
+++ b/lib/__tests__/timer.test.ts
@@ -236,6 +236,60 @@ describe('timer state machine', () => {
     expect(recoverMissedAlarm(createState(), DEFAULT_CONFIG, 5_000)).toBeNull();
   });
 
+  it('recovers a missed alarm for a completed SHORT_BREAK and transitions to IDLE', () => {
+    const state = createState({
+      phase: 'SHORT_BREAK',
+      startTime: 1_000,
+      endTime: 1_500,
+      duration: 500,
+      sessionCount: 1,
+      cyclePosition: 0,
+      completedToday: 1,
+    });
+
+    expect(recoverMissedAlarm(state, DEFAULT_CONFIG, 3_000)).toEqual(
+      createState({
+        sessionCount: 1,
+        cyclePosition: 1,
+        completedToday: 1,
+      }),
+    );
+  });
+
+  it('recovers a missed alarm for a completed LONG_BREAK and resets cyclePosition to 0', () => {
+    const state = createState({
+      phase: 'LONG_BREAK',
+      startTime: 1_000,
+      endTime: 3_000,
+      duration: 2_000,
+      sessionCount: 4,
+      cyclePosition: 3,
+      completedToday: 4,
+    });
+
+    expect(recoverMissedAlarm(state, DEFAULT_CONFIG, 5_000)).toEqual(
+      createState({
+        sessionCount: 4,
+        cyclePosition: 0,
+        completedToday: 4,
+      }),
+    );
+  });
+
+  it('returns null for a SHORT_BREAK whose endTime is still in the future', () => {
+    const state = createState({
+      phase: 'SHORT_BREAK',
+      startTime: 1_000,
+      endTime: 10_000,
+      duration: 9_000,
+      sessionCount: 1,
+      cyclePosition: 0,
+      completedToday: 1,
+    });
+
+    expect(recoverMissedAlarm(state, DEFAULT_CONFIG, 5_000)).toBeNull();
+  });
+
   it('returns correct remaining milliseconds', () => {
     const state = createState({ endTime: 10_000 });
 


### PR DESCRIPTION
## Summary

- Adds test for `recoverMissedAlarm` with a past-due `SHORT_BREAK` — verifies transition to `IDLE` with `cyclePosition` incremented
- Adds test for `recoverMissedAlarm` with a past-due `LONG_BREAK` — verifies transition to `IDLE` with `cyclePosition` reset to `0`
- Adds test for `recoverMissedAlarm` with a `SHORT_BREAK` whose `endTime` is still in the future — verifies it returns `null`

Closes #515

## Test plan

- [ ] Run `npx vitest run lib/__tests__/timer.test.ts` — all 14 tests pass